### PR TITLE
Update preferred_python3 to 3.10. Python 3.7 is no longer supported.

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+WEB_IMAGE_NAME=onezoom/oztree-with-iucn

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -5,7 +5,7 @@ const path = require('path');
 
 partial_install_site = "http://www.onezoom.org";
 partial_local_install_site = "http://127.0.0.1:8000"; // if you are running a local installation
-preferred_python3 = "python3.7"; // in case you have multiple python3 versions installed
+preferred_python3 = "python3.8"; // in case you have multiple python3 versions installed
 web2py_py = path.join(path.dirname(path.dirname(process.cwd())), 'web2py.py');
 
 /** Generate a function to execute a web2py script, handing over all arguments */

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -5,7 +5,7 @@ const path = require('path');
 
 partial_install_site = "http://www.onezoom.org";
 partial_local_install_site = "http://127.0.0.1:8000"; // if you are running a local installation
-preferred_python3 = "python3.8"; // in case you have multiple python3 versions installed
+preferred_python3 = "python3.10"; // in case you have multiple python3 versions installed
 web2py_py = path.join(path.dirname(path.dirname(process.cwd())), 'web2py.py');
 
 /** Generate a function to execute a web2py script, handing over all arguments */


### PR DESCRIPTION
If memory serves, this is also the Python version in the latest Docker image of alpine-compass-python-perl-node. We could also use a later version; I was just being conservative.