### PR TITLE
Renewals bug miscellany

### DIFF
--- a/controllers/default.py
+++ b/controllers/default.py
@@ -953,6 +953,7 @@ def sponsor_renew():
         all_partner_data=all_partner_data,
         form=form,
         giftaid_recorded=giftaid_recorded,
+        show_donor_link=(len(active_rows) > 0 or len(expiring_rows) > 0),
     )
 
 

--- a/modules/OZfunc.py
+++ b/modules/OZfunc.py
@@ -476,11 +476,6 @@ def nodes_info_from_string(
     else:
         all_pcols = ["ott", "src_id", "src", "rating"]
     all_rcols = ["OTT_ID", "verified_kind", "verified_name", "verified_more_info", "verified_url"]
-    alt_rtxt = {
-        "verified_name": "'leaf_sponsored'",
-        "verified_more_info": "''", 
-        "verified_url":"NULL",
-    }
     pic_cols = {nm:index for index,nm in enumerate(all_pcols)} 
     res_cols = {nm:index for index,nm in enumerate(all_rcols)} 
     if len(leafOtts):
@@ -497,16 +492,12 @@ def nodes_info_from_string(
             sql = query6.format(otts=ott_ids)
             iucn_query_res = db.executesql(sql)
         if include_sponsorship:
-            query7 = "SELECT "
-            # A very complicated query here, use alternative text if this is not an active
-            # node (waiting verification or expired)
-            query7 += ",".join(
-                ["IF(active,{0},{1}) as {0}".format(nm, alt_rtxt[nm]) 
-                    if nm in alt_rtxt else nm for nm in all_rcols])
-            query7 += (
-                " FROM (SELECT "
+            query7 = (
+                "SELECT "
                 + ",".join(all_rcols)
-                + ",(DATE_ADD(verified_time, INTERVAL sponsorship_duration_days DAY) > CURDATE()) AS active FROM reservations"
+                + " FROM (SELECT "
+                + ",".join(all_rcols)
+                + " FROM reservations"
                 + " WHERE OTT_ID in ({otts})"
                 +  " AND verified_time IS NOT NULL"
                 +  " AND (deactivated IS NULL OR deactivated = '')"

--- a/modules/sponsorship.py
+++ b/modules/sponsorship.py
@@ -752,6 +752,13 @@ def sponsorship_email_reminders(for_usernames=None):
             hmac_key=sponsor_hmac_key()
         )
 
+    def days_left(ends_dt, now_dt):
+        out = (r.sponsorship_ends - request.now).days
+        if out == 0 and ends_dt > now_dt:
+            # "Not quite expired"
+            out = 0.5
+        return out
+
     query = (db.reservations.verified_time != None) & (db.reservations.PP_transaction_code != None)  # i.e. has been bought
     if for_usernames is not None:
         # Get sponsorships for given username
@@ -812,7 +819,7 @@ def sponsorship_email_reminders(for_usernames=None):
         elif r.sponsorship_ends <= expiry_critical_date:
             # Expiry critical
             out['final_reminders'].append(r.OTT_ID)
-            out['days_left'][r.OTT_ID] = (r.sponsorship_ends - request.now).days
+            out['days_left'][r.OTT_ID] = days_left(r.sponsorship_ends, request.now)
             if r.emailed_re_renewal_final is None and r.sponsorship_ends <= expiry_critical_trigger:
                 # Below e-mail trigger date, send e-mail
                 out['final_triggers'].append(r.OTT_ID)
@@ -820,7 +827,7 @@ def sponsorship_email_reminders(for_usernames=None):
         elif r.sponsorship_ends <= expiry_soon_date:
             # Expiry soon
             out['initial_reminders'].append(r.OTT_ID)
-            out['days_left'][r.OTT_ID] = (r.sponsorship_ends - request.now).days
+            out['days_left'][r.OTT_ID] = days_left(r.sponsorship_ends, request.now)
             if r.emailed_re_renewal_initial is None and r.sponsorship_ends <= expiry_soon_trigger:
                 # Below e-mail trigger date, send e-mail
                 out['initial_triggers'].append(r.OTT_ID)

--- a/modules/sponsorship.py
+++ b/modules/sponsorship.py
@@ -816,6 +816,9 @@ def sponsorship_email_reminders(for_usernames=None):
         if status != '':
             # This item now banned/invalid, shouldn't be sending reminders.
             out['unsponsorable'].append(r.OTT_ID)
+        elif r.sponsorship_ends is None:
+            # NULL sponsorship_ends ==> doesn't ever expire
+            out['unsponsorable'].append(r.OTT_ID)
         elif r.sponsorship_ends <= expiry_critical_date:
             # Expiry critical
             out['final_reminders'].append(r.OTT_ID)

--- a/modules/sponsorship.py
+++ b/modules/sponsorship.py
@@ -710,6 +710,19 @@ def sponsor_hmac_key():
     return out
 
 
+def sponsor_signed_url(page, username, controller='default'):
+    URL = current.globalenv['URL']
+
+    return URL(
+        controller,
+        page,
+        args=[username],
+        scheme=True,
+        host=True,
+        hmac_key=sponsor_hmac_key()
+        )
+
+
 def sponsor_verify_url(request):
     """Verify current request has a valid signature"""
     URL = current.globalenv['URL']
@@ -736,21 +749,10 @@ def sponsorship_email_reminders(for_usernames=None):
     """
     request = current.request
     db = current.db
-    URL = current.globalenv['URL']
     expiry_soon_date = sponsorship_expiry_soon_date()
     expiry_soon_trigger = expiry_soon_date - datetime.timedelta(days=sponsorship_config()['expiry_hysteresis'])
     expiry_critical_date = sponsorship_expiry_soon_date('critical')
     expiry_critical_trigger = expiry_critical_date - datetime.timedelta(days=sponsorship_config()['expiry_hysteresis'])
-
-    def sponsor_signed_url(page, username, controller='default'):
-        return URL(
-            controller,
-            page,
-            args=[username],
-            scheme=True,
-            host=True,
-            hmac_key=sponsor_hmac_key()
-        )
 
     def days_left(ends_dt, now_dt):
         out = (r.sponsorship_ends - request.now).days

--- a/tests/unit/test_controllers_default_sponsor.py
+++ b/tests/unit/test_controllers_default_sponsor.py
@@ -51,11 +51,13 @@ class ControllersDefaultSponsorInfo(unittest.TestCase):
         current.request.get_vars._signature = sponsor_signed_url('sponsor_renew.html', user_1).split('_signature=')[1]
         out = default.sponsor_renew()
         self.assertEqual(out['username'], user_1)
+        self.assertEqual(out['show_donor_link'], False)  # Don't show donor link without sponsorships
 
         # Buy some OTTs
         current.request.now = expiry_time - datetime.timedelta(days=sponsorship_config()['duration_days'])
         rs = util.purchase_reservation(3, basket_details=dict(e_mail=email_1), verify=True)
         out = default.sponsor_renew()
+        self.assertEqual(out['show_donor_link'], True)  # Do show donor link with sponsorships
         self.assertEqual(str(out['all_row_categories'][0]['title']), 'Active sponsorships')
         self.assertEqual([r.OTT_ID for r in out['all_row_categories'][0]['rows']], [r.OTT_ID for r in rs])
         self.assertEqual([r.OTT_ID for r in out['all_row_categories'][1]['rows']], [])
@@ -64,6 +66,7 @@ class ControllersDefaultSponsorInfo(unittest.TestCase):
         # OTTs expiring soon
         current.request.now = expiry_time - datetime.timedelta(days=1)
         out = default.sponsor_renew()
+        self.assertEqual(out['show_donor_link'], True)  # Do show donor link with sponsorships
         self.assertEqual([r.OTT_ID for r in out['all_row_categories'][0]['rows']], [])
         self.assertEqual(str(out['all_row_categories'][1]['title']), 'Sponsorships expiring soon')
         self.assertEqual([r.OTT_ID for r in out['all_row_categories'][1]['rows']], [r.OTT_ID for r in rs])
@@ -74,6 +77,7 @@ class ControllersDefaultSponsorInfo(unittest.TestCase):
         for r in rs:
             reservation_expire(r)
         out = default.sponsor_renew()
+        self.assertEqual(out['show_donor_link'], False)  # Don't show donor link without sponsorships
         self.assertEqual([r.OTT_ID for r in out['all_row_categories'][0]['rows']], [])
         self.assertEqual([r.OTT_ID for r in out['all_row_categories'][1]['rows']], [])
         self.assertEqual(str(out['all_row_categories'][2]['title']), 'Expired sponsorships')

--- a/tests/unit/test_controllers_default_sponsor.py
+++ b/tests/unit/test_controllers_default_sponsor.py
@@ -1,0 +1,92 @@
+import datetime
+
+import unittest
+
+from applications.OZtree.tests.unit import util
+
+from gluon.globals import Request
+from gluon.http import HTTP
+
+import applications.OZtree.controllers.default as default
+
+from sponsorship import sponsorship_config, sponsor_signed_url, reservation_expire
+
+
+class ControllersDefaultSponsorInfo(unittest.TestCase):
+    def setUp(self):
+        util.clear_unittest_sponsors()
+        util.set_allow_sponsorship(1)
+        util.set_maintenance_mins(0)
+        util.set_reservation_time_limit_mins(0)
+        # Poke session / DB / request into API's namespace
+        default.session = current.session
+        default.db = current.db
+        default.request = current.request
+        default.response = current.response
+        for n in current.globalenv.keys():
+            setattr(default, n, current.globalenv[n])
+
+    def tearDown(self):
+        util.clear_unittest_sponsors()
+        # Remove anything created as part of tests
+        db.rollback()
+
+    def test_sponsor_renew(self):
+        expiry_time = current.request.now + datetime.timedelta(days=10*365)
+        email_1, user_1 = '1_betty@unittest.example.com', '1_bettyunittestexamplecom'
+
+        # Configure routing enough to get signatures right
+        current.request.controller = 'default'
+        current.request.function = 'sponsor_renew'
+        current.request.args = [user_1]
+        current.request.scheme = True
+        current.request.extension = 'html'
+
+        # Get signature wrong
+        with self.assertRaises(HTTP):
+            current.request.get_vars._signature = sponsor_signed_url('sponsor_renew.html', 'some other user').split('_signature=')[1]
+            default.sponsor_renew()
+
+        # Get signature right, no sponorships yet
+        current.request.get_vars._signature = sponsor_signed_url('sponsor_renew.html', user_1).split('_signature=')[1]
+        out = default.sponsor_renew()
+        self.assertEqual(out['username'], user_1)
+
+        # Buy some OTTs
+        current.request.now = expiry_time - datetime.timedelta(days=sponsorship_config()['duration_days'])
+        rs = util.purchase_reservation(3, basket_details=dict(e_mail=email_1), verify=True)
+        out = default.sponsor_renew()
+        self.assertEqual(str(out['all_row_categories'][0]['title']), 'Active sponsorships')
+        self.assertEqual([r.OTT_ID for r in out['all_row_categories'][0]['rows']], [r.OTT_ID for r in rs])
+        self.assertEqual([r.OTT_ID for r in out['all_row_categories'][1]['rows']], [])
+        self.assertEqual([r.OTT_ID for r in out['all_row_categories'][2]['rows']], [])
+
+        # OTTs expiring soon
+        current.request.now = expiry_time - datetime.timedelta(days=1)
+        out = default.sponsor_renew()
+        self.assertEqual([r.OTT_ID for r in out['all_row_categories'][0]['rows']], [])
+        self.assertEqual(str(out['all_row_categories'][1]['title']), 'Sponsorships expiring soon')
+        self.assertEqual([r.OTT_ID for r in out['all_row_categories'][1]['rows']], [r.OTT_ID for r in rs])
+        self.assertEqual([r.OTT_ID for r in out['all_row_categories'][2]['rows']], [])
+
+        # Fully expire OTTs
+        current.request.now = expiry_time - datetime.timedelta(days=-1)
+        for r in rs:
+            reservation_expire(r)
+        out = default.sponsor_renew()
+        self.assertEqual([r.OTT_ID for r in out['all_row_categories'][0]['rows']], [])
+        self.assertEqual([r.OTT_ID for r in out['all_row_categories'][1]['rows']], [])
+        self.assertEqual(str(out['all_row_categories'][2]['title']), 'Expired sponsorships')
+        self.assertEqual([r.OTT_ID for r in out['all_row_categories'][2]['rows']], [r.OTT_ID for r in rs])
+
+
+if __name__ == '__main__':
+    import sys
+
+    if current.globalenv['is_testing'] != True:
+        raise RuntimeError("Do not run tests in production environments, ensure is_testing = True")
+    suite = unittest.TestSuite()
+    suite.addTest(unittest.makeSuite(ControllersDefaultSponsorInfo))
+    result = unittest.TextTestRunner(verbosity=2).run(suite)
+    if not result.wasSuccessful():
+        sys.exit(1)

--- a/tests/unit/test_modules_OZfunc.py
+++ b/tests/unit/test_modules_OZfunc.py
@@ -1,0 +1,105 @@
+"""
+Run with
+
+python3 web2py.py -S OZtree -M -R applications/OZtree/tests/unit/test_modules_OZfunc.py
+
+Note you should make sure prices are set before running tests (manage/SET_PRICES.html)
+"""
+import datetime
+import unittest
+import urllib.parse
+import uuid
+
+from applications.OZtree.tests.unit import util
+
+from gluon.globals import Request
+
+from OZfunc import (
+    nodes_info_from_array,
+)
+
+from sponsorship import sponsorship_config
+
+
+class TestNodeInfo(unittest.TestCase):
+    def setUp(self):
+        util.clear_unittest_sponsors()
+        util.set_allow_sponsorship(1)
+        util.set_maintenance_mins(0)
+        util.set_reservation_time_limit_mins(0)
+
+    def tearDown(self):
+        util.clear_unittest_sponsors()
+        # Remove anything created as part of tests
+        db.rollback()
+
+    def ni(self, *args, **kwargs):
+        """Call nodes_info_from_array(), resolve array column outputs"""
+        meta = nodes_info_from_array([], [])
+
+        def id_col(x):
+            if x == 'reservations':
+                return meta['colnames_' + x]['OTT_ID']
+            return meta['colnames_' + x]['id']
+
+        out = nodes_info_from_array(*args, **kwargs)
+        for tblname in meta.keys():
+            if not tblname.startswith('colnames_'):
+                continue
+            tblname = tblname.replace('colnames_', '')
+            if tblname not in out:
+                continue
+            out[tblname + '_dict'] = {row[id_col(tblname)]:{k:row[idx] for (k, idx) in meta['colnames_' + tblname].items()} for row in out[tblname]}
+        return out
+
+    def test_nodes_info_from_string_sponsorship(self):
+        db = current.db
+
+        def reservation_leaf(r):
+            return db(db.ordered_leaves.ott == r.OTT_ID).select()[0]
+
+        expiry_time = current.request.now + datetime.timedelta(days=10*365)
+        # Buy some OTTs
+        email_1, user_1 = '1_betty@unittest.example.com', '1_bettyunittestexamplecom'
+        current.request.now = expiry_time - datetime.timedelta(days=sponsorship_config()['duration_days'])
+        rs = util.purchase_reservation(3, basket_details=dict(e_mail=email_1), verify=False)
+        leaves = [reservation_leaf(r) for r in rs]
+        util.verify_reservation(rs[0], verified_name="Definitely Betty", verified_url="https://betty.org")
+        util.verify_reservation(rs[1], verified_name="It's Betty again", verified_kind="for", verified_url="https://betty.com", verified_more_info="More info about Betty")
+        # NB: rs[2] isn't verified
+
+        out = self.ni([l.id for l in leaves], [], include_sponsorship=True)
+        self.assertEqual(out['leaves_dict'], {
+            leaves[0].id: {k: getattr(leaves[0], k) for k in ('id', 'ott', 'name', 'popularity', 'price', 'extinction_date')},
+            leaves[1].id: {k: getattr(leaves[1], k) for k in ('id', 'ott', 'name', 'popularity', 'price', 'extinction_date')},
+            leaves[2].id: {k: getattr(leaves[2], k) for k in ('id', 'ott', 'name', 'popularity', 'price', 'extinction_date')},
+        })
+
+        self.assertEqual(out['reservations_dict'], {
+            rs[0].OTT_ID: dict(
+                OTT_ID=rs[0].OTT_ID,
+                verified_name="Definitely Betty",
+                verified_kind="by",
+                verified_url="https://betty.org",
+                verified_more_info=None,
+            ), rs[1].OTT_ID: dict(
+                OTT_ID=rs[1].OTT_ID,
+                verified_name="It's Betty again",
+                verified_kind="for",
+                verified_url="https://betty.com",
+                verified_more_info="More info about Betty",
+            ),
+            # NB: rs[2] doesn't appear in reservations output
+        })
+
+
+if __name__ == '__main__':
+    import sys
+
+    if current.globalenv['is_testing'] != True:
+        raise RuntimeError("Do not run tests in production environments, ensure is_testing = True")
+    suite = unittest.TestSuite()
+    suite.addTest(unittest.makeSuite(TestNodeInfo))
+    result = unittest.TextTestRunner(verbosity=2).run(suite)
+    if not result.wasSuccessful():
+        sys.exit(1)

--- a/views/default/sponsor_renew.html
+++ b/views/default/sponsor_renew.html
@@ -7,7 +7,7 @@
 {{block masthead}}
 <div class="home-heading uk-text-center uk-padding-small">
     <h1>This is the private sponsorship renewal page for {{=username}}</h1>
-    <p>There is also a public page available at <a href="{{=URL("/donor/%s" % username)}}">{{=URL("/donor/%s" % username, scheme=True, host=True)}}</a> that you can share if you wish.</p>
+    {{if show_donor_link:}}<p>There is also a public page available at <a href="{{=URL("/donor/%s" % username)}}">{{=URL("/donor/%s" % username, scheme=True, host=True)}}</a> that you can share if you wish.</p>{{pass}}
 </div>
 {{end block}}
 

--- a/views/email/sponsor_renew_reminder.txt
+++ b/views/email/sponsor_renew_reminder.txt
@@ -21,7 +21,7 @@ To renew your sponsored species please visit this URL:
 {{for ott in final_reminders:}}
 * {{=XML(nice_names[ott])}} -
 {{if days_left[ott] > 1:}}{{=days_left[ott]}} days left
-{{elif days_left[ott] == 1:}}final day to renew!
+{{elif days_left[ott] > 0:}}final day to renew!
 {{else:}}now expired, but might not be too late to renew{{pass}}
 {{pass}}{{pass}}
 


### PR DESCRIPTION
Fix up the tests after config change, and include any fractional day as the "final day".

This makes the final day a bit Central Line, but it'd be very hard to notice.

Also make "sponsorship_ends == NULL" items say "contact us for renewal"

Fixes #665 
Fixes #664 
Fixes #663 
Fixes #660 