### PR TITLE
Add rank in ordered_nodes table

### DIFF
--- a/models/db.py
+++ b/models/db.py
@@ -58,6 +58,7 @@ except:
     local_pic_path = lambda s, s_id: os.path.join(request.folder, img.local_path, img.thumb_path(s, s_id))
 
 name_length_chars = 190 ##max length for a species name is 190 chars (allows indexing. NB: max OTT name is 108 chars)
+name_rank_chars = 30 ##max length for a taxonomic rank, e.g. species, genus, ...
 
 
 #########################################################################
@@ -241,6 +242,7 @@ db.define_table('ordered_nodes',
     Field('wikidata', type='integer'),
     Field('wikipedia_lang_flag', type='integer'), #
     Field('eol', type='integer'),
+    Field('rnk', type='string', length=name_rank_chars),
     Field('raw_popularity', type='double'),
     Field('popularity', type='double'),
     #the following 5 fields are sources listed by the OpenTree


### PR DESCRIPTION
This is a companion to https://github.com/OneZoom/tree-build/pull/40, part of https://github.com/OneZoom/tree-build/issues/39.

Notes:
- I chose the limit of 30 somewhat arbitraily. The longest rank used on the tree is 'no rank - terminal'.
- I placed the new column after 'eol', somewhat arbitrarily
- To manually add the column, you can run `ALTER TABLE ordered_nodes ADD COLUMN rnk VARCHAR(30) AFTER eol;`