### PR TITLE
Focal area targeting

### DIFF
--- a/OZprivate/rawJS/OZTreeModule/src/controller/controller.js
+++ b/OZprivate/rawJS/OZTreeModule/src/controller/controller.js
@@ -120,11 +120,11 @@ class Controller {
         return;
       }
       call_hook("before_draw");
-      if ((this.widthres != this.canvas.clientWidth)||(this.heightres != this.canvas.clientHeight))
+      if ((tree_state.widthres != this.canvas.clientWidth)||(tree_state.heightres != this.canvas.clientHeight))
       {
-          this.widthres = this.canvas.width = this.canvas.clientWidth;
-          this.heightres = this.canvas.height = this.canvas.clientHeight;
           // we are setting 1px on canvas = 1px on screen (client)
+          this.canvas.width = this.canvas.clientWidth;
+          this.canvas.height = this.canvas.clientHeight;
           this.cancel_flight();
           this.re_calc();
           this.renderer.setup_canvas(this.canvas);

--- a/OZprivate/rawJS/OZTreeModule/src/position_helper.js
+++ b/OZprivate/rawJS/OZTreeModule/src/position_helper.js
@@ -194,20 +194,6 @@ function get_v_horizon_by_arc(node, factor, x, y, r) {
 }
 
 
-function print_target_node(node) {
-  let arr = [];
-  get_targets(node, arr);
-  console.log(arr.reverse());
-}
-
-function get_targets(node, arr) {
-  arr.push(node.metacode);
-  if (node.upnode) {
-    get_targets(node.upnode, arr);
-  }
-}
-
-
 // this function clears completely all the targeted tags in the tree
 function clear_target(node) {
   // set value to false

--- a/OZprivate/rawJS/OZTreeModule/src/position_helper.js
+++ b/OZprivate/rawJS/OZTreeModule/src/position_helper.js
@@ -1,7 +1,6 @@
 import tree_state from './tree_state';
 import {max, min} from './util/index';
 
-let targetScreenProp = 0.95;  // proportion of screen that should be filled with targeted area when zooming in / out
 let x_add = null;
 let y_add = null;
 let r_mult = null;
@@ -88,15 +87,17 @@ function get_xyr_target(node, x2,y2,r2,into_node) {
   }
 
   // find out if new target area is constained by x or y axis compared to current view
-  if ((tree_state.widthres/tree_state.heightres)> (x_targ_max-x_targ_min)/(y_targ_max-y_targ_min)) {
+  if (tree_state.focal_area.width / tree_state.focal_area.height > (x_targ_max-x_targ_min)/(y_targ_max-y_targ_min)) {
     // height controls size
-    r_mult = (tree_state.heightres*targetScreenProp)/(y_targ_max-y_targ_min);
+    r_mult = tree_state.focal_area.height / (y_targ_max-y_targ_min);
   } else {
     // width controls size
-    r_mult = (tree_state.widthres*targetScreenProp)/(x_targ_max-x_targ_min);
+    r_mult = tree_state.focal_area.width / (x_targ_max-x_targ_min);
   }
-  x_add = (x_targ_max+x_targ_min - tree_state.widthres)/2;
-  y_add = (y_targ_max+y_targ_min - tree_state.heightres)/2;
+
+  // Center node in focal area
+  x_add = (x_targ_max+x_targ_min)/2 - tree_state.focal_area.xcentre;
+  y_add = (y_targ_max+y_targ_min)/2 - tree_state.focal_area.ycentre;
 
   // only go 1000000 at a time on r_mult
   if (r_mult >= 10000000 && !node.graphref) {
@@ -345,8 +346,8 @@ function pan_zoom(prop_p, prop_z) {
   let x_add2 = x_add;
   let r_mult2 = r_mult;
 
-  const tree_centreX = tree_state.widthres/2;
-  const tree_centreY = tree_state.heightres/2
+  const tree_centreX = tree_state.focal_area.xcentre;
+  const tree_centreY = tree_state.focal_area.ycentre;
 
   if (r_mult2 < 1) { // Zooming outwards
     pre_xp2 = tree_centreX + (pre_xp2-x_add2-tree_centreX)*r_mult2;

--- a/OZprivate/rawJS/OZTreeModule/src/position_helper.js
+++ b/OZprivate/rawJS/OZTreeModule/src/position_helper.js
@@ -337,43 +337,37 @@ function perform_fly_b2(controller, into_node, speed, accel_type, finalize_func,
  * @param {float} prop_z Proportion of r_mult to zoom (0 - start, 1 - end)
  */
 function pan_zoom(prop_p, prop_z) {
-  if (r_mult >= 1) {
-    auto_pan_zoom(prop_p, prop_z);
-  } else {
-    auto_pan_zoom_out(prop_p, prop_z);
+  // Copy globals so we can modify
+  let pre_xp2 = pre_xp;
+  let pre_yp2 = pre_yp;
+  let pre_ws2 = pre_ws;
+  let y_add2 = y_add;
+  let x_add2 = x_add;
+  let r_mult2 = r_mult;
+
+  const tree_centreX = tree_state.widthres/2;
+  const tree_centreY = tree_state.heightres/2
+
+  if (r_mult2 < 1) { // Zooming outwards
+    pre_xp2 = tree_centreX + (pre_xp2-x_add2-tree_centreX)*r_mult2;
+    pre_yp2 = tree_centreY + (pre_yp2-y_add2-tree_centreY)*r_mult2;
+    pre_ws2 = pre_ws2 * r_mult2;
+
+    prop_p = 1-prop_p;
+    prop_z = 1-prop_z;
+
+    y_add2 = (-y_add2)*r_mult2;
+    x_add2 = (-x_add2)*r_mult2;
+    r_mult2 = 1/r_mult2;
+    // todo - getting there, but need to play with the function still - it's not right
+    // also can transform the prop_p and prop_z components of this to make it non linear and more zooming initially
+    // could change to measure x and y add in terms of the zoomed out version
   }
+
+  tree_state.ws = pre_ws2 * Math.pow(r_mult2,prop_z);
+  tree_state.xp = tree_centreX + x_add2*(1-prop_p) + (pre_xp2-x_add2-tree_centreX) * Math.pow(r_mult2,prop_z);
+  tree_state.yp = tree_centreY + y_add2*(1-prop_p) + (pre_yp2-y_add2-tree_centreY) * Math.pow(r_mult2,prop_z);
 }
-
-function auto_pan_zoom(prop_p,prop_z) {  
-  let centreY = y_add + tree_state.heightres/2;
-  let centreX = x_add + tree_state.widthres/2;
-  tree_state.ws = pre_ws*(Math.pow(r_mult,prop_z));
-  tree_state.xp = centreX + (pre_xp-centreX)*(Math.pow(r_mult,prop_z)) - x_add*prop_p;
-  tree_state.yp = centreY + (pre_yp-centreY)*(Math.pow(r_mult,prop_z)) - y_add*prop_p;
-}
-
-function auto_pan_zoom_out(prop_p,prop_z){
-  let pre_xp_new = tree_state.widthres/2 + (pre_xp-tree_state.widthres/2 - x_add)*r_mult;
-  let pre_yp_new = tree_state.heightres/2 + (pre_yp-tree_state.heightres/2 - y_add)*r_mult;
-  let pre_ws_new = pre_ws*r_mult;
-  
-  let prop_p2 = 1-prop_p;
-  let prop_z2 = 1-prop_z;
-  
-  let y_add2 = (-y_add)*r_mult;
-  let x_add2 = (-x_add)*r_mult;
-  let r_mult2 = 1/r_mult;
-    
-  let centreY = y_add2+tree_state.heightres/2;
-  let centreX = x_add2+tree_state.widthres/2;
-  tree_state.ws = pre_ws_new*(Math.pow(r_mult2,prop_z2));
-  tree_state.xp = centreX + (pre_xp_new-centreX)*(Math.pow(r_mult2,prop_z2)) - x_add2*prop_p2;
-  tree_state.yp = centreY + (pre_yp_new-centreY)*(Math.pow(r_mult2,prop_z2)) - y_add2*prop_p2;
-
-  // todo - getting there, but need to play with the function still - it's not right
-  // also can transform the prop_p and prop_z components of this to make it non linear and more zooming initially
-  // could change to measure x and y add in terms of the zoomed out version
-};
 
 function reanchor_at_node(node) {
   node.graphref = true;

--- a/OZprivate/rawJS/OZTreeModule/src/projection/re_calc.js
+++ b/OZprivate/rawJS/OZTreeModule/src/projection/re_calc.js
@@ -4,7 +4,7 @@ import tree_state from '../tree_state';
 
 
 function re_calc(node, xp, yp, ws) {
-  drawreg(node, xp, yp, ws*220, this);
+  drawreg(node, xp, yp, ws*220);
 }
 
 // the horizon is precalcualted these parts are calculated every time the tree view gets moved

--- a/OZprivate/rawJS/OZTreeModule/src/tour/Tour.js
+++ b/OZprivate/rawJS/OZTreeModule/src/tour/Tour.js
@@ -117,6 +117,16 @@ class Tour {
       this.remove_canvas_interaction_callbacks()
     }
 
+    // Inside a tour, leave room for tourstops during flights
+    if (new_state === tstate.INACTIVE) {
+      tree_state.constrain_focal_area(1, 1);
+    } else if (this.container[0].hasAttribute('data-focal-area')){
+      tree_state.constrain_focal_area.apply(
+          tree_state,
+          this.container[0].getAttribute('data-focal-area').split(" "),
+      );
+    }
+
     return this._state;
   }
 

--- a/OZprivate/rawJS/OZTreeModule/src/tree_state.js
+++ b/OZprivate/rawJS/OZTreeModule/src/tree_state.js
@@ -60,17 +60,34 @@ class TreeState {
     }
   }
 
+  /**
+   * Constrain focal area to the right (frac_landscape) if landscape, topmost (frac_portrait) if portrait
+   */
+  constrain_focal_area(frac_landscape, frac_portrait) {
+    this._fa = {
+      frac_landscape: frac_landscape,
+      frac_portrait: frac_portrait,
+    };
+    this._update_focal_area();
+  }
+
   // Update the focal_area bounding box: The rect we should fill on flights, used by position_helper
   _update_focal_area() {
     const targetScreenProp = 0.95;  // proportion of screen that should be filled with targeted area when zooming in / out
     const borderPerc = (1 - targetScreenProp) / 2;
+    const is_landscape = this.widthres / this.heightres > 1;
+
+    if (!this._fa) this._fa = {
+      frac_landscape: 1,
+      frac_portrait: 1,
+    };
 
     this.focal_area = {
       // Shrink overall bounding box by targetScreenProp
-      xmin: Math.round(this.widthres * borderPerc),
+      xmin: Math.round(this.widthres * (is_landscape ? 1-this._fa.frac_landscape : 0) + this.widthres * borderPerc),
       ymin: Math.round(this.heightres * borderPerc),
       xmax: Math.round(this.widthres - this.widthres * borderPerc),
-      ymax: Math.round(this.heightres - this.heightres * borderPerc),
+      ymax: Math.round(this.heightres * (!is_landscape ? this._fa.frac_portrait: 1) - this.heightres * borderPerc),
     };
 
     // Include width/height/center as convenience helpers

--- a/OZprivate/rawJS/OZTreeModule/src/tree_state.js
+++ b/OZprivate/rawJS/OZTreeModule/src/tree_state.js
@@ -96,11 +96,11 @@ class TreeState {
 
     // After 400ms, any action should be cleared (unless something updates it with a new action)
     if (this.action_timeout) {
-        window.clearTimeout(this.action_timeout);
+        clearTimeout(this.action_timeout);
         this.action_timeout = null;
     }
     if (this.action) {
-        this.action_timeout = window.setTimeout(this.set_action.bind(this, null), 400);
+        this.action_timeout = setTimeout(this.set_action.bind(this, null), 400);
     }
   }
   is_idle() {

--- a/OZprivate/rawJS/OZTreeModule/src/tree_state.js
+++ b/OZprivate/rawJS/OZTreeModule/src/tree_state.js
@@ -47,6 +47,7 @@ class TreeState {
     }
     this.widthres = canvas.width;
     this.heightres = canvas.height;
+    this._update_focal_area()
     call_hook("window_size_change");
   }
   get flying() {
@@ -58,6 +59,27 @@ class TreeState {
       call_hook("flying_finish");
     }
   }
+
+  // Update the focal_area bounding box: The rect we should fill on flights, used by position_helper
+  _update_focal_area() {
+    const targetScreenProp = 0.95;  // proportion of screen that should be filled with targeted area when zooming in / out
+    const borderPerc = (1 - targetScreenProp) / 2;
+
+    this.focal_area = {
+      // Shrink overall bounding box by targetScreenProp
+      xmin: Math.round(this.widthres * borderPerc),
+      ymin: Math.round(this.heightres * borderPerc),
+      xmax: Math.round(this.widthres - this.widthres * borderPerc),
+      ymax: Math.round(this.heightres - this.heightres * borderPerc),
+    };
+
+    // Include width/height/center as convenience helpers
+    this.focal_area.width = this.focal_area.xmax - this.focal_area.xmin;
+    this.focal_area.height = this.focal_area.ymax - this.focal_area.ymin;
+    this.focal_area.xcentre = (this.focal_area.xmax + this.focal_area.xmin)/2;
+    this.focal_area.ycentre = (this.focal_area.ymax + this.focal_area.ymin)/2;
+  }
+
   get xp() {
     return this._xp;
   }

--- a/OZprivate/rawJS/OZTreeModule/tests/test_position_helper.js
+++ b/OZprivate/rawJS/OZTreeModule/tests/test_position_helper.js
@@ -1,0 +1,157 @@
+/**
+  * Usage: npx babel-tape-runner OZprivate/rawJS/OZTreeModule/tests/test_position_helper.js
+  */
+import * as position_helper from '../src/position_helper.js';
+import { resolve_pinpoints } from '../src/navigation/pinpoint.js';
+import { populate_factory } from './util_factory'
+import test from 'tape';
+
+import tree_state from '../src/tree_state.js'
+import get_projection from '../src/projection/projection.js';
+import { set_pre_calculator } from '../src/projection/pre_calc/pre_calc';
+import { set_horizon_calculator } from '../src/projection/horizon_calc/horizon_calc';
+
+function fake_controller(factory, widthres, heightres) {
+  tree_state.setup_canvas({ width: widthres, height: heightres });
+
+  const controller = {
+    root: factory.get_root(),
+    tree_state: tree_state,
+    projection: get_projection(),
+    factory: factory,
+  };
+
+  // Helpers from src/controller/controller.js
+  controller.re_calc = function () {
+    this.projection.re_calc(this.root, this.tree_state.xp, this.tree_state.yp, this.tree_state.ws);
+  }.bind(controller);
+
+  controller.reanchor = function () {
+    position_helper.reanchor(this.root);
+  }.bind(controller);
+
+  controller.trigger_refresh_loop = function () {
+    // Don't do anything here
+  }.bind(controller);
+
+  controller.get_graphref_node = function () {
+    function gr(node) {
+      for (let i=0; i<node.children.length; i++) {
+        if (node.children[i].graphref) return gr(node.children[i]);
+      }
+      // No children are graphref, this must be a leaf or the end of the path
+      return node;
+    }
+    return gr(this.root);
+  }
+
+  // tree_settings.vis
+  set_pre_calculator('spiral');
+  set_horizon_calculator('bezier');
+
+  // dynamic_load_and_calc
+  controller.re_calc();
+  controller.projection.pre_calc(controller.root);
+  controller.projection.calc_horizon(controller.root)
+  controller.projection.update_parent_horizon(controller.root)
+  controller.projection.highlight_propogate(controller.root)
+  
+  return controller;
+}
+
+function move_to(controller, node, opts) {
+  // Rough parallel to Controller.prototype.leap_to / Controller.prototype.fly_on_tree_to
+
+  return new Promise((resolve, reject) => {
+    // develop_branch_to_and_target
+    controller.factory.dynamic_loading_by_metacode(node.ozid)
+    position_helper.clear_target(controller.root);
+    position_helper.target_by_code(controller.root, node.ozid);
+
+    position_helper.perform_actual_fly(
+      controller,
+      !!opts.into_node,
+      opts.speed || 1,
+      opts.accel_type || 'linear',
+      resolve,
+      () => reject(new Error("Flight interrupted")),
+    );
+  });
+}
+function test_cur_location(test, controller, node_latin_name, exp_xp, exp_yp, exp_ws, message) {
+  function round(x) {
+    return Math.round(x * 10000) / 10000;
+  }
+  const target = controller.get_graphref_node();
+
+  test.deepEqual({
+    graphref: target.latin_name || target.ozid,
+    xp: round(controller.tree_state.xp),
+    yp: round(controller.tree_state.yp),
+    ws: round(controller.tree_state.ws),
+  }, {
+    graphref: node_latin_name,
+    xp: round(exp_xp),
+    yp: round(exp_yp),
+    ws: round(exp_ws),
+  }, "At " + node_latin_name + " - " + message);
+  exp_xp = round(exp_xp);
+}
+
+
+test('perform_actual_fly', function (test) {
+  var nodes = {};
+  
+  return populate_factory().then((factory) => {
+    // Gather some test points
+    return resolve_pinpoints([
+      '@biota=93302',
+      '@Dobsonia=988790',  // Bare-backed fruit bats
+      '@Acerodon=635024', // Flying foxes
+      '@Pteropus=813030', // Flying foxes
+      '@Pteralopex_atrata=164526', // Monkey-faced bat
+    ]).then((pps) => pps.forEach((pp) => {
+      nodes[pp.sciname] = factory.dynamic_loading_by_metacode(pp.ozid)
+    })).then(() => {
+      return factory;
+    });
+
+  }).then(function (factory) {
+    var controller = fake_controller(factory, 2000, 1000);
+    return Promise.resolve().then(() => {
+      return move_to(controller, nodes['Dobsonia'], {speed: Infinity}).then(() => {
+        test_cur_location(test, controller, "Laurasiatheria", 28826.0739, -18858.2284, 48.0688, "Retargeted, jumped");
+      });
+    }).then(() => {
+      return move_to(controller, nodes['biota'], {speed: Infinity}).then(() => {
+        test_cur_location(test, controller, "biota", 801.3117, 1170.5032, 1.5371, "Retargeted, jumped");
+      });
+    }).then(() => {
+      return move_to(controller, nodes['Dobsonia'], {speed: Infinity}).then(() => {
+        test_cur_location(test, controller, "Laurasiatheria", 28826.0739, -18858.2284, 48.0688, "Went back again, Dobsonia in same place");
+      });
+    }).then(() => {
+      return move_to(controller, nodes['Acerodon'], {speed: 1}).then(() => {
+        test_cur_location(test, controller, "Laurasiatheria", 42907.5839, -32331.2601, 79.3102, "Flights to nearby location");
+      });
+    }).then(() => {
+      return move_to(controller, nodes['Dobsonia'], {speed: 1}).then(() => {
+        test_cur_location(test, controller, "Laurasiatheria", 28826.0739, -18858.2284, 48.0688, "Flight back");
+      });
+    });
+
+  }).then(function () {
+    test.end();
+  }).catch(function (err) {
+    console.log(err.stack);
+    test.fail(err);
+    test.end();
+  })
+});
+
+
+test.onFinish(function() {
+  // NB: Something data_repo includes in is holding node open.
+  //     Can't find it so force our tests to end.
+  process.exit(0)
+});

--- a/OZprivate/rawJS/OZTreeModule/tests/test_tree_state.js
+++ b/OZprivate/rawJS/OZTreeModule/tests/test_tree_state.js
@@ -39,6 +39,24 @@ test('focal_area', function (test) {
     ymax: 900 - 900 * 0.025,
   }, "Applied border to 500x900");
 
+  tree_state.setup_canvas({ width: 2000, height: 1000 });
+  tree_state.constrain_focal_area(0.75, 0.66);
+  test_focal_area(test, {
+    xmin: 2000 * (1-0.75) + 2000 * 0.025,
+    xmax: 2000 - 2000 * 0.025,
+    ymin: 1000 * 0.025,
+    ymax: 1000 - 1000 * 0.025,
+  }, "Landscape: constrained by increasing xmin by 1-perc");
+
+  tree_state.setup_canvas({ width: 1000, height: 2000 });
+  tree_state.constrain_focal_area(0.75, 0.66);
+  test_focal_area(test, {
+    xmin: 1000 * 0.025,
+    xmax: 1000 - 1000 * 0.025,
+    ymin: 2000 * 0.025,
+    ymax: 2000 * (0.66) - 2000 * 0.025,
+  }, "Portrait: constrained by decreeasing xmax");
+
   test.end();
 });
 

--- a/OZprivate/rawJS/OZTreeModule/tests/test_tree_state.js
+++ b/OZprivate/rawJS/OZTreeModule/tests/test_tree_state.js
@@ -1,0 +1,50 @@
+/**
+  * Usage: npx babel-tape-runner OZprivate/rawJS/OZTreeModule/tests/test_tree_state.js
+  */
+import { populate_factory } from './util_factory'
+import test from 'tape';
+
+import tree_state from '../src/tree_state.js'
+
+function test_focal_area(test, expected, message) {
+  // Round first
+  expected.xmin = Math.round(expected.xmin);
+  expected.xmax = Math.round(expected.xmax);
+  expected.ymin = Math.round(expected.ymin);
+  expected.ymax = Math.round(expected.ymax);
+  
+  // Fill in derived values
+  expected.width = expected.xmax - expected.xmin;
+  expected.height = expected.ymax - expected.ymin;
+  expected.xcentre = (expected.xmax + expected.xmin) / 2;
+  expected.ycentre = (expected.ymax + expected.ymin) / 2;
+
+  test.deepEqual(tree_state.focal_area, expected, message);
+}
+
+test('focal_area', function (test) {
+  tree_state.setup_canvas({ width: 2000, height: 1000 });
+  test_focal_area(test, {
+    xmin: 2000 * 0.025,
+    xmax: 2000 - 2000 * 0.025,
+    ymin: 1000 * 0.025,
+    ymax: 1000 - 1000 * 0.025,
+  }, "Applied border to 2000x1000");
+
+  tree_state.setup_canvas({ width: 500, height: 900 });
+  test_focal_area(test, {
+    xmin: 500 * 0.025,
+    xmax: 500 - 500 * 0.025,
+    ymin: 900 * 0.025,
+    ymax: 900 - 900 * 0.025,
+  }, "Applied border to 500x900");
+
+  test.end();
+});
+
+
+test.onFinish(function() {
+  // NB: Something data_repo includes in is holding node open.
+  //     Can't find it so force our tests to end.
+  process.exit(0)
+});


### PR DESCRIPTION
Previously when flying to a node, the final state would be calculated so that the target bounding box (node or node+descendants) is contained by a box 95% of the size of the treeviewer.

We extract this 95% bounding box and turn it into the focal area, defined in tree_state. Then we add ``tree_state.constrain_focal_area()``, that can shrink the focal area by a given ratio, so flights will end with the node on the right 50% of the screen, e.g.

Finally, we allow tours to modify this with the ``data-focal-area`` attribute. This is a bit coarse, arguably it should be a query-string parameter that each tourstop is setting, but I'm not sure there's any practical use for that, especially with the current tourstop layout.

If there is then adding later wouldn't be a huge issue.

