### PR TITLE
data_repo refactoring / "tours" attributes for midnodes

### DIFF
--- a/OZprivate/rawJS/OZTreeModule/docs/JSinterface.markdown
+++ b/OZprivate/rawJS/OZTreeModule/docs/JSinterface.markdown
@@ -17,16 +17,15 @@ When calling the entry function, you may want to have already defined
 4. Initial tree config (see 
 5. Pagetitle function
 6. A string of brackets, in 'OneZoom-reduced-newick' format, giving the topology of the tree. This format is essentially a strictly binary tree in newick format, ladderized ascending, with all details except braces removed. Additionally, groups with 0-length branches (indicating arbitrarily resolved bifurcations) have their round braces removed and replaced with curly braces.
-7. Basic metadata column names and details associated with the tree
-8. A set of cut positions, defined in JSON format
-9. A set of polytomy cut positions, defined in JSON format
-10. A cut threshold for 3 and 4 above.
-11. A set of dates for the tree, 
+7. A set of cut positions, defined in JSON format
+8. A set of polytomy cut positions, defined in JSON format
+9. A cut threshold for 3 and 4 above.
+10. A set of dates for the tree, 
 
 Items 1-5 are usually defined within the html of the page, and may change from . Items 6-11 are usually defined in .js files which are loaded from the tree viewer web page. 
 
 
-Items 6 and 7 are usually defined within the file `FinalOutputs/data/completetree_XXXXXXX.js` (XXXXXXX is a timestamp), in the variables `rawData` and `metadata` respectively.
+Item 6 are usually defined within the file `FinalOutputs/data/completetree_XXXXXXX.js` (XXXXXXX is a timestamp), in the variable `rawData`.
 
 Items (3), (4) and (5) are usually defined within the file `FinalOutputs/data/cut_position_map_XXXXXXX.js`, in the variables `cut_position_map_json_str`, `polytomy_cut_position_map_json_str`, and `cut_threshold` respectively.
 
@@ -44,7 +43,7 @@ onezoom = OZentry.default(
 	'OneZoomCanvasID', 
 	tree_config, 
 	rawData, 
-	metadata,
+	null,  // NB: Legacy argument, leave null
 	cut_position_map_json_str, 
 	polytomy_cut_position_map_json_str, 
 	cut_threshold,

--- a/OZprivate/rawJS/OZTreeModule/src/OZentry.js
+++ b/OZprivate/rawJS/OZTreeModule/src/OZentry.js
@@ -40,7 +40,7 @@ functionality. At the moment, a single file is created, called OZentry.js
  * @param {string} rawData A 'condensed Newick' string, e.g. as defined in completetree_XXXXX.js
  * (condensed Newick is a ladderized-ascending binary newick tree with all characters except braces removed, 
  * and curly braces substituted where a bifurcation only exists order to randomly resolve polytomies.
- * @param {Object} metadata - *** To document ...
+ * @param {Object} unused - leave null
  * @param {Object} cut_position_map_json_str dichotomy cut map from the tree-build-generated cut_position_map.js
  * @param {Object} polytomy_cut_position_map_json_str polytomy cut map from the tree-build-generated cut_position_map.js
  * @param {Object} cut_threshold - Threshold used when generating (and defined in) cut_position_map.js
@@ -54,7 +54,7 @@ function setup(
   canvasID,
   default_viz_settings,
   rawData,
-  metadata,
+  unused,
   cut_position_map_json_str,
   polytomy_cut_position_map_json_str,
   cut_threshold,
@@ -131,7 +131,6 @@ function setup(
           raw_data: rawData,
           cut_map: JSON.parse(cut_position_map_json_str || "{}"),
           poly_cut_map: JSON.parse(polytomy_cut_position_map_json_str || "{}"),
-          metadata: metadata,
           cut_threshold: cut_threshold || 10000,
           tree_date: tree_date || "{}"
         })

--- a/OZprivate/rawJS/OZTreeModule/src/factory/data_repo.js
+++ b/OZprivate/rawJS/OZTreeModule/src/factory/data_repo.js
@@ -1,6 +1,10 @@
 import {call_hook} from '../util/index';
 import node_details_api from '../api/node_details';
 import {pic_src_order} from '../tree_settings';
+
+const metadata_cols_leaf = ["OTTid","scientificName","common_en","popularity","picID","picID_credit","picID_rating","IUCN","price","sponsor_kind","sponsor_name","sponsor_extra","sponsor_url","n_spp"];
+const metadata_cols_node = ["OTTid","scientificName","common_en","popularity","picID","picID_credit","picID_rating","IUCN","price","sponsor_kind","sponsor_name","sponsor_extra","sponsor_url","lengthbr","sp1","sp2","sp3","sp4","sp5","sp6","sp7","sp8","iucnNE","iucnDD","iucnLC","iucnNT","iucnVU","iucnEN","iucnCR","iucnEW","iucnEX"];
+
 /**
  * A class to store all tree data, metadata and metadata related information. It also provides interface to update metadata.
  */
@@ -96,8 +100,17 @@ class DataRepo {
             
     };
     this.image_source = "best_any";
-    this.leaf_col_len = 15;
-    this.node_col_len = 31;
+
+    // Configure leaf/node column key lookups
+    this.mc_key_l = {};
+    metadata_cols_leaf.forEach((k, i) => this.mc_key_l[k] = i);
+    this.leaf_col_len = metadata_cols_leaf.length;
+
+    this.mc_key_n = {};
+    metadata_cols_node.forEach((k, i) => this.mc_key_n[k] = i);
+    this.node_col_len = metadata_cols_node.length;
+
+    this.metadata = { leaf_meta: [], node_meta: [] };
   }
   /**
    * Place all the data in the passed-in object into the this object
@@ -107,14 +120,6 @@ class DataRepo {
   setup(data_obj) {
     for (let key of Object.keys(data_obj)) {
       this[key] = data_obj[key];
-    }
-    this.mc_key_l = {};
-    this.mc_key_n = {};
-    for (let i = 0 ; i < (this.metadata.leaf_meta[0].length) ; i ++) {
-        this.mc_key_l[this.metadata.leaf_meta[0][i]] = i;
-    }  
-    for (let i = 0 ; i < (this.metadata.node_meta[0].length) ; i ++) {
-        this.mc_key_n[this.metadata.node_meta[0][i]] = i;
     }
   }
   

--- a/OZprivate/rawJS/OZTreeModule/src/factory/data_repo.js
+++ b/OZprivate/rawJS/OZTreeModule/src/factory/data_repo.js
@@ -245,60 +245,69 @@ class DataRepo {
       }
     }
   }
+
+  get_meta_entry(id) {
+    if (id < 0) {
+      if (!this.metadata.leaf_meta[-id]) this.metadata.leaf_meta[-id] = new Array(this.leaf_col_len);
+      return { entry: this.metadata.leaf_meta[-id], idx: this.mc_key_l };
+    }
+    if (id > 0) {
+      if (!this.metadata.node_meta[id]) this.metadata.node_meta[id] = new Array(this.node_col_len);
+      return { entry: this.metadata.node_meta[id], idx: this.mc_key_n };
+    }
+    // id null --> probably an empty entry in ott_id_map
+    return null;
+  }
 }
   
-  
+
 function parse_ordered_leaves(data_repo, leaves, node_details) {
   for (let i=0; i<leaves.length; i++) {
-    let id = leaves[i][node_details.leaf_cols["id"]];
-    let ott = leaves[i][node_details.leaf_cols["ott"]];
-    if (!data_repo.metadata.leaf_meta[id]) data_repo.metadata.leaf_meta[id] = new   Array(data_repo.leaf_col_len);
-    let leaf_meta_entry = data_repo.metadata.leaf_meta[id];
-    leaf_meta_entry[data_repo.mc_key_l["OTTid"]] = ott;
-    leaf_meta_entry[data_repo.mc_key_l["scientificName"]] =leaves[i][node_details.leaf_cols["name"]];
-    leaf_meta_entry[data_repo.mc_key_l["popularity"]] = leaves[i][node_details.leaf_cols["popularity"]];
+    let m = data_repo.get_meta_entry(-leaves[i][node_details.leaf_cols["id"]]);
+
+    m.entry[m.idx["OTTid"]] = leaves[i][node_details.leaf_cols["ott"]];
+    m.entry[m.idx["scientificName"]] =leaves[i][node_details.leaf_cols["name"]];
+    m.entry[m.idx["popularity"]] = leaves[i][node_details.leaf_cols["popularity"]];
   }
 }
 
 function parse_ordered_nodes(data_repo, nodes, node_details) {
   for (let i=0; i<nodes.length; i++) {
-    let id = nodes[i][node_details.node_cols["id"]];
-    let ott = nodes[i][node_details.node_cols["ott"]];
-    if (!data_repo.metadata.node_meta[id]) data_repo.metadata.node_meta[id] = new Array(data_repo.node_col_len);
-    let node_meta_entry = data_repo.metadata.node_meta[id];
-    node_meta_entry[data_repo.mc_key_n["OTTid"]] = ott;
-    node_meta_entry[data_repo.mc_key_n["scientificName"]] = nodes[i][node_details.node_cols["name"]];
-    node_meta_entry[data_repo.mc_key_n["popularity"]] = nodes[i][node_details.node_cols["popularity"]];
-    node_meta_entry[data_repo.mc_key_n["lengthbr"]] = Math.abs(nodes[i][node_details.node_cols["age"]]);
+    let m = data_repo.get_meta_entry(nodes[i][node_details.node_cols["id"]]);
+
+    m.entry[m.idx["OTTid"]] = nodes[i][node_details.node_cols["ott"]];
+    m.entry[m.idx["scientificName"]] = nodes[i][node_details.node_cols["name"]];
+    m.entry[m.idx["popularity"]] = nodes[i][node_details.node_cols["popularity"]];
+    m.entry[m.idx["lengthbr"]] = Math.abs(nodes[i][node_details.node_cols["age"]]);
     
-    node_meta_entry[data_repo.mc_key_n["sp1"]] = nodes[i][node_details.node_cols["{pic}1"]];
-    node_meta_entry[data_repo.mc_key_n["sp2"]] = nodes[i][node_details.node_cols["{pic}2"]];
-    node_meta_entry[data_repo.mc_key_n["sp3"]] = nodes[i][node_details.node_cols["{pic}3"]];
-    node_meta_entry[data_repo.mc_key_n["sp4"]] = nodes[i][node_details.node_cols["{pic}4"]];
-    node_meta_entry[data_repo.mc_key_n["sp5"]] = nodes[i][node_details.node_cols["{pic}5"]];
-    node_meta_entry[data_repo.mc_key_n["sp6"]] = nodes[i][node_details.node_cols["{pic}6"]];
-    node_meta_entry[data_repo.mc_key_n["sp7"]] = nodes[i][node_details.node_cols["{pic}7"]];
-    node_meta_entry[data_repo.mc_key_n["sp8"]] = nodes[i][node_details.node_cols["{pic}8"]];
+    m.entry[m.idx["sp1"]] = nodes[i][node_details.node_cols["{pic}1"]];
+    m.entry[m.idx["sp2"]] = nodes[i][node_details.node_cols["{pic}2"]];
+    m.entry[m.idx["sp3"]] = nodes[i][node_details.node_cols["{pic}3"]];
+    m.entry[m.idx["sp4"]] = nodes[i][node_details.node_cols["{pic}4"]];
+    m.entry[m.idx["sp5"]] = nodes[i][node_details.node_cols["{pic}5"]];
+    m.entry[m.idx["sp6"]] = nodes[i][node_details.node_cols["{pic}6"]];
+    m.entry[m.idx["sp7"]] = nodes[i][node_details.node_cols["{pic}7"]];
+    m.entry[m.idx["sp8"]] = nodes[i][node_details.node_cols["{pic}8"]];
     
-    node_meta_entry[data_repo.mc_key_n["iucnDD"]] = nodes[i][node_details.node_cols["iucnDD"]];
-    node_meta_entry[data_repo.mc_key_n["iucnNE"]] = nodes[i][node_details.node_cols["iucnNE"]];
-    node_meta_entry[data_repo.mc_key_n["iucnLC"]] = nodes[i][node_details.node_cols["iucnLC"]];
-    node_meta_entry[data_repo.mc_key_n["iucnNT"]] = nodes[i][node_details.node_cols["iucnNT"]];
-    node_meta_entry[data_repo.mc_key_n["iucnVU"]] = nodes[i][node_details.node_cols["iucnVU"]];
-    node_meta_entry[data_repo.mc_key_n["iucnEN"]] = nodes[i][node_details.node_cols["iucnEN"]];
-    node_meta_entry[data_repo.mc_key_n["iucnCR"]] = nodes[i][node_details.node_cols["iucnCR"]];
-    node_meta_entry[data_repo.mc_key_n["iucnEW"]] = nodes[i][node_details.node_cols["iucnEW"]];
-    node_meta_entry[data_repo.mc_key_n["iucnEX"]] = nodes[i][node_details.node_cols["iucnEX"]];
+    m.entry[m.idx["iucnDD"]] = nodes[i][node_details.node_cols["iucnDD"]];
+    m.entry[m.idx["iucnNE"]] = nodes[i][node_details.node_cols["iucnNE"]];
+    m.entry[m.idx["iucnLC"]] = nodes[i][node_details.node_cols["iucnLC"]];
+    m.entry[m.idx["iucnNT"]] = nodes[i][node_details.node_cols["iucnNT"]];
+    m.entry[m.idx["iucnVU"]] = nodes[i][node_details.node_cols["iucnVU"]];
+    m.entry[m.idx["iucnEN"]] = nodes[i][node_details.node_cols["iucnEN"]];
+    m.entry[m.idx["iucnCR"]] = nodes[i][node_details.node_cols["iucnCR"]];
+    m.entry[m.idx["iucnEW"]] = nodes[i][node_details.node_cols["iucnEW"]];
+    m.entry[m.idx["iucnEX"]] = nodes[i][node_details.node_cols["iucnEX"]];
   }
 }
 
 function parse_iucn(data_repo, iucn) {
   for (let i=0; i<iucn.length; i++) {
     let ott = iucn[i][0];
-    let status_code = iucn[i][1];
-    let id = -data_repo.ott_id_map[ott];
-    if (!data_repo.metadata.leaf_meta[id]) data_repo.metadata.leaf_meta[id] = new Array(data_repo.leaf_col_len);
-    data_repo.metadata.leaf_meta[id][data_repo.mc_key_l["IUCN"]] = status_code;
+    let m = data_repo.get_meta_entry(data_repo.ott_id_map[ott]);
+    if (!m) continue;
+
+    m.entry[m.idx["IUCN"]] = iucn[i][1];
   }
 }
 
@@ -317,29 +326,29 @@ function parse_pics(data_repo, leaves, pics, order, node_details) {
 
   // For each potential leaf, clear any stored image first (in case this leaf no longer has an image)
   for (let i=0; i<leaves.length; i++) {
-    let id = leaves[i][node_details.leaf_cols["id"]];
-    if (!data_repo.metadata.leaf_meta[id]) data_repo.metadata.leaf_meta[id] = new Array(data_repo.leaf_col_len);
-    let pic_entry = data_repo.metadata.leaf_meta[id];
-    pic_entry[data_repo.mc_key_l["picID_src"]]    = null;
-    pic_entry[data_repo.mc_key_l["picID"]]        = null;
-    pic_entry[data_repo.mc_key_l["picID_rating"]] = null;
+    let m = data_repo.get_meta_entry(-leaves[i][node_details.leaf_cols["id"]]);
+
+    m.entry[m.idx["picID_src"]]    = null;
+    m.entry[m.idx["picID"]]        = null;
+    m.entry[m.idx["picID_rating"]] = null;
     /** 
      * this attribute is fetched by image_details api call. 
      * set credit to null to force it being fetched by image_details API call. 
      * Otherwise if user change image source, the image credit
      * might refer to previous image source.
      */
-    pic_entry[data_repo.mc_key_l["picID_credit"]] = null;
+    m.entry[m.idx["picID_credit"]] = null;
   }
 
   // Add all found images back
   for (let i=0; i<pics.length; i++) {
     let ott = pics[i][node_details.pic_cols["ott"]];
-    let id = -data_repo.ott_id_map[ott];
-    let pic_entry = data_repo.metadata.leaf_meta[id];
-    pic_entry[data_repo.mc_key_l["picID_src"]]    = pics[i][node_details.pic_cols["src"]].toString();
-    pic_entry[data_repo.mc_key_l["picID"]]        = pics[i][node_details.pic_cols["src_id"]].toString();
-    pic_entry[data_repo.mc_key_l["picID_rating"]] = pics[i][node_details.pic_cols["rating"]];
+    let m = data_repo.get_meta_entry(data_repo.ott_id_map[ott]);
+    if (!m) continue;
+
+    m.entry[m.idx["picID_src"]]    = pics[i][node_details.pic_cols["src"]].toString();
+    m.entry[m.idx["picID"]]        = pics[i][node_details.pic_cols["src_id"]].toString();
+    m.entry[m.idx["picID_rating"]] = pics[i][node_details.pic_cols["rating"]];
   }
 }
 
