### PR TITLE
Fixed threatened_branch() to exclude extinct species.

### DIFF
--- a/OZprivate/rawJS/OZTreeModule/src/factory/midnode.js
+++ b/OZprivate/rawJS/OZTreeModule/src/factory/midnode.js
@@ -411,11 +411,13 @@ class Midnode {
       num_threatened += this.get_attribute("iucnVU");
       num_threatened += this.get_attribute("iucnEN");
       num_threatened += this.get_attribute("iucnCR");
+      num_threatened += this.get_attribute("iucnEW");
     }
+    let num_extant = this.richness_val - this.get_attribute("iucnEX");
     if (this.detail_fetched) {
-      this._threatened_branch = (num_threatened > this.richness_val * 0.5);
+      this._threatened_branch = (num_threatened > num_extant * 0.5);
     }
-    return num_threatened > this.richness_val * 0.5;
+    return num_threatened > num_extant * 0.5;
   }
   get redlist() {
     if (this._redlist !== null) return this._redlist;

--- a/OZprivate/rawJS/OZTreeModule/src/factory/midnode.js
+++ b/OZprivate/rawJS/OZTreeModule/src/factory/midnode.js
@@ -411,9 +411,8 @@ class Midnode {
       num_threatened += this.get_attribute("iucnVU");
       num_threatened += this.get_attribute("iucnEN");
       num_threatened += this.get_attribute("iucnCR");
-      num_threatened += this.get_attribute("iucnEW");
     }
-    let num_extant = this.richness_val - this.get_attribute("iucnEX");
+    let num_extant = this.richness_val - (this.get_attribute("iucnEX") + this.get_attribute("iucnEW"));
     if (this.detail_fetched) {
       this._threatened_branch = (num_threatened > num_extant * 0.5);
     }


### PR DESCRIPTION
With the way that threatened_branch() was being calculated, a branch consisting entirely of threatened and extinct species could get marked as not threatened. This excludes extinct species from the calculation.