### PR TITLE
Remove id_ott_map & ott_name_map

### DIFF
--- a/OZprivate/rawJS/OZTreeModule/src/api/process_taxon_list.js
+++ b/OZprivate/rawJS/OZTreeModule/src/api/process_taxon_list.js
@@ -41,7 +41,7 @@ export default function process_taxon_list(taxon_json, taxon_callback, header_ca
               ott_array: otts
             },
             success: function (xhr) {
-              let res = populate_data_repo_id_ott_map(xhr);
+              let res = populate_data_repo_ott_id_map(xhr);
               let ott_id_map = res[0];
               let scinames = res[1];
               for (let i = 0; i < taxon_list.length; i++) {
@@ -74,20 +74,18 @@ export default function process_taxon_list(taxon_json, taxon_callback, header_ca
   }
 }
 
-function populate_data_repo_id_ott_map(xhr) {
+function populate_data_repo_ott_id_map(xhr) {
   let ott_id_map = {};
   for (let ott in xhr.leaves) {
     if (xhr.leaves.hasOwnProperty(ott)) {
       ott_id_map[ott] = -xhr.leaves[ott];
       data_repo.ott_id_map[ott] = -xhr.leaves[ott];
-      data_repo.id_ott_map[-xhr.leaves[ott]] = ott;
     }
   }
   for (let ott in xhr.nodes) {
     if (xhr.nodes.hasOwnProperty(ott)) {
       ott_id_map[ott] = xhr.nodes[ott];
       data_repo.ott_id_map[ott] = xhr.nodes[ott];
-      data_repo.id_ott_map[xhr.nodes[ott]] = ott;
     }
   }
   return [ott_id_map, xhr.names];

--- a/OZprivate/rawJS/OZTreeModule/src/api/search_manager.js
+++ b/OZprivate/rawJS/OZTreeModule/src/api/search_manager.js
@@ -290,14 +290,6 @@ class SearchManager {
     let tidy_latin = (latinName && (!latinName.startsWith("_")) && (!latinName.endsWith("_"))) ? latinName.split("_").join(" ") : null; 
     let tidy_common = vernacular ? capitalizeFirstLetter(vernacular) : null; // ready for printing in UI
     
-    //populate some global hash tables
-    if (this.data_repo && ott) {
-        this.data_repo.id_ott_map[id*id_decider] = ott;
-        if (!this.data_repo.ott_name_map[ott]) this.data_repo.ott_name_map[ott] = [];
-        if (tidy_latin) this.data_repo.ott_name_map[ott][0] = tidy_latin;
-        if (tidy_common) this.data_repo.ott_name_map[ott][1] = tidy_common;
-    }
-    
     let row = [tidy_common, tidy_latin, id * id_decider];
     let score_result = overall_search_score(toSearchFor, latinName, lang, vernacular, extra_vernaculars);
     if (score_result.length < 2) {

--- a/OZprivate/rawJS/OZTreeModule/src/api/search_manager.js
+++ b/OZprivate/rawJS/OZTreeModule/src/api/search_manager.js
@@ -206,17 +206,11 @@ class SearchManager {
         if (res.nodes){ // check if there are node search results before processing those
             for (let i=0; i<res.nodes.length; i++) {
                 temp_ott_id_map[res.nodes[i].ott] = res.nodes[i].id;
-                if (this.data_repo)
-                    // If this.data_repo exists append data - this is to enable URL rewriting later
-                    this.data_repo.id_ott_map[res.nodes[i].id] = res.nodes[i].ott;
             }
         }
         if (res.leaves){ // check that there are leaf search results
             for (let i=0; i<res.leaves.length; i++) {
                 temp_ott_id_map[res.leaves[i].ott] = -res.leaves[i].id;
-                if (this.data_repo)
-                    // If this.data_repo exists append data - this is to enable URL rewriting later
-                    this.data_repo.id_ott_map[-res.leaves[i].id] = res.leaves[i].ott;
             }
          }
           if (res.reservations){ // check that there are reservation search results (sponsors)

--- a/OZprivate/rawJS/OZTreeModule/src/controller/controller.js
+++ b/OZprivate/rawJS/OZTreeModule/src/controller/controller.js
@@ -114,6 +114,11 @@ class Controller {
     */
   trigger_refresh_loop() {
     function refresh_loop() {
+      if (!this.root) {
+        // Tree not init-ed, we started early.
+        this.refresh_timer = null;
+        return;
+      }
       call_hook("before_draw");
       if ((this.widthres != this.canvas.clientWidth)||(this.heightres != this.canvas.clientHeight))
       {

--- a/OZprivate/rawJS/OZTreeModule/src/controller/controller_anim.js
+++ b/OZprivate/rawJS/OZTreeModule/src/controller/controller_anim.js
@@ -10,13 +10,14 @@ import { UserInterruptError } from '../errors';
  * This function collects nodes and leaves which are on or near the main branch in the fly animation,
  * animation, then fetches metadata of these nodes or leaves, returning resolve when done.
  * @param {node} root controller.root
+ * @param subbranch_depth How far off main branch to develop
  * @return {Promise}
  * -- resolve when metadata is returned.
  * -- reject if there is any error.
  */
-function get_details_of_nodes_in_view_during_fly(root) {
+function get_details_of_nodes_in_view_during_fly(root, subbranch_depth) {
   /**
-   * Push all nodes that are on the main branch or within 4 generations from the main branch from the root to the targeted node.
+   * Push all nodes that are on the main branch or within (subbranch_depth) generations from the main branch from the root to the targeted node.
    */
   function get_target_nodes_arr(node, nodes_arr) {
     if (node.targeted) {
@@ -26,7 +27,7 @@ function get_details_of_nodes_in_view_during_fly(root) {
       }
       nodes_arr.push(node);
     } else {
-      nodes_arr = nodes_arr.concat(get_subbranch_nodes_arr(node, 4));
+      nodes_arr = nodes_arr.concat(get_subbranch_nodes_arr(node, subbranch_depth));
     }
     return nodes_arr;
   }
@@ -185,7 +186,7 @@ export default function (Controller) {
   }
   Controller.prototype.fetch_details_and_leap_to = function(dest_OZid, position=null, into_node=false) {
     this.develop_branch_to_and_target(dest_OZid);
-    return get_details_of_nodes_in_view_during_fly(this.root).then(function () {
+    return get_details_of_nodes_in_view_during_fly(this.root, 0).then(function () {
         return this.leap_to(dest_OZid, position, into_node);
     }.bind(this));
   }
@@ -317,7 +318,7 @@ export default function (Controller) {
                 flight_p = flight_p.then(function () {
                     position_helper.clear_target(this.root);
                     position_helper.target_by_code(this.root, n.ozid);
-                    return get_details_of_nodes_in_view_during_fly(this.root);
+                    return get_details_of_nodes_in_view_during_fly(this.root, 4);
                 }.bind(this));
             }.bind(this));
 

--- a/OZprivate/rawJS/OZTreeModule/src/controller/controller_anim.js
+++ b/OZprivate/rawJS/OZTreeModule/src/controller/controller_anim.js
@@ -79,6 +79,7 @@ function get_details_of_nodes_in_view_during_fly(root) {
             image_source: data_repo.image_source
           },
           success: function(res) {
+            // NB: Do the work of update_nodes_details()
             let length;
             length = temp_nodes_arr.length;
             for (let i=0; i<length; i++) {

--- a/OZprivate/rawJS/OZTreeModule/src/controller/controller_anim.js
+++ b/OZprivate/rawJS/OZTreeModule/src/controller/controller_anim.js
@@ -183,6 +183,12 @@ export default function (Controller) {
         this, into_node, Infinity, 'linear', resolve, () => reject(new UserInterruptError('Fly is interrupted')));
     }))
   }
+  Controller.prototype.fetch_details_and_leap_to = function(dest_OZid, position=null, into_node=false) {
+    this.develop_branch_to_and_target(dest_OZid);
+    return get_details_of_nodes_in_view_during_fly(this.root).then(function () {
+        return this.leap_to(dest_OZid, position, into_node);
+    }.bind(this));
+  }
   
   /**
    * Fly directly to a specified OneZoom node id in the tree from your current position.
@@ -394,13 +400,7 @@ export default function (Controller) {
     }
 
     // init == "leap"
-    // NB: leap_to won't fetch details, we do it ourselves
-    position_helper.clear_target(this.root);
-    n = this.develop_branch_to_and_target(dest_OZid);
-    position_helper.target_by_code(this.root, n.ozid);
-    return get_details_of_nodes_in_view_during_fly(this.root).then(function () {
-        return this.leap_to(dest_OZid, init, into_node=into_node);
-    }.bind(this));
+    return this.fetch_details_and_leap_to(dest_OZid, init, into_node=into_node);
   };
   
   /**

--- a/OZprivate/rawJS/OZTreeModule/src/controller/controller_search.js
+++ b/OZprivate/rawJS/OZTreeModule/src/controller/controller_search.js
@@ -73,7 +73,7 @@ export default function (Controller) {
         if (config.search_jump_mode === 'flight') {
             return p.then((pp) => this.fly_on_tree_to(null, pp.ozid));
         } else {
-            return p.then((pp) => this.leap_to(pp.ozid));
+            return p.then((pp) => this.fetch_details_and_leap_to(pp.ozid));
         }
     }
 

--- a/OZprivate/rawJS/OZTreeModule/src/factory/data_repo.js
+++ b/OZprivate/rawJS/OZTreeModule/src/factory/data_repo.js
@@ -9,7 +9,6 @@ class DataRepo {
     this.ott_id_map = {};
     this.id_ott_map = {};
     this.name_id_map = {};
-    this.ott_name_map = {};
     this.ott_region_map = {
         
         // lowest priority
@@ -154,7 +153,6 @@ class DataRepo {
     for (let arr of Object.values(this.metadata.node_meta)) {
       delete arr[data_repo.mc_key_n["common_en"]];
     }
-    this.ott_name_map = {};
   }
 
   get raw_data() {
@@ -359,11 +357,6 @@ function parse_vernacular_by_ott(data_repo, vernacular_by_ott) {
       if (!data_repo.metadata.leaf_meta[id][data_repo.mc_key_l["common_en"]])
         data_repo.metadata.leaf_meta[id][data_repo.mc_key_l["common_en"]] = vernacular;
     }
-    
-    //data_repo.ott_name_map[ott] = [scientificName, vernacular]
-    if (!data_repo.ott_name_map[ott]) data_repo.ott_name_map[ott] = [];
-    if (!data_repo.ott_name_map[ott][1])
-      data_repo.ott_name_map[ott][1] = vernacular;
   }
 }
 

--- a/OZprivate/rawJS/OZTreeModule/src/factory/data_repo.js
+++ b/OZprivate/rawJS/OZTreeModule/src/factory/data_repo.js
@@ -7,7 +7,6 @@ import {pic_src_order} from '../tree_settings';
 class DataRepo {
   constructor() {
     this.ott_id_map = {};
-    this.id_ott_map = {};
     this.name_id_map = {};
     this.ott_region_map = {
         
@@ -125,7 +124,7 @@ class DataRepo {
    */
   
   update_metadata(res) {
-    this.populate_id_ott_map(res);
+    this.populate_ott_id_map(res);
     this.populate_name_id_map(res);
     parse_ordered_leaves(this, res.leaves, node_details_api);
     parse_ordered_nodes(this, res.nodes, node_details_api);
@@ -204,7 +203,7 @@ class DataRepo {
    * @private 
    * @param {Object} res - the API JSON return result from node_details.json
    */
-  populate_id_ott_map(res) {
+  populate_ott_id_map(res) {
     let nodes = res.nodes;
     let leaves = res.leaves;
     for (let i=0; i<nodes.length; i++) {
@@ -212,7 +211,6 @@ class DataRepo {
       let id = nodes[i][node_details_api.node_cols["id"]];
       if (ott) {
         this.ott_id_map[ott] = id;
-        this.id_ott_map[id] = ott;
       }
     }
     for (let i=0; i<leaves.length; i++) {
@@ -220,7 +218,6 @@ class DataRepo {
       let id = leaves[i][node_details_api.leaf_cols["id"]];
       if (ott) {
         this.ott_id_map[ott] = -id;
-        this.id_ott_map[-id] = ott;
       }
     }
   }

--- a/OZprivate/rawJS/OZTreeModule/src/factory/midnode.js
+++ b/OZprivate/rawJS/OZTreeModule/src/factory/midnode.js
@@ -474,8 +474,6 @@ class Midnode {
   get ott() {
     if (this._ott !== null) return this._ott;
     let ott = this.get_attribute("OTTid");
-    if (!ott && this.is_interior_node && data_repo.id_ott_map[this.metacode]) ott = data_repo.id_ott_map[this.metacode];
-    else if (!ott && this.is_leaf && data_repo.id_ott_map[-this.metacode]) ott = data_repo.id_ott_map[-this.metacode];
     if (this.detail_fetched || ott) {
       this._ott = ott;
     }

--- a/OZprivate/rawJS/OZTreeModule/src/factory/midnode.js
+++ b/OZprivate/rawJS/OZTreeModule/src/factory/midnode.js
@@ -282,18 +282,14 @@ class Midnode {
    * Get attribute of node by key name. Use this function to fetch metadata of node only.
    */
   get_attribute(key_name) {
-    if (this.detail_fetched && this.is_leaf) {
-      let col = data_repo.mc_key_l[key_name];
-      if (data_repo.metadata.leaf_meta[this.metacode] && data_repo.metadata.leaf_meta[this.metacode][col] !== undefined) {
-        return data_repo.metadata.leaf_meta[this.metacode][col];
-      }
-    } else if (this.detail_fetched && this.is_interior_node) {
-      let col = data_repo.mc_key_n[key_name];
-      if (data_repo.metadata.node_meta[this.metacode] && data_repo.metadata.node_meta[this.metacode][col] !== undefined) {
-        return data_repo.metadata.node_meta[this.metacode][col];
-      }
+    if (this.is_leaf) {
+      if (!data_repo.metadata.leaf_meta[this.metacode]) return undefined;
+      return data_repo.metadata.leaf_meta[this.metacode][data_repo.mc_key_l[key_name]];
     }
-    return undefined;
+    if (this.is_interior_node) {
+      if (!data_repo.metadata.node_meta[this.metacode]) return undefined;
+      return data_repo.metadata.node_meta[this.metacode][data_repo.mc_key_n[key_name]];
+    }
   }
   
   clear_pics() {
@@ -332,7 +328,6 @@ class Midnode {
   get cname() {
     if (this._cname !== null) return this._cname;
     let _cname = this.get_attribute("common_en");
-    if (!_cname && this.ott && data_repo.ott_name_map[this.ott]) _cname = data_repo.ott_name_map[this.ott][1];
     if (this.detail_fetched) {
       _cname = capitalizeFirstLetter(_cname);
       this._cname = _cname;
@@ -342,7 +337,6 @@ class Midnode {
   get latin_name() {
     if (this._latin_name !== null) return this._latin_name;
     let _latin_name = this.get_attribute("scientificName");
-    if (!_latin_name && this.ott && data_repo.ott_name_map[this.ott]) _latin_name = data_repo.ott_name_map[this.ott][0];
     if (_latin_name && _latin_name.charAt(_latin_name.length-1) === "_") {
       _latin_name = null;
     } else if (_latin_name) {

--- a/OZprivate/rawJS/OZTreeModule/src/navigation/pinpoint.js
+++ b/OZprivate/rawJS/OZTreeModule/src/navigation/pinpoint.js
@@ -82,7 +82,6 @@ export function resolve_pinpoints(pinpoint_or_pinpoints) {
         if (res.ids && res.ids.length) {
           if (p.ott) {
             data_repo.ott_id_map[p.ott] = res.ids[0]
-            data_repo.id_ott_map[res.ids[0]] = p.ott
           }
           p.ozid = res.ids[0]
           resolve(p);

--- a/OZprivate/rawJS/OZTreeModule/tests/util_data_repo.js
+++ b/OZprivate/rawJS/OZTreeModule/tests/util_data_repo.js
@@ -49,11 +49,14 @@ export function populate_data_repo(tree_serial = '25589581') {
   * Find an OZid that matches given conditions
   */
 export function get_ozid({leaf = false, node = false, nonexistant = false}) {
-  var candidates = Object.keys(data_repo.id_ott_map);
+  var candidates = [].concat(
+      Object.keys(data_repo.metadata.leaf_meta).map((x) => parseInt(x, 10)).map((x) => -x),
+      Object.keys(data_repo.metadata.node_meta).map((x) => parseInt(x, 10)),
+  );
 
   if (nonexistant) candidates = [999999999, -999999999]
   if (leaf) candidates = candidates.filter((x) => x < 0)
   if (node) candidates = candidates.filter((x) => x >= 0)
 
-  return parseInt(candidates[Math.floor(Math.random() * (candidates.length - 1))]);
+  return candidates[Math.floor(Math.random() * (candidates.length - 1))];
 }


### PR DESCRIPTION
As per #656, get rid of some big node metadata caches that are superfluous.

To make this happen, we fetch details before leaping to search results. This already happens with flights (and initial leap to), so the fact that it didn't here was a bug.