@@ -347,74 +356,40 @@ function parse_vernacular_by_ott(data_repo, vernacular_by_ott) {
   //pick the first vernacular returned by the array
   for (let i=0; i<vernacular_by_ott.length; i++) {
     let ott = vernacular_by_ott[i][0];
-    let vernacular = vernacular_by_ott[i][1];
-    let id = data_repo.ott_id_map[ott];
-    if (id && id>0) {
-      if (!data_repo.metadata.node_meta[id]) data_repo.metadata.node_meta[id] = new Array(data_repo.node_col_len);
-      if (!data_repo.metadata.node_meta[id][data_repo.mc_key_n["common_en"]])
-        data_repo.metadata.node_meta[id][data_repo.mc_key_n["common_en"]] = vernacular;
-    } else if (id && id<0) {
-      id = -id;
-      if (!data_repo.metadata.leaf_meta[id]) data_repo.metadata.leaf_meta[id] = new Array(data_repo.leaf_col_len);
-      if (!data_repo.metadata.leaf_meta[id][data_repo.mc_key_l["common_en"]])
-        data_repo.metadata.leaf_meta[id][data_repo.mc_key_l["common_en"]] = vernacular;
-    }
+    let m = data_repo.get_meta_entry(data_repo.ott_id_map[ott]);
+    if (!m) continue;
+
+    if (!m.entry[m.idx["common_en"]]) m.entry[m.idx["common_en"]] = vernacular_by_ott[i][1];
   }
 }
 
 function parse_vernacular_by_name(data_repo, vernacular_by_name) {
   for (let i=0; i<vernacular_by_name.length; i++) {
     let name = vernacular_by_name[i][0];
-    let vernacular = vernacular_by_name[i][1];
-    let id = data_repo.name_id_map[name];
-    if (id && id>0) {
-      if (!data_repo.metadata.node_meta[id]) data_repo.metadata.node_meta[id] = new Array(data_repo.node_col_len);
-      if (!data_repo.metadata.node_meta[id][data_repo.mc_key_n["common_en"]])
-        data_repo.metadata.node_meta[id][data_repo.mc_key_n["common_en"]] = vernacular;
-    } else if (id && id<0) {
-      id = -id;
-      if (!data_repo.metadata.leaf_meta[id]) data_repo.metadata.leaf_meta[id] = new Array(data_repo.leaf_col_len);
-      if (!data_repo.metadata.leaf_meta[id][data_repo.mc_key_l["common_en"]])
-        data_repo.metadata.leaf_meta[id][data_repo.mc_key_l["common_en"]] = vernacular;
-    }
+    let m = data_repo.get_meta_entry(data_repo.name_id_map[name]);
+    if (!m) continue;
+
+    if (!m.entry[m.idx["common_en"]]) m.entry[m.idx["common_en"]] = vernacular_by_name[i][1];
   }
 }
 
 function parse_sponsorship(data_repo, reservations, node_details) {
   for (let i=0; i<reservations.length; i++) {
     let ott = reservations[i][node_details.res_cols["OTT_ID"]];
-    if (data_repo.ott_id_map[ott] && data_repo.ott_id_map[ott] > 0) {  //node
-      let id = data_repo.ott_id_map[ott];
-      if (!data_repo.metadata.node_meta[id]) data_repo.metadata.node_meta[id] = new Array(data_repo.node_col_len);
-      let node_meta_entry = data_repo.metadata.node_meta[id];
-      node_meta_entry[data_repo.mc_key_n["sponsor_name"]] = reservations[i][node_details.res_cols["verified_name"]];
-      node_meta_entry[data_repo.mc_key_n["sponsor_kind"]] = reservations[i][node_details.res_cols["verified_kind"]];
-      node_meta_entry[data_repo.mc_key_n["sponsor_extra"]] = reservations[i][node_details.res_cols["verified_more_info"]];
-      node_meta_entry[data_repo.mc_key_n["sponsor_url"]] = reservations[i][node_details.res_cols["verified_url"]];
+    let m = data_repo.get_meta_entry(data_repo.ott_id_map[ott]);
+    if (!m) continue;
+
+    m.entry[m.idx["sponsor_name"]] = reservations[i][node_details.res_cols["verified_name"]];
+    m.entry[m.idx["sponsor_kind"]] = reservations[i][node_details.res_cols["verified_kind"]];
+    m.entry[m.idx["sponsor_extra"]] = reservations[i][node_details.res_cols["verified_more_info"]];
+    m.entry[m.idx["sponsor_url"]] = reservations[i][node_details.res_cols["verified_url"]];
       
-      //only replace scientificName and common_en if scientificName or common_name is not present.
-      if (!node_meta_entry[data_repo.mc_key_n["scientificName"]]) {
-        node_meta_entry[data_repo.mc_key_n["scientificName"]] = reservations[i][node_details.res_cols["name"]];
-      }      
-      if (!node_meta_entry[data_repo.mc_key_n["common_en"]]) {
-        node_meta_entry[data_repo.mc_key_n["common_en"]] = reservations[i][node_details.res_cols["common_name"]];
-      }      
-    } else if (data_repo.ott_id_map[ott] && data_repo.ott_id_map[ott] < 0) {  //leaf
-      let id = -data_repo.ott_id_map[ott];
-      if (!data_repo.metadata.leaf_meta[id]) data_repo.metadata.leaf_meta[id] = new Array(data_repo.leaf_col_len);
-      let leaf_meta_entry = data_repo.metadata.leaf_meta[id];
-      leaf_meta_entry[data_repo.mc_key_l["sponsor_name"]] = reservations[i][node_details.res_cols["verified_name"]];
-      leaf_meta_entry[data_repo.mc_key_l["sponsor_kind"]] = reservations[i][node_details.res_cols["verified_kind"]];
-      leaf_meta_entry[data_repo.mc_key_l["sponsor_extra"]] = reservations[i][node_details.res_cols["verified_more_info"]];
-      leaf_meta_entry[data_repo.mc_key_l["sponsor_url"]] = reservations[i][node_details.res_cols["verified_url"]];
-      
-      //only replace scientificName and common_en if scientificName or common_name is not present.
-      if (!leaf_meta_entry[data_repo.mc_key_l["scientificName"]]) {
-        leaf_meta_entry[data_repo.mc_key_l["scientificName"]] = reservations[i][node_details.res_cols["name"]];
-      }      
-      if (!leaf_meta_entry[data_repo.mc_key_l["common_en"]]) {
-        leaf_meta_entry[data_repo.mc_key_l["common_en"]] = reservations[i][node_details.res_cols["common_name"]];
-      }  
+    //only replace scientificName and common_en if scientificName or common_name is not present.
+    if (!m.entry[m.idx["scientificName"]]) {
+      m.entry[m.idx["scientificName"]] = reservations[i][node_details.res_cols["name"]];
+    }
+    if (!m.entry[m.idx["common_en"]]) {
+      m.entry[m.idx["common_en"]] = reservations[i][node_details.res_cols["common_name"]];
     }
   }
 }

--- a/OZprivate/rawJS/OZTreeModule/src/factory/data_repo.js
+++ b/OZprivate/rawJS/OZTreeModule/src/factory/data_repo.js
@@ -4,6 +4,7 @@ import {pic_src_order} from '../tree_settings';
 
 const metadata_cols_leaf = ["OTTid","scientificName","common_en","popularity","picID","picID_credit","picID_rating","IUCN","price","sponsor_kind","sponsor_name","sponsor_extra","sponsor_url","n_spp"];
 const metadata_cols_node = ["OTTid","scientificName","common_en","popularity","picID","picID_credit","picID_rating","IUCN","price","sponsor_kind","sponsor_name","sponsor_extra","sponsor_url","lengthbr","sp1","sp2","sp3","sp4","sp5","sp6","sp7","sp8","iucnNE","iucnDD","iucnLC","iucnNT","iucnVU","iucnEN","iucnCR","iucnEW","iucnEX"];
+const metadata_sparse_cols = ["tours"];
 
 /**
  * A class to store all tree data, metadata and metadata related information. It also provides interface to update metadata.
@@ -110,6 +111,12 @@ class DataRepo {
     metadata_cols_node.forEach((k, i) => this.mc_key_n[k] = i);
     this.node_col_len = metadata_cols_node.length;
 
+    // Don't reserve space for sparse cols, just add them as separate properties to the array when needed
+    metadata_sparse_cols.forEach((k) => {
+      this.mc_key_l[k] = k;
+      this.mc_key_n[k] = k;
+    });
+
     this.metadata = { leaf_meta: [], node_meta: [] };
   }
   /**
@@ -138,6 +145,7 @@ class DataRepo {
     parse_vernacular_by_ott(this, res.vernacular_by_ott);
     parse_vernacular_by_name(this, res.vernacular_by_name);
     parse_sponsorship(this, res.reservations, node_details_api);
+    parse_tours_by_ott(this, res.tours_by_ott || []);
   }
   update_image_metadata(metacode, rights, licence) {
     this.metadata.leaf_meta[metacode][this.mc_key_l["picID_credit"]] = rights +  " / " + licence;
@@ -391,6 +399,17 @@ function parse_sponsorship(data_repo, reservations, node_details) {
     if (!m.entry[m.idx["common_en"]]) {
       m.entry[m.idx["common_en"]] = reservations[i][node_details.res_cols["common_name"]];
     }
+  }
+}
+
+function parse_tours_by_ott(data_repo, vals) {
+  // Cols: OTT, url
+  for (let i = 0; i < vals.length; i++) {
+    let ott = vals[i][0]
+    let m = data_repo.get_meta_entry(data_repo.ott_id_map[ott]);
+    if (!m) continue;
+
+    m.entry[m.idx["tours"]] = vals[i][1];
   }
 }
 

--- a/OZprivate/rawJS/OZTreeModule/src/factory/midnode.js
+++ b/OZprivate/rawJS/OZTreeModule/src/factory/midnode.js
@@ -282,14 +282,10 @@ class Midnode {
    * Get attribute of node by key name. Use this function to fetch metadata of node only.
    */
   get_attribute(key_name) {
-    if (this.is_leaf) {
-      if (!data_repo.metadata.leaf_meta[this.metacode]) return undefined;
-      return data_repo.metadata.leaf_meta[this.metacode][data_repo.mc_key_l[key_name]];
-    }
-    if (this.is_interior_node) {
-      if (!data_repo.metadata.node_meta[this.metacode]) return undefined;
-      return data_repo.metadata.node_meta[this.metacode][data_repo.mc_key_n[key_name]];
-    }
+    let m = data_repo.get_meta_entry(this.ozid);
+    if (!m) return undefined;
+
+    return m.entry[m.idx[key_name]];
   }
   
   clear_pics() {
@@ -401,9 +397,7 @@ class Midnode {
     let codes = [];
     let keys = ["sp1", "sp2", "sp3", "sp4", "sp5", "sp6", "sp7", "sp8"];
     for (let i=0; i<keys.length; i++) {
-      let key = keys[i];
-      let col = data_repo.mc_key_n[key];
-      let ott = data_repo.metadata.node_meta[this.metacode] ? data_repo.metadata.node_meta[this.metacode][col] : null;
+      let ott = this.get_attribute(keys[i]);
       if (ott && data_repo.ott_id_map[ott]) {
         let code = -data_repo.ott_id_map[ott];
         codes.push(code);
@@ -520,31 +514,30 @@ class Midnode {
    */
   
   get_picset_src_info(index) {
-    let code = this.picset_code[index];
-    if (code) {
-      let srcID_col = data_repo.mc_key_l["picID"];
-      let src_col = data_repo.mc_key_l["picID_src"];
-      let credit = data_repo.mc_key_l["picID_credit"];
-      return [data_repo.metadata.leaf_meta[code][src_col], data_repo.metadata.leaf_meta[code][srcID_col], data_repo.metadata.leaf_meta[code][credit]];
-    }
+    let m = data_repo.get_meta_entry(-this.picset_code[index]);
+    if (!m) return undefined;
+
+    return [
+      m.entry[m.idx["picID_src"]],
+      m.entry[m.idx["picID"]],
+      m.entry[m.idx["picID_credit"]],
+    ];
   }
   get_picset_common(index) {
-    let code = this.picset_code[index];
-    if (code) {
-      let col = data_repo.mc_key_l["common_en"];
-      let common = data_repo.metadata.leaf_meta[code][col];
-      if (common && common.length > 0) common = common[0].toUpperCase() + common.slice(1);
-      return common;
-    }
+    let m = data_repo.get_meta_entry(-this.picset_code[index]);
+    if (!m) return undefined;
+
+    let common = m.entry[m.idx["common_en"]];
+    if (common && common.length > 0) common = common[0].toUpperCase() + common.slice(1);
+    return common;
   }
   get_picset_latin(index) {
-    let code = this.picset_code[index];
-    if (code) {
-      let col = data_repo.mc_key_l["scientificName"];
-      let latin = data_repo.metadata.leaf_meta[code][col];
-      if (latin && latin.length > 0) latin = latin.split("_").join(" ");
-      return latin;
-    }
+    let m = data_repo.get_meta_entry(-this.picset_code[index]);
+    if (!m) return undefined;
+
+    let latin = m.entry[m.idx["scientificName"]];
+    if (latin && latin.length > 0) latin = latin.split("_").join(" ");
+    return latin;
   }
   get has_child() {
     return this.children.length > 0;

--- a/OZprivate/rawJS/OZTreeModule/src/factory/midnode.js
+++ b/OZprivate/rawJS/OZTreeModule/src/factory/midnode.js
@@ -347,6 +347,10 @@ class Midnode {
   get sponsor_extra() {
     return this.get_attribute("sponsor_extra");
   }
+  get tours() {
+    // NB: Should always be a list (either stored in data_repo or no tours)
+    return this.get_attribute("tours") || [];
+  }
   get lengthbr() {
     if (this._age !== null) return this._age;
     let age = this.get_attribute("lengthbr");

--- a/OZprivate/rawJS/OZTreeModule/src/factory/midnode.js
+++ b/OZprivate/rawJS/OZTreeModule/src/factory/midnode.js
@@ -22,9 +22,6 @@ class Midnode {
     // metadata information
     this._cname = null;
     this._latin_name = null;
-    this._sponsor_name = null;
-    this._sponsor_kind = null;
-    this._sponsor_extra = null;
     this._age = null;
     this._spec_num_full = null;
     this._picset_len = null;
@@ -83,12 +80,10 @@ class Midnode {
   }
   release() {
     this.children = [];
+    this._meta = undefined;
     this._detail_fetched = false;
     this._cname = null;
     this._latin_name = null;
-    this._sponsor_name = null;
-    this._sponsor_kind = null;
-    this._sponsor_extra = null;
     this._age = null;
     this._spec_num_full = null;
     this._picset_len = null;
@@ -282,10 +277,10 @@ class Midnode {
    * Get attribute of node by key name. Use this function to fetch metadata of node only.
    */
   get_attribute(key_name) {
-    let m = data_repo.get_meta_entry(this.ozid);
-    if (!m) return undefined;
+    if (!this._meta) this._meta = data_repo.get_meta_entry(this.ozid);
+    if (!this._meta) return undefined;
 
-    return m.entry[m.idx[key_name]];
+    return this._meta.entry[this._meta.idx[key_name]];
   }
   
   clear_pics() {
@@ -344,28 +339,13 @@ class Midnode {
     return _latin_name;
   }
   get sponsor_name() {
-    if (this._sponsor_name !== null) return this._sponsor_name;
-    let _sponsor_name = this.get_attribute("sponsor_name");
-    if (this.detail_fetched) {
-      this._sponsor_name = _sponsor_name;
-    }
-    return _sponsor_name
+    return this.get_attribute("sponsor_name");
   }
   get sponsor_kind() {
-    if (this._sponsor_kind !== null) return this._sponsor_kind;
-    let _sponsor_kind = this.get_attribute("sponsor_kind");
-    if (this.detail_fetched) {
-      this._sponsor_kind = _sponsor_kind;
-    }
-    return _sponsor_kind;
+    return this.get_attribute("sponsor_kind");
   }
   get sponsor_extra() {
-    if (this._sponsor_extra !== null) return this._sponsor_extra;
-    let _sponsor_extra = this.get_attribute("sponsor_extra");
-    if (this.detail_fetched) {
-      this._sponsor_extra = _sponsor_extra;
-    }
-    return _sponsor_extra;
+    return this.get_attribute("sponsor_extra");
   }
   get lengthbr() {
     if (this._age !== null) return this._age;

--- a/OZprivate/rawJS/OZTreeModule/tests/test_factory_data_repo.js
+++ b/OZprivate/rawJS/OZTreeModule/tests/test_factory_data_repo.js
@@ -7,14 +7,6 @@ import test from 'tape';
 
 // From static/FinalOutputs/data/completetree_0.js
 var rawdata = '((()))';
-var metadata = {
-"leaf_meta":{
-"0":["OTTid","scientificName","common_en","popularity","picID","picID_credit","picID_rating","IUCN","price","sponsor_kind","sponsor_name","sponsor_extra","sponsor_url","n_spp"],
-"temp":[null," "]},
-
-"node_meta":{
-"0":["OTTid","scientificName","common_en","popularity","picID","picID_credit","picID_rating","IUCN","price","sponsor_kind","sponsor_name","sponsor_extra","sponsor_url","lengthbr","sp1","sp2","sp3","sp4","sp5","sp6","sp7","sp8","iucnNE","iucnDD","iucnLC","iucnNT","iucnVU","iucnEN","iucnCR","iucnEW","iucnEX"],
-"temp":[]}};
 
 test('DataRepo:parse_pics', function (t) {
     function um (ottids, leafPic) {
@@ -59,7 +51,7 @@ test('DataRepo:parse_pics', function (t) {
         }).filter(function (x) { return x.ozid !== '0' && x.ozid !== 'temp' });
     }
 
-    data_repo.setup({raw_data: rawdata, cut_map: {}, poly_cut_map: {}, metadata: metadata, cut_threshold: 10000, tree_date: "{}"});
+    data_repo.setup({raw_data: rawdata, cut_map: {}, poly_cut_map: {}, cut_threshold: 10000, tree_date: "{}"});
     t.deepEqual(pic_metadata(), [], "No leaves at start");
 
     // Add some leaves without images

--- a/OZprivate/rawJS/OZTreeModule/tests/test_factory_data_repo.js
+++ b/OZprivate/rawJS/OZTreeModule/tests/test_factory_data_repo.js
@@ -37,6 +37,10 @@ test('DataRepo:update_metadata', function (t) {
             "vernacular_by_ott": ottids.map(ottid => vernaculars[ottid]).filter(x => !!x),
             "vernacular_by_name":[],
             "leafIucn": ottids.map(ottid => leafIucn[ottid]).filter(x => !!x),
+            "tours_by_ott": [
+                [770315, ['ut::tour1', 'ut::tour2']],
+                [158484, ['ut::tour1']],
+            ],
         });
     }
 
@@ -73,6 +77,13 @@ test('DataRepo:update_metadata', function (t) {
         { ozid: -837462, OTTid: 158484, sponsor_name: undefined, sponsor_kind: undefined, sponsor_extra: undefined, sponsor_url: undefined },
         { ozid: -837463, OTTid: 417950, sponsor_name: undefined, sponsor_kind: undefined, sponsor_extra: undefined, sponsor_url: undefined },
     ], "Sponsorship details set");
+
+    // Test parse_tours_by_ott
+    t.deepEqual(pic_metadata(["OTTid", "tours"]), [
+        { ozid: -837461, OTTid: 770315, tours: ['ut::tour1', 'ut::tour2'] },
+        { ozid: -837462, OTTid: 158484, tours: ['ut::tour1'] },
+        { ozid: -837463, OTTid: 417950, tours: undefined },
+    ], "Tour URLs set");
 
     um([158484, 417950], [
         [158484,26863090,99,40000],

--- a/OZprivate/rawJS/OZTreeModule/tests/test_factory_data_repo.js
+++ b/OZprivate/rawJS/OZTreeModule/tests/test_factory_data_repo.js
@@ -8,7 +8,7 @@ import test from 'tape';
 // From static/FinalOutputs/data/completetree_0.js
 var rawdata = '((()))';
 
-test('DataRepo:parse_pics', function (t) {
+test('DataRepo:update_metadata', function (t) {
     function um (ottids, leafPic) {
         let leaves = {
             770315: [837461,770315,176839.3579154182,"Homo sapiens",null,null],
@@ -22,13 +22,16 @@ test('DataRepo:parse_pics', function (t) {
         }
         let leafIucn = {
             158484: [158484,"EN"],
-            417950: [417950,"EN"],
+            417950: [417950,"LC"],
         };
 
         data_repo.update_metadata({
             "leaves": ottids.map(ottid => leaves[ottid]).filter(x => !!x),
             "leafPic":leafPic,
-            "reservations":[],
+            "reservations":[
+                // OTT_ID, verified_kind, verified_name, verified_more_info, verified_url
+                [770315, "For", "Arthur Dent", "Don't panic", "https://example.com"],
+            ],
             "nodes":[],
             "lang":"en-GB,en;q=0.9",
             "vernacular_by_ott": ottids.map(ottid => vernaculars[ottid]).filter(x => !!x),
@@ -37,57 +40,66 @@ test('DataRepo:parse_pics', function (t) {
         });
     }
 
-    function pic_metadata() {
-        return Object.keys(data_repo.metadata.leaf_meta).map(function (ozid) {
-            let m = data_repo.metadata.leaf_meta[ozid];
-            return {
-                ozid: ozid,
-                "OTTid": m[data_repo.mc_key_l["OTTid"]],
-                "picID": m[data_repo.mc_key_l["picID"]],
-                "picID_src": m[data_repo.mc_key_l["picID_src"]],
-                "picID_rating": m[data_repo.mc_key_l["picID_rating"]],
-                "picID_credit": m[data_repo.mc_key_l["picID_credit"]],
-            };
+    function pic_metadata(fields) {
+        return Object.keys(data_repo.metadata.leaf_meta).map(function (leaf_metacode) {
+            let m = data_repo.get_meta_entry(-leaf_metacode);
+            let out = { ozid: -leaf_metacode };
+            fields.forEach((k) => out[k] = m.entry[m.idx[k]]);
+            return out;
         }).filter(function (x) { return x.ozid !== '0' && x.ozid !== 'temp' });
     }
 
     data_repo.setup({raw_data: rawdata, cut_map: {}, poly_cut_map: {}, cut_threshold: 10000, tree_date: "{}"});
-    t.deepEqual(pic_metadata(), [], "No leaves at start");
+    t.deepEqual(pic_metadata(["OTTid", "picID", "picID_src", "picID_rating", "picID_credit"]), [], "No leaves at start");
 
     // Add some leaves without images
     um([770315, 158484, 417950], []);
-    t.deepEqual(pic_metadata(), [
-        { ozid: '837461', OTTid: 770315, picID: null, picID_src: null, picID_rating: null, picID_credit: null },
-        { ozid: '837462', OTTid: 158484, picID: null, picID_src: null, picID_rating: null, picID_credit: null },
-        { ozid: '837463', OTTid: 417950, picID: null, picID_src: null, picID_rating: null, picID_credit: null },
+    t.deepEqual(pic_metadata(["OTTid", "picID", "picID_src", "picID_rating", "picID_credit"]), [
+        { ozid: -837461, OTTid: 770315, picID: null, picID_src: null, picID_rating: null, picID_credit: null },
+        { ozid: -837462, OTTid: 158484, picID: null, picID_src: null, picID_rating: null, picID_credit: null },
+        { ozid: -837463, OTTid: 417950, picID: null, picID_src: null, picID_rating: null, picID_credit: null },
     ], "Added leaves without any images");
+
+    // Test parse_ordered_leaves, parse_iucn
+    t.deepEqual(pic_metadata(["OTTid", "scientificName", "common_en", "popularity", "IUCN"]), [
+        { ozid: -837461, OTTid: 770315, scientificName: 'Homo sapiens', common_en: 'Human', popularity: 176839.3579154182, IUCN: undefined },
+        { ozid: -837462, OTTid: 158484, scientificName: 'Pan paniscus', common_en: 'Bonobo', popularity: 182704.23513227384, IUCN: 'EN' },
+        { ozid: -837463, OTTid: 417950, scientificName: 'Pan troglodytes', common_en: 'Chimpanzee', popularity: 175868.4889146225, IUCN: 'LC' },
+    ], "Names, popularity, IUCN set");
+
+    // Test parse_sponsorship
+    t.deepEqual(pic_metadata(["OTTid", "sponsor_name", "sponsor_kind", "sponsor_extra", "sponsor_url"]), [
+        { ozid: -837461, OTTid: 770315, sponsor_name: 'Arthur Dent', sponsor_kind: 'For', sponsor_extra: 'Don\'t panic', sponsor_url: 'https://example.com' },
+        { ozid: -837462, OTTid: 158484, sponsor_name: undefined, sponsor_kind: undefined, sponsor_extra: undefined, sponsor_url: undefined },
+        { ozid: -837463, OTTid: 417950, sponsor_name: undefined, sponsor_kind: undefined, sponsor_extra: undefined, sponsor_url: undefined },
+    ], "Sponsorship details set");
 
     um([158484, 417950], [
         [158484,26863090,99,40000],
         [417950,27252520,99,50000],
     ]);
-    t.deepEqual(pic_metadata(), [
-        { ozid: '837461', OTTid: 770315, picID: null, picID_src: null, picID_rating: null, picID_credit: null },
-        { ozid: '837462', OTTid: 158484, picID: '26863090', picID_src: '99', picID_rating: 40000, picID_credit: null },
-        { ozid: '837463', OTTid: 417950, picID: '27252520', picID_src: '99', picID_rating: 50000, picID_credit: null },
+    t.deepEqual(pic_metadata(["OTTid", "picID", "picID_src", "picID_rating", "picID_credit"]), [
+        { ozid: -837461, OTTid: 770315, picID: null, picID_src: null, picID_rating: null, picID_credit: null },
+        { ozid: -837462, OTTid: 158484, picID: '26863090', picID_src: '99', picID_rating: 40000, picID_credit: null },
+        { ozid: -837463, OTTid: 417950, picID: '27252520', picID_src: '99', picID_rating: 50000, picID_credit: null },
     ], "Added 2 leaves, only 2 with images");
 
     um([770315, 158484], [
         [158484,12345678,99,40000],
         [770315,26865347,99,35217],
     ]);
-    t.deepEqual(pic_metadata(), [
-        { ozid: '837461', OTTid: 770315, picID: '26865347', picID_src: '99', picID_rating: 35217, picID_credit: null },
-        { ozid: '837462', OTTid: 158484, picID: '12345678', picID_src: '99', picID_rating: 40000, picID_credit: null },
-        { ozid: '837463', OTTid: 417950, picID: '27252520', picID_src: '99', picID_rating: 50000, picID_credit: null },
+    t.deepEqual(pic_metadata(["OTTid", "picID", "picID_src", "picID_rating", "picID_credit"]), [
+        { ozid: -837461, OTTid: 770315, picID: '26865347', picID_src: '99', picID_rating: 35217, picID_credit: null },
+        { ozid: -837462, OTTid: 158484, picID: '12345678', picID_src: '99', picID_rating: 40000, picID_credit: null },
+        { ozid: -837463, OTTid: 417950, picID: '27252520', picID_src: '99', picID_rating: 50000, picID_credit: null },
     ], "Added 1 image, updated another, leave final alone");
 
     um([770315], [
     ]);
-    t.deepEqual(pic_metadata(), [
-        { ozid: '837461', OTTid: 770315, picID: null, picID_src: null, picID_rating: null, picID_credit: null },
-        { ozid: '837462', OTTid: 158484, picID: '12345678', picID_src: '99', picID_rating: 40000, picID_credit: null },
-        { ozid: '837463', OTTid: 417950, picID: '27252520', picID_src: '99', picID_rating: 50000, picID_credit: null },
+    t.deepEqual(pic_metadata(["OTTid", "picID", "picID_src", "picID_rating", "picID_credit"]), [
+        { ozid: -837461, OTTid: 770315, picID: null, picID_src: null, picID_rating: null, picID_credit: null },
+        { ozid: -837462, OTTid: 158484, picID: '12345678', picID_src: '99', picID_rating: 40000, picID_credit: null },
+        { ozid: -837463, OTTid: 417950, picID: '27252520', picID_src: '99', picID_rating: 50000, picID_credit: null },
     ], "Removed 1 image");
 
     t.end();

--- a/OZprivate/rawJS/OZTreeModule/tests/test_factory_midnode.js
+++ b/OZprivate/rawJS/OZTreeModule/tests/test_factory_midnode.js
@@ -1,0 +1,58 @@
+/**
+  * Usage: npx babel-tape-runner OZprivate/rawJS/OZTreeModule/tests/test_factory_midnode.js
+  */
+import { get_ozid } from './util_data_repo'
+import { populate_factory } from './util_factory'
+import test from 'tape';
+
+test('picset', function (test) {
+  var factory;
+  function picset(ozid) {
+    var node = factory.dynamic_loading_by_metacode(ozid);
+    var out = [];
+    for (let i = 0; i < node.num_pics; i++) {
+      out.push({
+        ozid: node.ozid,
+        ott: node.ott,
+        picset_code: node.get_picset_code(i),
+        picset_src_info: node.get_picset_src_info(i),
+        picset_common: node.get_picset_common(i),
+        picset_latin: node.get_picset_latin(i),
+      });
+    }
+    return out;
+  }
+
+  return populate_factory().then((f) => {
+    // Init data_repo & factory
+    factory = f;
+
+ }).then(() => {
+    // Grab representative picset
+    test.deepEqual(picset(759126), [
+      { ozid: 759126, ott: 691846, picset_code: 1604804, picset_src_info: [ '3', '-26781256', null ], picset_common: 'Seven-spot ladybird', picset_latin: 'Coccinella septempunctata' },
+      { ozid: 759126, ott: 691846, picset_code: 859495, picset_src_info: [ '99', '26864213', null ], picset_common: 'Black-headed Bunting', picset_latin: 'Emberiza melanocephala' },
+      { ozid: 759126, ott: 691846, picset_code: 909997, picset_src_info: [ '99', '27480684', null ], picset_common: 'Common octopus', picset_latin: 'Octopus vulgaris' },
+      { ozid: 759126, ott: 691846, picset_code: 761509, picset_src_info: [ '99', '13144803', null ], picset_common: 'Giant barrel sponge', picset_latin: 'Xestospongia muta' },
+      { ozid: 759126, ott: 691846, picset_code: 766689, picset_src_info: [ '99', '27825566', null ], picset_common: 'Sea walnut', picset_latin: 'Mnemiopsis leidyi' },
+      { ozid: 759126, ott: 691846, picset_code: 780665, picset_src_info: [ '99', '31356256', null ], picset_common: 'Cauliflower Coral', picset_latin: 'Pocillopora damicornis' },
+      { ozid: 759126, ott: 691846, picset_code: 992201, picset_src_info: [ '99', '26864323', null ], picset_common: undefined, picset_latin: 'Caenorhabditis elegans' },
+      { ozid: 759126, ott: 691846, picset_code: 1000050, picset_src_info: [ '99', '27736333', null ], picset_common: undefined, picset_latin: 'Hypsibius dujardini' },
+    ]);
+
+  }).then(function () {
+    test.end();
+  }).catch(function (err) {
+    console.log(err.stack);
+    test.fail(err);
+    test.end();
+  })
+});
+
+
+test.onFinish(function() {
+  // NB: Something data_repo includes in is holding node open.
+  //     Can't find it so force our tests to end.
+  process.exit(0)
+});
+

--- a/OZprivate/rawJS/OZTreeModule/tests/test_factory_midnode.js
+++ b/OZprivate/rawJS/OZTreeModule/tests/test_factory_midnode.js
@@ -65,6 +65,32 @@ test('sponsor_name,sponsor_kind,sponsor_extra', function (test) {
 
 });
 
+test('tours', function (test) {
+  var factory;
+
+  return populate_factory().then((f) => {
+    // Init data_repo & factory
+    factory = f;
+
+ }).then(() => {
+   var node = factory.dynamic_loading_by_metacode(759126);
+
+   test.deepEqual(node.tours, []);
+   um({tours_by_ott: [
+     // OTT_ID, verified_kind, verified_name, verified_more_info, verified_url
+     [node.ott, ["ut::tour1"]],
+   ]})
+   test.deepEqual(node.tours, ["ut::tour1"]);
+
+  }).then(function () {
+    test.end();
+  }).catch(function (err) {
+    console.log(err.stack);
+    test.fail(err);
+    test.end();
+  })
+});
+
 test('picset', function (test) {
   var factory;
   function picset(ozid) {

--- a/OZprivate/rawJS/OZTreeModule/tests/util_data_repo.js
+++ b/OZprivate/rawJS/OZTreeModule/tests/util_data_repo.js
@@ -13,7 +13,7 @@ export function populate_data_repo(tree_serial = '25589581') {
     // NB: We use JSDOM because the generated files don't export their contents, so wouldn't
     //     be accessible if we require()d them.
     const vdom = new jsdom.JSDOM(`<body>
-       <!-- rawData, metadata -->
+       <!-- rawData -->
        <script src="completetree_${tree_serial}.js" type="text/javascript"></script>
        <!-- cut_position_map_json_str, polytomy_cut_position_map_json_str, cut_thresholdcut_threshold -->
        <script src="cut_position_map_${tree_serial}.js" type="text/javascript"></script>
@@ -31,7 +31,6 @@ export function populate_data_repo(tree_serial = '25589581') {
         raw_data: this.rawData,
         cut_map: JSON.parse(this.cut_position_map_json_str),
         poly_cut_map: JSON.parse(this.polytomy_cut_position_map_json_str),
-        metadata: this.metadata,
         cut_threshold: this.cut_threshold,
         tree_date: this.tree_date,
       });

--- a/views/default/index.html
+++ b/views/default/index.html
@@ -146,7 +146,7 @@ $(document).ready(function() {    /* Mainly a place to attach JS event handlers 
             'OneZoomCanvasID',
             window['tree_config'],
             window.rawData,
-            window.metadata,
+            null,
             window.cut_position_map_json_str,
             window.polytomy_cut_position_map_json_str,
             window.cut_threshold,

--- a/views/treeviewer/layout.html
+++ b/views/treeviewer/layout.html
@@ -923,7 +923,7 @@ $(document).ready(function() {    /* Mainly a place to attach JS event handlers 
             'OneZoomCanvasID',
             window['tree_config'],
             window.rawData,
-            window.metadata,
+            null,
             window.cut_position_map_json_str,
             window.polytomy_cut_position_map_json_str,
             window.cut_threshold,


### PR DESCRIPTION
@jrosindell @hyanwong 

The following does a bunch of refactoring to simplify data_repo metadata storage, along with bits of of #656 to make adding tours easier. We then add a ``tours_by_ott`` lookup to the ``node_details`` api call, and make the results of that accessible from midnode objects. We don't display them yet, but getting there.

Most notably, ``metadata``, an array of columns currently part of ``completetree_0.js``, is now stored within ``data_repo`` instead of relying on tree-build to generate it for us. The arrays it describes aren't part of the server/client communication, and only used inside ``data_repo``.

This also means we can add to it with new entries.