### PR TITLE
models/db: Revert auto is_testing attempt in aa80e2db

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -150,6 +150,8 @@ npm ci --legacy-peer-deps
 ./node_modules/.bin/grunt prod
 ```
 
+Edit ``models/db.py``, and set ``is_testing = False``.
+
 Then run the install scripts to set up nginx & supervisord:
 
 ```

--- a/models/db.py
+++ b/models/db.py
@@ -20,8 +20,9 @@ from gluon import current
 ## Useful global variables
 #########################################################################
 
-# Running under rocket --> is_testing is true
-is_testing = (request.env.server_software or '').lower().startswith('rocket')
+## once in production, set is_testing=False to gain optimizations
+## this will also set migration=False for all tables, so that the DB table definitions are fixed
+is_testing = True
 
 ## Read configuration
 if is_testing and len(request.env.cmd_options.args) > 1 and os.path.isfile(request.env.cmd_options.args[-1]):
@@ -30,7 +31,7 @@ if is_testing and len(request.env.cmd_options.args) > 1 and os.path.isfile(reque
     # (on the main server this is not used, and we default back to appconfig.ini
     myconf = AppConfig(request.env.cmd_options.args[-1], reload=is_testing)
 else:
-    # NB: When running under rocket, re-load config every request with is_testing
+    # Reload config on each request when is_testing (i.e. not production)
     myconf = AppConfig(reload=is_testing)
 
 ## Configure i18n


### PR DESCRIPTION
@hyanwong I'm reverting my attempt to automagically get ``is_testing`` right. The unit tests don't run under rocket (obviously) so weren't running. This could have been fixed, but there's no way that the "don't run the unit tests on production" interlock could have worked, we just don't know.

Maybe we could do something as part of ``grunt prod`` in the future, but I'm probably causing enough havoc as it is :)