### PR TITLE
Fix OZtree/dev/DOCS

### DIFF
--- a/controllers/dev.py
+++ b/controllers/dev.py
@@ -18,7 +18,7 @@ def COMPILED_DOCS():
     return the markdown
     """
     try:
-        with open('applications/{}/OZprivate/rawJS/OZTreeModule/docs/_compiled.markdown'.format(request.application), 'rb') as md:
+        with open('applications/{}/OZprivate/rawJS/OZTreeModule/docs/_compiled.markdown'.format(request.application), 'r', encoding="utf-8") as md:
             return dict(markdown=md.read())
     except:
         return dict(markdown="No compiled markdown file found")

--- a/controllers/dev.py
+++ b/controllers/dev.py
@@ -18,8 +18,8 @@ def COMPILED_DOCS():
     return the markdown
     """
     try:
-    with open('applications/{}/OZprivate/rawJS/OZTreeModule/docs/_compiled.markdown'.format(request.application), 'rb') as md:
-        return dict(markdown=md.read())
+        with open('applications/{}/OZprivate/rawJS/OZTreeModule/docs/_compiled.markdown'.format(request.application), 'rb') as md:
+            return dict(markdown=md.read())
     except:
         return dict(markdown="No compiled markdown file found")
 


### PR DESCRIPTION
Just fixing the broken Python indentation results in a garbled page. Changing it to explicitly decode the unicode produces a readable page.