### PR TITLE
Add web2pyjs to allow ajax loading

### DIFF
--- a/views/uikit_layout.html
+++ b/views/uikit_layout.html
@@ -28,6 +28,7 @@
     <link rel="stylesheet" type="text/css" href="{{=URL('static', 'css/content.css')}}" />
     
     {{
+    response.files.insert(0,URL('static','js/web2py.js'))
     response.include_meta()
     response.include_files()
     }}


### PR DESCRIPTION
Hi @lentinj - I find that I need to add back in the `web2py.js` file, so that in sub-pages like `sponsor_node.html` I can use the web2py provided AJAX `LOAD` function. ISTR that we were worried before that the web2py js messed up some button stuff, but perhaps that's been fixed in the latest web2py version? Is this PR safe for the homepage, do you think?