### PR TITLE
Add /API/pinpoints endpoint

### DIFF
--- a/OZprivate/rawJS/OZTreeModule/src/api/api_manager.js
+++ b/OZprivate/rawJS/OZTreeModule/src/api/api_manager.js
@@ -12,8 +12,8 @@ class APIManager {
   
   /** Set the urls that will be used when calling the API.
    *  @params {Object.<string, string>} server_urls - a set of urls for the OneZoom API. 
-   * Names for each url can be one of 'search_api', 'search_sponsor_api', 'get_ids_by_ott_array_api',
-   * 'otts2vns_api', 'node_details_api', 'pinpoints_api'
+   * Names for each url can be one of 'search_api', 'search_sponsor_api',
+   * 'node_details_api', 'pinpoints_api'
    */
   set_urls(server_urls) {
     for (let name in server_urls) {
@@ -76,16 +76,6 @@ class APIManager {
       alert('Something’s not quite right.' +
        '\n(search_sponsor_api was not set in config.api).' +
        '\nPlease email mail@onezoom.org and let us know.')
-  }
-  get_ids_by_ott_array(params) {
-    params.url = config.api.get_ids_by_ott_array_api;
-    api_wrapper(params);
-  }
-  otts2vns(params) {
-    //returns vernaculars, so we have to set the language if necessary
-    if (config.lang) params.data.lang = config.lang;
-    params.url = config.api.otts2vns_api;
-    api_wrapper(params);
   }
   node_detail(params) {
     //node_detail contains vernaculars, so we have to set the language if necessary

--- a/OZprivate/rawJS/OZTreeModule/src/api/api_manager.js
+++ b/OZprivate/rawJS/OZTreeModule/src/api/api_manager.js
@@ -13,7 +13,7 @@ class APIManager {
   /** Set the urls that will be used when calling the API.
    *  @params {Object.<string, string>} server_urls - a set of urls for the OneZoom API. 
    * Names for each url can be one of 'search_api', 'search_sponsor_api', 'get_ids_by_ott_array_api',
-   * 'otts2vns_api', 'search_init_api', 'node_details_api', 
+   * 'otts2vns_api', 'node_details_api', 'pinpoints_api'
    */
   set_urls(server_urls) {
     for (let name in server_urls) {
@@ -32,6 +32,28 @@ class APIManager {
     image_details_api.start(controller);
   }
 
+  /**
+   * Call the /API/pinpoints endpoint
+   * @param pps Array of pinpoints to lookup
+   * @param options /API/pinpoints querystring options
+   * @return Promise of parsed result
+   */
+  pinpoints(pps, options={}) {
+    return new Promise((resolve, reject) => {
+      if (pps.length === 0) {
+        // Don't bother the server if we have nothing to do
+        resolve({ results: [] });
+        return;
+      }
+      api_wrapper({
+        method: 'get',
+        url: config.api.pinpoints_api + '/' + pps.join("/"),
+        data: options,
+        success: resolve,
+        error: (res) => reject("Failed to talk to server: " + res),
+      })
+    });
+  }
   
   /**
    * @params {String} query
@@ -63,10 +85,6 @@ class APIManager {
     //returns vernaculars, so we have to set the language if necessary
     if (config.lang) params.data.lang = config.lang;
     params.url = config.api.otts2vns_api;
-    api_wrapper(params);
-  }
-  search_init(params) {
-    params.url = config.api.search_init_api;
     api_wrapper(params);
   }
   node_detail(params) {

--- a/OZprivate/rawJS/OZTreeModule/src/global_config.js
+++ b/OZprivate/rawJS/OZTreeModule/src/global_config.js
@@ -58,7 +58,7 @@ config.api = {
   get_ids_by_ott_array_api: null,
   otts2vns_api: null,
 
-  search_init_api: null,
+  pinpoints_api: null,
 
   abort_request_threshold: 30000, //timeout for ajax call
   max_concurrent_request: 3,

--- a/OZprivate/rawJS/OZTreeModule/src/global_config.js
+++ b/OZprivate/rawJS/OZTreeModule/src/global_config.js
@@ -55,8 +55,6 @@ config.api = {
 
   search_api: null,
   search_sponsor_api: null,
-  get_ids_by_ott_array_api: null,
-  otts2vns_api: null,
 
   pinpoints_api: null,
 

--- a/OZprivate/rawJS/OZTreeModule/src/navigation/pinpoint.js
+++ b/OZprivate/rawJS/OZTreeModule/src/navigation/pinpoint.js
@@ -142,17 +142,20 @@ export function node_to_pinpoint(node) {
 /**
  * Convert latin name to pinpoint-friendly form
  *
- * Tidy latin doesn't contain space
+ * Tidy latin doesn't contain any of /,=,_ or space
+ * * Truncate at the first instance of any of the dissalowed characters
  * * Convert space to underscore
  *
  * NB: "latin names" starting or ending with underscore are "fake" in OneZoom
  */
 function tidy_latin(s) {
-  return s.replace(/ /g, '_');
+  return s.replace(/[\/=_].*$/, '').replace(/ /g, '_');
 }
 
 /**
  * Revert tidy_latin as much as possible
+ *
+ * Should at least be true that ``s.startsWith(untidy_latin(tidy_latin(s)))``
  */
 function untidy_latin(s) {
   return s.replace(/_/g, ' ');

--- a/OZprivate/rawJS/OZTreeModule/src/navigation/pinpoint.js
+++ b/OZprivate/rawJS/OZTreeModule/src/navigation/pinpoint.js
@@ -10,7 +10,7 @@ import data_repo from '../factory/data_repo';
  * ``@name``: Where name is a latin name
  * ``@name=12345``: Where name is a latin name, 12345 an OTT
  * ``@=12345``: Where 12345 is an OTT
- * ``@_ancestor=1234-6789``: Where 1234-6789 are OTTs
+ * ``@_ancestor=1234=6789``: Where 1234, 6789 are OTTs
  * ``@_ozid=123456``: Where 123456 is an OZid / metacode
  * If required, API lookups will be made to fill in an gaps in local knowledge.
  *
@@ -54,7 +54,7 @@ export function resolve_pinpoints(pinpoint_or_pinpoints, extra_metadata={}) {
       out.ozid = parseInt(parts[1], 10);
     } else if (parts[0] === '_ancestor') {
       // Common-ancestor lookup, add extra lookups to list of things to get
-      out.sub_pinpoints = parts[1].split('-').map((sub_ott) => {
+      out.sub_pinpoints = parts.slice(1).map((sub_ott) => {
         let sub_pp = { pinpoint: sub_ott, ott: parseInt(sub_ott) };
         extra_lookups.push(sub_pp);
         return sub_pp;

--- a/OZprivate/rawJS/OZTreeModule/src/navigation/pinpoint.js
+++ b/OZprivate/rawJS/OZTreeModule/src/navigation/pinpoint.js
@@ -47,7 +47,7 @@ export function resolve_pinpoints(pinpoint_or_pinpoints, extra_metadata={}) {
       // NB: "@12345" used to be OZid. We've stopped doing that, but keep the NaN check
       //     so we don't interpret "@12345" as a latin_name
       if (isNaN(parseInt(parts[0]))) {
-        out.latin_name = parts[0];
+        out.latin_name = untidy_latin(parts[0]);
       }
     } else if (parts[0] === '_ozid') {
       // Raw OZID
@@ -63,7 +63,7 @@ export function resolve_pinpoints(pinpoint_or_pinpoints, extra_metadata={}) {
       out.ozid = 'common_ancestor';
     } else {
       // Regular @[latin]=[OTT] form
-      if (parts[0].length > 0) out.latin_name = parts[0];
+      if (parts[0].length > 0) out.latin_name = untidy_latin(parts[0]);
       if (!isNaN(parseInt(parts[1]))) out.ott = parseInt(parts[1]);
     }
 
@@ -114,7 +114,26 @@ export function node_to_pinpoint(node) {
   if (!node.ott && !node.latin_name) return null;
   return [
     "@",
-    node.latin_name ? node.latin_name.split(" ").join("_") : "",
+    node.latin_name ? tidy_latin(node.latin_name) : '',
     node.ott ? "=" + node.ott : "",
   ].join("")
+}
+
+/**
+ * Convert latin name to pinpoint-friendly form
+ *
+ * Tidy latin doesn't contain space
+ * * Convert space to underscore
+ *
+ * NB: "latin names" starting or ending with underscore are "fake" in OneZoom
+ */
+function tidy_latin(s) {
+  return s.replace(/ /g, '_');
+}
+
+/**
+ * Revert tidy_latin as much as possible
+ */
+function untidy_latin(s) {
+  return s.replace(/_/g, ' ');
 }

--- a/OZprivate/rawJS/OZTreeModule/tests/test_navigation_pinpoint.js
+++ b/OZprivate/rawJS/OZTreeModule/tests/test_navigation_pinpoint.js
@@ -43,6 +43,45 @@ test('resolve_pinpoints:ott', function (test) {
   })
 });
 
+test('resolve_pinpoints:sciname', function (test) {
+  return populate_data_repo().then(() => {
+    return Promise.all([
+        test_pinpoint(test, '@Pteropus_vampyrus=448935', {
+            pinpoint: '@Pteropus_vampyrus=448935',
+            // NB; Got back untidied name, as it's valid
+            sciname: 'Pteropus vampyrus',
+            ott: 448935,
+            ozid: -836320,
+        }),
+        test_pinpoint(test, '@Pteropus_vamp=448935', {
+            pinpoint: '@Pteropus_vamp=448935',
+            // NB: No sciname since the broken value isn't in the map
+            ott: 448935,
+            ozid: -836320,
+        }),
+        test_pinpoint(test, '@Pteropus_lylei', {
+            pinpoint: '@Pteropus_lylei',
+            // Can look up just from latin name if in map
+            sciname: 'Pteropus lylei',
+            ozid: -836318,
+        }),
+        test_pinpoint(test, '@Pteropus_lylei=448935', {
+            pinpoint: '@Pteropus_lylei=448935',
+            // NB: OTT won over latin name, so we don't mention it
+            ott: 448935,
+            ozid: -836320,
+        }),
+    ]);
+
+  }).then(function () {
+    test.end();
+  }).catch(function (err) {
+    console.log(err.stack);
+    test.fail(err);
+    test.end();
+  })
+});
+
 test('resolve_pinpoints:ozid', function (test) {
   return populate_data_repo().then(() => {
     return test_pinpoint(test, '@_ozid=836250', {

--- a/OZprivate/rawJS/OZTreeModule/tests/test_navigation_pinpoint.js
+++ b/OZprivate/rawJS/OZTreeModule/tests/test_navigation_pinpoint.js
@@ -65,7 +65,7 @@ test('resolve_pinpoints:common_ancestor', function (test) {
     factory = f;
 
   }).then(function () {
-    return test_pinpoint(test, '@_ancestor=988790-824869', {
+    return test_pinpoint(test, '@_ancestor=988790=824869', {
       sub_pinpoints: [
         { pinpoint: '988790', ott: 988790, ozid: 836250 },
         { pinpoint: '824869', ott: 824869, ozid: 836247 },
@@ -75,7 +75,7 @@ test('resolve_pinpoints:common_ancestor', function (test) {
 
   }).then(function () {
     // Ancestor of a node below another is the first node
-    return test_pinpoint(test, '@_ancestor=244265-48401', {
+    return test_pinpoint(test, '@_ancestor=244265=48401', {
       sub_pinpoints: [
         { pinpoint: '244265', ott: 244265, ozid: 834744 },  // Mammals
         { pinpoint: '48401', ott: 48401, ozid: -836261 },  // Fijian monkey-faced bat (Mirimiri acrodonta)

--- a/OZprivate/rawJS/OZTreeModule/tests/test_navigation_pinpoint.js
+++ b/OZprivate/rawJS/OZTreeModule/tests/test_navigation_pinpoint.js
@@ -1,7 +1,7 @@
 /**
   * Usage: npx babel-tape-runner OZprivate/rawJS/OZTreeModule/tests/test_navigation_pinpoint.js
   */
-import { resolve_pinpoints } from '../src/navigation/pinpoint.js';
+import { resolve_pinpoints, node_to_pinpoint } from '../src/navigation/pinpoint.js';
 import { populate_data_repo } from './util_data_repo.js'
 import { populate_factory } from './util_factory'
 import test from 'tape';
@@ -131,6 +131,39 @@ test('resolve_pinpoints:common_ancestor', function (test) {
   })
 });
 
+test('node_to_pinpoint:tidy_latin', function (test) {
+  test.deepEqual(
+    node_to_pinpoint({  }),
+    null,
+    "Nothing defined, return null rather than an empty string",
+  );
+
+  test.deepEqual(
+    node_to_pinpoint({ ott: 12345 }),
+    '@=12345',
+    "Just OTT"
+  );
+
+  test.deepEqual(
+    node_to_pinpoint({ latin_name: "Pteropus vampyrus" }),
+    '@Pteropus_vampyrus',
+    "Just latin, tidied"
+  );
+
+  test.deepEqual(
+    node_to_pinpoint({ latin_name: "Bacillus cereus F837/76", ott: 612331 }),
+    '@Bacillus_cereus_F837=612331',
+    "Latin tidied and truncated"
+  );
+
+  test.deepEqual(
+    node_to_pinpoint({ latin_name: "Bacillus coagulans DSM 1 = ATCC 7050", ott: 724868 }),
+    '@Bacillus_coagulans_DSM_1_=724868',
+    "Latin tidied and truncated"
+  );
+
+  test.end();
+});
 
 test.onFinish(function() {
   // NB: Something data_repo includes in is holding node open.

--- a/OZprivate/rawJS/OZTreeModule/tests/test_navigation_state.js
+++ b/OZprivate/rawJS/OZTreeModule/tests/test_navigation_state.js
@@ -31,10 +31,10 @@ test('parse_state', function (t) {
         pinpoint: null,
     }, "No pinpoint")
 
-    t.deepEqual(pwl("http://onezoom.example.com/life/@Myzopoda_aurita?otthome=%40_ancestor%3D983483-3600795"), {
+    t.deepEqual(pwl("http://onezoom.example.com/life/@Myzopoda_aurita?otthome=%40_ancestor%3D983483%3D3600795"), {
         url_base: 'http://onezoom.example.com/life/',
         pinpoint: '@Myzopoda_aurita',
-        home_ott_id: '@_ancestor=983483-3600795',
+        home_ott_id: '@_ancestor=983483=3600795',
     }, "Pinpoint with latin name & OTT, common-ancestor otthome")
 
     t.deepEqual(pwl("http://onezoom.example.com/life/@Myzopoda_aurita?highlight=fan:@biota&initmark=12345&highlight=fan:@mammalia"), {
@@ -84,7 +84,7 @@ test('deparse_state', function (t) {
     test_url_match("http://onezoom.example.com/life/@Myzopoda_aurita?pop=ol_6794");
     test_url_match("http://onezoom.example.com/life/@Myzopoda_aurita");
     test_url_match("http://onezoom.example.com/life/@=6794#x1402,y364,w1.4013");
-    test_url_match("http://onezoom.example.com/life/@Myzopoda_aurita?otthome=%40_ancestor%3D983483-3600795");
+    test_url_match("http://onezoom.example.com/life/@Myzopoda_aurita?otthome=%40_ancestor%3D983483%3D3600795");
 
     t.end();
 });

--- a/OZprivate/rawJS/OZTreeModule/tests/test_projection_highlight.js
+++ b/OZprivate/rawJS/OZTreeModule/tests/test_projection_highlight.js
@@ -17,7 +17,7 @@ function test_highlights_for(test, node, highlight_strs) {
   test.deepEqual(
     highlights_for(node).map((h) => h.str),
     highlight_strs,
-    "Highlights at " + node.ozid + (node.latin_name ? ' / ' + node.latin_name : '') + (node.cname ? ' / ' + node.cname : '') + (node.ott ? ' / ' + node.ott : ''),
+    "Highlights at " + node.ozid + (node.sciname ? ' / ' + node.sciname : '') + (node.cname ? ' / ' + node.cname : '') + (node.ott ? ' / ' + node.ott : ''),
   );
 }
 
@@ -81,18 +81,18 @@ test('update_highlights', function (test) {
     // Gather some test points
     return resolve_pinpoints([
       '@biota=93302',
-      '@mammalia=244265',
+      '@Mammalia=244265',
       '@chiroptera=574724',  // All bats
-      '@peropodidae=574742',  // Megabats
-      '@dobsonia=988790',  // Bare-backed fruit bats
-      '@dobsonia_moluccensis=1032365',
-      '@dobsonia_crenulata=3613457',
-      '@acerodon=635024', // Flying foxes
-      '@pteropus=813030', // Flying foxes
-      '@pteropus_vampyrus=448935',
-      '@pteropus_lylei=630309',
+      '@Peropodidae=574742',  // Megabats
+      '@Dobsonia=988790',  // Bare-backed fruit bats
+      '@Dobsonia_moluccensis=1032365',
+      '@Dobsonia_crenulata=3613457',
+      '@Acerodon=635024', // Flying foxes
+      '@Pteropus=813030', // Flying foxes
+      '@Pteropus_vampyrus=448935',
+      '@Pteropus_lylei=630309',
     ]).then((pps) => pps.forEach((pp) => {
-        nodes[pp.latin_name] = factory.dynamic_loading_by_metacode(pp.ozid)
+        nodes[pp.ott === 574724 ? 'chiroptera' : pp.sciname] = factory.dynamic_loading_by_metacode(pp.ozid)
     }));
 
   }).then(function () {
@@ -101,7 +101,7 @@ test('update_highlights', function (test) {
     ], fake_picker).then((hs) => highlight_update(nodes.biota, hs)).then(() => {
       test.deepEqual(current_highlights(), []);
       test_highlights_for(test, nodes.biota, []);
-      test_highlights_for(test, nodes.mammalia, []);
+      test_highlights_for(test, nodes.Mammalia, []);
     });
 
   }).then(function () {
@@ -136,23 +136,23 @@ test('update_highlights', function (test) {
         // ... on both paths
         'fan:@chiroptera=574724@pteropus=813030',
       ]);
-      test_highlights_for(test, nodes.acerodon, [
+      test_highlights_for(test, nodes.Acerodon, [
         'fan:@chiroptera=574724@pteropus=813030',
         'path:@acerodon=635024',
       ]);
-      test_highlights_for(test, nodes['dobsonia moluccensis'], [
+      test_highlights_for(test, nodes['Dobsonia moluccensis'], [
         'fan:@chiroptera=574724@pteropus=813030',
       ]);
-      test_highlights_for(test, nodes.pteropus, [
+      test_highlights_for(test, nodes.Pteropus, [
         // NB: Path from here not active
         'path:@pteropus_vampyrus=448935',
       ]);
-      test_highlights_for(test, nodes.pteropus.children[1], [
+      test_highlights_for(test, nodes.Pteropus.children[1], [
         // NB: Now it is NB(2): The order of our highlights has been preserved
         'path:@pteropus=813030@pteropus_vampyrus=448935',
         'path:@pteropus_vampyrus=448935',
       ]);
-      test_highlights_for(test, nodes['pteropus vampyrus'], [
+      test_highlights_for(test, nodes['Pteropus vampyrus'], [
         'path:@pteropus=813030@pteropus_vampyrus=448935',
         'path:@pteropus_vampyrus=448935',
       ]);
@@ -176,7 +176,7 @@ test('highlights_for', function (test) {
     return resolve_pinpoints([
       '@biota=93302',
     ]).then((pps) => pps.forEach((pp) => {
-        nodes[pp.latin_name] = factory.dynamic_loading_by_metacode(pp.ozid)
+        nodes[pp.sciname] = factory.dynamic_loading_by_metacode(pp.ozid)
     }));
 
   }).then(function () {

--- a/OZprivate/rawJS/OZTreeModule/tests/test_projection_highlight.js
+++ b/OZprivate/rawJS/OZTreeModule/tests/test_projection_highlight.js
@@ -140,7 +140,7 @@ test('update_highlights', function (test) {
         'fan:@chiroptera=574724@pteropus=813030',
         'path:@acerodon=635024',
       ]);
-      test_highlights_for(test, nodes.dobsonia_moluccensis, [
+      test_highlights_for(test, nodes['dobsonia moluccensis'], [
         'fan:@chiroptera=574724@pteropus=813030',
       ]);
       test_highlights_for(test, nodes.pteropus, [
@@ -152,7 +152,7 @@ test('update_highlights', function (test) {
         'path:@pteropus=813030@pteropus_vampyrus=448935',
         'path:@pteropus_vampyrus=448935',
       ]);
-      test_highlights_for(test, nodes.pteropus_vampyrus, [
+      test_highlights_for(test, nodes['pteropus vampyrus'], [
         'path:@pteropus=813030@pteropus_vampyrus=448935',
         'path:@pteropus_vampyrus=448935',
       ]);

--- a/controllers/API.py
+++ b/controllers/API.py
@@ -217,8 +217,8 @@ def search_init():
     except (TypeError, ValueError) as error:
         pass  # Some problem converting ott to int, try on name
     try:
-        tidy_latin = request.vars.name.replace("_", " ")
-        query = db.ordered_leaves.name == tidy_latin
+        sciname = pinpoint.untidy_latin(request.vars.name)
+        query = db.ordered_leaves.name == sciname
         name_ids = set([-r.id for r in db(query).select(db.ordered_leaves.id)])
         query = db.ordered_nodes.name == request.vars.name
         name_ids.update([r.id for r in db(query).select(db.ordered_nodes.id)])

--- a/controllers/API.py
+++ b/controllers/API.py
@@ -165,6 +165,8 @@ def pinpoints():
             ozid=-r.id if is_leaf else r.id,
             ott=r.ott,
         ))
+        if request.vars.get('sciname', None):
+            results[-1]['sciname'] = r.name;
 
     vn_type = request.vars.get('vernacular', None)
     if vn_type:

--- a/controllers/API.py
+++ b/controllers/API.py
@@ -168,7 +168,7 @@ def pinpoints():
         if request.vars.get('sciname', None):
             results[-1]['sciname'] = r.name;
 
-    vn_type = request.vars.get('vernacular', None)
+    vn_type = request.vars.get('vn', None)
     if vn_type:
         vn_results = OZfunc.get_common_names(
             [r['ott'] for r in results if r.get('ott', None)],

--- a/modules/pinpoint.py
+++ b/modules/pinpoint.py
@@ -1,6 +1,44 @@
 from gluon import current
 
 
+def common_ancestor_of_otts(otts):
+    """
+    Given a list of otts, return their common ancestor as ozid
+    NB: We don't consider the case where all of otts are identical (or just one)
+    """
+    db = current.db
+
+    rs = db.executesql("""
+        WITH RECURSIVE cte (ozid, real_parent, lvl) AS (
+            -- Find start points in nodes table (lvl 0)
+            SELECT n.id, n.real_parent, 0 lvl
+              FROM ordered_nodes n
+             WHERE n.ott IN ({ott_list})
+                UNION ALL
+            -- Find start points in leaves table (lvl 0)
+            SELECT -l.id, l.real_parent, 0 lvl
+              FROM ordered_leaves l
+             WHERE l.ott in ({ott_list})
+                UNION ALL
+            -- Recurse, add parent of previous items to our rowset, add one to level
+            SELECT n.id, n.real_parent, cte.lvl + 1 lvl
+              FROM ordered_nodes n
+        INNER JOIN cte ON n.id = cte.real_parent
+        ) SELECT ozid -- Debug:, COUNT(*), GROUP_CONCAT(lvl SEPARATOR ':')
+            FROM cte
+        GROUP BY ozid              -- We have multiple rows for common ancestors, group them together
+          HAVING COUNT(*) >= {pl}  -- Only interested in common-ancestor rows (i.e. one for each start-point)
+        ORDER BY MIN(lvl) ASC      -- Want to find the row closest to the start
+           LIMIT 1                 -- Comment this out to see chain, w/debug above
+    """.format(
+        ott_list=",".join(db.placeholder for _ in otts),
+        pl=db.placeholder,
+    ), otts + otts + [len(otts)])
+    if len(rs) == 0:
+        raise ValueError("Cannot find OTTs: %s" % ",".join(str(x) for x in otts))
+    return rs[0][0]
+
+
 def resolve_pinpoint_to_row(pinpoint):
     """
     Parse a pinpoint string, as defined in src/navigation/pinpoint.js.
@@ -25,10 +63,16 @@ def resolve_pinpoint_to_row(pinpoint):
             node_query = db.ordered_nodes.name == tidy_latin
             leaf_query = db.ordered_leaves.name == tidy_latin
         elif parts[0] == '_ancestor':
-            sub_pinpoints = [int(x) for x in parts[1].split('-')]
-            # NB: Cheat and just return the left branch, don't do the lookup yet
-            node_query = db.ordered_nodes.ott == sub_pinpoints[0]
-            leaf_query = db.ordered_leaves.ott == sub_pinpoints[0]
+            otts = [int(x) for x in parts[1].split('-')]
+            if all(x == otts[0] for x in otts):
+                # All-identical, just an OTT query
+                node_query = db.ordered_nodes.ott == otts[0]
+                leaf_query = db.ordered_leaves.ott == otts[0]
+            else:
+                # Find OZid of common ancestor, look up row for that
+                ozid = common_ancestor_of_otts([int(x) for x in otts])
+                node_query = (db.ordered_nodes.id == ozid) if ozid > 0 else None
+                leaf_query = (db.ordered_leaves.id == -ozid) if ozid < 0 else None
         elif parts[0] == '_ozid':
             ozid = int(parts[1])
             node_query = (db.ordered_nodes.id == ozid) if ozid > 0 else None

--- a/modules/pinpoint.py
+++ b/modules/pinpoint.py
@@ -57,13 +57,13 @@ def resolve_pinpoint_to_row(pinpoint):
         node_query = db.ordered_nodes.ott == int(pinpoint)
         leaf_query = db.ordered_leaves.ott == int(pinpoint)
     else:
-        parts = pinpoint[1:].split("=", 2)
+        parts = pinpoint[1:].split("=")  # NB: Split subsequent = for _ancestor
         if len(parts) == 1:  # @(latin) form
             tidy_latin = parts[0].replace("_", " ")
             node_query = db.ordered_nodes.name == tidy_latin
             leaf_query = db.ordered_leaves.name == tidy_latin
         elif parts[0] == '_ancestor':
-            otts = [int(x) for x in parts[1].split('-')]
+            otts = [int(x) for x in parts[1:]]
             if all(x == otts[0] for x in otts):
                 # All-identical, just an OTT query
                 node_query = db.ordered_nodes.ott == otts[0]

--- a/modules/pinpoint.py
+++ b/modules/pinpoint.py
@@ -100,7 +100,7 @@ def tidy_latin(s):
 
     Python version of src/navigation/pinpoint:tidy_latin
     """
-    return s.replace(' ', '_')
+    return re.sub(r'[\/=_].*$', '', s).replace(' ', '_')
 
 
 def untidy_latin(s):

--- a/tests/unit/test_controllers_API.py
+++ b/tests/unit/test_controllers_API.py
@@ -49,6 +49,16 @@ class TestControllersAPI(unittest.TestCase):
             ) for v in vns],
         )
 
+        # Request sciname in results
+        self.assertEqual(
+            pinpoints(['@=%d' % n.ott for n in leaves], sciname='y'),
+            [dict(ott=n.ott, ozid=-n.id, pinpoint='@=%d' % n.ott, sciname=n.name) for n in leaves],
+        )
+        self.assertEqual(
+            pinpoints(['@=%d' % n.ott for n in nodes], sciname='y'),
+            [dict(ott=n.ott, ozid=n.id, pinpoint='@=%d' % n.ott, sciname=n.name) for n in nodes],
+        )
+
     def test_search_init(self):
         """Search for arbitary node/name combinations"""
         def search_init(**kwargs):

--- a/tests/unit/test_controllers_API.py
+++ b/tests/unit/test_controllers_API.py
@@ -40,7 +40,7 @@ class TestControllersAPI(unittest.TestCase):
             [dict(ott=n.ott, ozid=n.id, pinpoint='@=%d' % n.ott) for n in nodes],
         )
         self.assertEqual(
-            pinpoints(['@=%d' % v.ordered_leaves.ott for v in vns], vernacular='short', lang='en'),
+            pinpoints(['@=%d' % v.ordered_leaves.ott for v in vns], vn='short', lang='en'),
             [dict(
                 ott=v.vernacular_by_ott.ott,
                 ozid=-v.ordered_leaves.id,

--- a/tests/unit/test_modules_pinpoint.py
+++ b/tests/unit/test_modules_pinpoint.py
@@ -85,6 +85,9 @@ class TestModulesPinpoint(unittest.TestCase):
             "aves",
         )
 
+    def test_tidy_latin(self):
+        self.assertEqual(tidy_latin("Bacillus cereus F837/76"), "Bacillus_cereus_F837")
+        self.assertEqual(tidy_latin("Bacillus coagulans DSM 1 = ATCC 7050"), "Bacillus_coagulans_DSM_1_")
 
 if __name__ == '__main__':
     import sys

--- a/tests/unit/test_modules_pinpoint.py
+++ b/tests/unit/test_modules_pinpoint.py
@@ -7,12 +7,9 @@ import unittest
 
 from applications.OZtree.modules.pinpoint import (
     resolve_pinpoint_to_row,
+    tidy_latin,
 )
 from applications.OZtree.tests.unit import util
-
-
-def tidy_latin(s):
-    return s.replace(" ", "_")
 
 
 class TestModulesPinpoint(unittest.TestCase):

--- a/tests/unit/test_modules_pinpoint.py
+++ b/tests/unit/test_modules_pinpoint.py
@@ -32,7 +32,7 @@ class TestModulesPinpoint(unittest.TestCase):
             return r
         def ancestor(*pps):
             """Find common ancestor of pinpoints"""
-            return rpr("@_ancestor=" + "-".join(str(rpr(p).ott) for p in pps))
+            return rpr("@_ancestor=" + "=".join(str(rpr(p).ott) for p in pps))
 
         # Get arbitary content
         leaves = db((db.ordered_leaves.ott != None) & (db.ordered_leaves.name != None)).select(orderby='ott', limitby=(0,4))

--- a/tests/unit/test_modules_pinpoint.py
+++ b/tests/unit/test_modules_pinpoint.py
@@ -30,6 +30,10 @@ class TestModulesPinpoint(unittest.TestCase):
             else:
                 self.assertEqual(is_leaf, False)
             return r
+        def ancestor(*pps):
+            """Find common ancestor of pinpoints"""
+            return rpr("@_ancestor=" + "-".join(str(rpr(p).ott) for p in pps))
+
         # Get arbitary content
         leaves = db((db.ordered_leaves.ott != None) & (db.ordered_leaves.name != None)).select(orderby='ott', limitby=(0,4))
         nodes = db((db.ordered_nodes.ott != None) & (db.ordered_nodes.name != None)).select(orderby='ott', limitby=(0,4))
@@ -65,6 +69,24 @@ class TestModulesPinpoint(unittest.TestCase):
         # Both
         for n in leaves:
             self.assertEqual(rpr("@%s=%d" % (tidy_latin(n.name), n.ott)).id, n.id)
+
+        # Common ancestor
+        self.assertEqual(
+            ancestor("@Crypturellus", "@Crypturellus").name.lower(),
+            "crypturellus",
+        )
+        self.assertEqual(
+            ancestor("@Xenicus_gilviventris", "@Crypturellus").name.lower(),
+            "aves",
+        )
+        self.assertEqual(
+            ancestor("@Xenicus_gilviventris", "@Alectoris").name.lower(),
+            "neognathae",
+        )
+        self.assertEqual(
+            ancestor("@Xenicus_gilviventris", "@Crypturellus", "@Alectoris").name.lower(),
+            "aves",
+        )
 
 
 if __name__ == '__main__':

--- a/tests/unit/test_modules_pinpoint.py
+++ b/tests/unit/test_modules_pinpoint.py
@@ -1,0 +1,79 @@
+"""
+Run with::
+
+    grunt exec:test_server:test_controllers_api.py
+"""
+import unittest
+
+from applications.OZtree.modules.pinpoint import (
+    resolve_pinpoint_to_row,
+)
+from applications.OZtree.tests.unit import util
+
+
+def tidy_latin(s):
+    return s.replace(" ", "_")
+
+
+class TestModulesPinpoint(unittest.TestCase):
+    maxDiff = None
+
+    def tearDown(self):
+        db.rollback()
+
+    def test_resolve_pinpoint_to_row(self):
+        def rpr(pp):
+            """Check is_leaf based on row returned"""
+            r, is_leaf = resolve_pinpoint_to_row(pp)
+            if r:
+                self.assertTrue(hasattr(r, 'extinction_date' if is_leaf else 'vern_synth'))
+            else:
+                self.assertEqual(is_leaf, False)
+            return r
+        # Get arbitary content
+        leaves = db((db.ordered_leaves.ott != None) & (db.ordered_leaves.name != None)).select(orderby='ott', limitby=(0,4))
+        nodes = db((db.ordered_nodes.ott != None) & (db.ordered_nodes.name != None)).select(orderby='ott', limitby=(0,4))
+
+        # No pinpoint -> root node
+        self.assertEqual(rpr("").name, "biota")
+
+        # Invalid pinpoint -> None
+        self.assertEqual(rpr("@missingmissingmissing"), None)
+
+        # Bare OTT
+        for n in leaves:
+            self.assertEqual(rpr(str(n.ott)).id, n.id)
+        for n in nodes:
+            self.assertEqual(rpr(str(n.ott)).id, n.id)
+
+        # @=OTT
+        for n in leaves:
+            self.assertEqual(rpr("@=%d" % n.ott).id, n.id)
+        for n in nodes:
+            self.assertEqual(rpr("@=%d" % n.ott).id, n.id)
+
+        # @_ozid=OZID
+        for n in leaves:
+            self.assertEqual(rpr("@_ozid=%d" % -n.id).id, n.id)
+        for n in nodes:
+            self.assertEqual(rpr("@_ozid=%d" % n.id).id, n.id)
+
+        # Latin name
+        for n in leaves:
+            self.assertEqual(rpr("@%s" % tidy_latin(n.name)).id, n.id)
+
+        # Both
+        for n in leaves:
+            self.assertEqual(rpr("@%s=%d" % (tidy_latin(n.name), n.ott)).id, n.id)
+
+
+if __name__ == '__main__':
+    import sys
+
+    if current.globalenv['is_testing'] != True:
+        raise RuntimeError("Do not run tests in production environments, ensure is_testing = True")
+    suite = unittest.TestSuite()
+    suite.addTest(unittest.makeSuite(TestModulesPinpoint))
+    result = unittest.TextTestRunner(verbosity=2).run(suite)
+    if not result.wasSuccessful():
+        sys.exit(1)

--- a/views/API/pinpoints.json
+++ b/views/API/pinpoints.json
@@ -1,0 +1,11 @@
+{{
+try:
+    from json import dumps
+    response.write(dumps(response._vars, separators=(',',':')), escape=False)
+    # enable CORS, so that e.g. the Ancestor's Tale site can access the API on OneZoom.org
+    response.headers['Access-Control-Allow-Origin'] = '*'
+    response.headers['Access-Control-Allow-Methods'] = "POST, GET, OPTIONS"
+    response.headers['Content-Type'] = 'application/json'
+except:
+    raise HTTP(405,'no json')
+}}

--- a/views/treeviewer/server_urls.html
+++ b/views/treeviewer/server_urls.html
@@ -9,8 +9,6 @@ var server_urls = {
   pinpoints_api: "{{try:}}{{=myconf.take('API.pinpoints')}}{{except:}}{{=URL('API','pinpoints.json', scheme=True, host=True)}}{{pass}}",
   search_api: "{{try:}}{{=myconf.take('API.search')}}{{except:}}{{=URL('API','search_node.json', scheme=True, host=True)}}{{pass}}",
   search_sponsor_api: "{{try:}}{{=myconf.take('API.search_sponsor')}}{{except:}}{{=URL('API','search_for_sponsor.json', scheme=True, host=True)}}{{pass}}",
-  get_ids_by_ott_array_api: "{{try:}}{{=myconf.take('API.ott2id_array')}}{{except:}}{{=URL('API', 'get_ids_by_ott_array.json', scheme=True, host=True)}}{{pass}}",
-  otts2vns_api: "{{try:}}{{=myconf.take('API.otts2vns')}}{{except:}}{{=URL('API','otts2vns.json', scheme=True, host=True)}}{{pass}}",
   image_details_api: "{{try:}}{{=myconf.take('API.image')}}{{except:}}{{=URL('API', 'image_details.json', scheme=True, host=True)}}{{pass}}",
   update_visit_count_api: "{{try:}}{{=myconf.take('API.update_visit_count')}}{{except:}}{{=URL('API','update_visit_count.json', scheme=True, host=True)}}{{pass}}",
   tourstop_page: "{{=URL('default','tourstop.load', scheme=True, host=True)}}",

--- a/views/treeviewer/server_urls.html
+++ b/views/treeviewer/server_urls.html
@@ -6,9 +6,9 @@ var server_urls = {
      They are coded with the full URL so that they can be used remotely (e.g. in a partial install) */
   data_path_pics: {{=XML(img.js_thumb_url(thumb_base_url))}},
   node_details_api: "{{try:}}{{=myconf.take('API.node')}}{{except:}}{{=URL('API','node_details.json', scheme=True, host=True)}}{{pass}}",
+  pinpoints_api: "{{try:}}{{=myconf.take('API.pinpoints')}}{{except:}}{{=URL('API','pinpoints.json', scheme=True, host=True)}}{{pass}}",
   search_api: "{{try:}}{{=myconf.take('API.search')}}{{except:}}{{=URL('API','search_node.json', scheme=True, host=True)}}{{pass}}",
   search_sponsor_api: "{{try:}}{{=myconf.take('API.search_sponsor')}}{{except:}}{{=URL('API','search_for_sponsor.json', scheme=True, host=True)}}{{pass}}",
-  search_init_api: "{{try:}}{{=myconf.take('API.search_init')}}{{except:}}{{=URL('API','search_init.json', scheme=True, host=True)}}{{pass}}",
   get_ids_by_ott_array_api: "{{try:}}{{=myconf.take('API.ott2id_array')}}{{except:}}{{=URL('API', 'get_ids_by_ott_array.json', scheme=True, host=True)}}{{pass}}",
   otts2vns_api: "{{try:}}{{=myconf.take('API.otts2vns')}}{{except:}}{{=URL('API','otts2vns.json', scheme=True, host=True)}}{{pass}}",
   image_details_api: "{{try:}}{{=myconf.take('API.image')}}{{except:}}{{=URL('API', 'image_details.json', scheme=True, host=True)}}{{pass}}",


### PR DESCRIPTION
Add ``/API/pinpoints``:

* Use it in place of ``search_init`` in ``resolve_pinpoints``
* Rewrite ``process_taxon_list`` to use ``resolve_pinpoints``
* Remove now redundant ``get_ids_by_ott_array``, ``otts2vns``, ``search_init`` from javascript code. Don't remove them server-side.

Fixes #646 