### PR TITLE
Use starting URL as default home

### DIFF
--- a/OZprivate/rawJS/OZTreeModule/src/navigation/setup_page.js
+++ b/OZprivate/rawJS/OZTreeModule/src/navigation/setup_page.js
@@ -33,6 +33,11 @@ function setup_page_by_state(controller, state) {
       // Not init-ing tree, so fly to new location
       return controller.default_move_to(state.pinpoint);
     }
+    if (!config.home_ott_id) {
+        // No home_ott_id set yet, use current (initial) pinpoint as home
+        // so a homepage Carnivorans link resets to Carnivorans, e.g.
+        config.home_ott_id = state.pinpoint;
+    }
     return resolve_pinpoints(state.pinpoint).then((pp) => {
       // If there's somewhere to move to, do that.
       return controller.init_move_to(pp.ozid, state.xp !== undefined ? state : state.init);


### PR DESCRIPTION
@jrosindell @hyanwong This was a simple and decisive change that came up in our meeting this morning.

The reset button currently, unless otthome has been explicitly set, goes back to the very top of the tree. This is IMO makes matters worse, since invariably you want to reset because you've excitedly zoomed to the top and want to get back to something familiar.

Instead, set the default otthome to the initial pinpoint, if any. This means that if you click "Explore the Great Whales" on the homepage (for example), then reset will take you back to Whales.

One downside is our urls are likely to end up having otthome appended to them to store this information, but I don't think this is the end of the world.

Another obvious possibility is reset restores all of the URL, not just the pinpoint. But this would be a bit weird if you started within a tour, e.g. Then reset would take you into that tour again.