### PR TITLE
Several fixes to compile_js_dev:watch

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -296,6 +296,13 @@ You can then run the tests with:
 
     grunt test-server-functional
 
+## Debugging
+
+If you wish to use your editor's debugger to debug the JavaScript code, you will need to compile source maps. Run the following:
+
+1. Run `grunt dev` to perform the initial dev compilation.
+1. Run `npm run compile_js_dev:watch` to compile source maps and automatically recompile if files are changed. Note: this command will continue to run until it is killed.
+
 # Documentation
 
 Documentation is partially compiled from the source code using Grunt, and lives in `OZprivate/rawJS/OZTreeModule/docs`. Once compiled, it can be viewed online using your web2py server. For example, if you are running web2py on http://127.0.0.1:8000, you should be able to visit [http://127.0.0.1:8000/OZtree/dev/DOCS](http://127.0.0.1:8000/OZtree/dev/DOCS), or (if you have manager access to the OneZoom site) at [http://onezoom.org/dev/DOCS](http://onezoom.org/dev/DOCS).

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "test": "npx babel-tape-runner OZprivate/rawJS/OZTreeModule/tests/*.js",
     "compile_js": "webpack --mode production",
-    "compile_js_dev:watch": "webpack --watch --config webpack.config.dev.js",
+    "compile_js_dev:watch": "webpack --mode development --watch --config webpack.config.dev.js",
     "compile_js_dev": "webpack --mode development"
   },
   "repository": {

--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -1,5 +1,7 @@
+const path = require('path')
+
 const config = require('./webpack.config')
 
-config.output.path = './static/OZTreeModule/dist/'
+config.output.path = path.resolve(__dirname, 'static/OZTreeModule/dist/')
 
 module.exports = config

--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -3,5 +3,6 @@ const path = require('path')
 const config = require('./webpack.config')
 
 config.output.path = path.resolve(__dirname, 'static/OZTreeModule/dist/')
+config.devtool = 'eval-source-map'
 
 module.exports = config

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -59,7 +59,6 @@ var config = {
       }
     ]
   },
-  devtool: 'eval-source-map',
   plugins: [
     new HtmlWebpackPlugin({
       filename: 'OZ_main.html',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -59,6 +59,7 @@ var config = {
       }
     ]
   },
+  devtool: 'eval-source-map',
   plugins: [
     new HtmlWebpackPlugin({
       filename: 'OZ_main.html',


### PR DESCRIPTION
- Absolute filename is required for config.output.path (not sure how this ever worked for anyone, I guess older versions of webpack didn't require this)
- Use `--mode development` to be consistent with compile_js_dev 
- Add `devtool = 'eval-source-map'` which makes this mode work with editor debuggers such as VSCode. Technically this change could be independent of whether ":watch" is specified, but the webpack.config.dev.js file was a convenient place to apply this so it won't affect prod. Another approach would be to create a third webpack file that sits between webpack.config.js and webpack.config.dev.js in the inheritance hierarchy, which supplies this configuration.