### PR TITLE
Support wikimedia video

### DIFF
--- a/OZprivate/rawJS/OZTreeModule/src/tour/Tour.js
+++ b/OZprivate/rawJS/OZTreeModule/src/tour/Tour.js
@@ -44,7 +44,7 @@
  * * ``data-stop_wait``: Wait at tourstop for (stop_wait) milliseconds, then automatically move on. By default wait for user to press "next"
  *
  * Other modules provide extra functionality useful when writing tours, in particular:
- * * {@link tour/handler/HtmlAudio} Autoplays/stops ``<audio>`` in a tourstop based on ``data-ts_autoplay``.
+ * * {@link tour/handler/HtmlAV} Autoplays/stops HTML ``<audio>`` / ``<video>`` in a tourstop based on ``data-ts_autoplay``.
  * * {@link tour/handler/QsOpts} Applies/reverts tree state based on ``data-qs_opts``, e.g. highlights, colour schemes, language.
  * * {@link tour/handler/UiEvents} Behavioural CSS classes to add to tour forward/backward/etc buttons.
  * * {@link tour/handler/TsProgress} Individual links to tourstops, showing currently visited stops.
@@ -54,7 +54,7 @@
  *
  * @module tour/Tour
  */
-import handler_htmlaudio from './handler/HtmlAudio';
+import handler_htmlav from './handler/HtmlAV';
 import handler_qsopts from './handler/QsOpts';
 import handler_uievents from './handler/UIEvents';
 import handler_tsprogress from './handler/TsProgress';
@@ -250,7 +250,7 @@ class Tour {
           this.pinpoint_to_ozid[pp.pinpoint] = pp.ozid;
         });
       }),
-      handler_htmlaudio(this),
+      handler_htmlav(this),
       handler_qsopts(this),
       handler_tsprogress(this),
       handler_vimeo(this),

--- a/OZprivate/rawJS/OZTreeModule/src/tour/handler/HtmlAV.js
+++ b/OZprivate/rawJS/OZTreeModule/src/tour/handler/HtmlAV.js
@@ -1,5 +1,5 @@
 /**
- * Add autoplay functionality for HTML audio in tourstops.
+ * Add autoplay functionality for HTML video/audio in tourstops.
  *
  * Designed to be used with ``applications.OZtree.modules.embed:media_embed``, i.e.
  *
@@ -8,25 +8,26 @@
  *       <div class="container">{{=XML(media_embed(url, ts_autoplay='tsstate-active_wait'))}}</div>
  *     </div>
  *
+ * See {@link https://developer.mozilla.org/en-US/docs/Web/HTML/Element/video}
  * See {@link https://developer.mozilla.org/en-US/docs/Web/HTML/Element/audio}
  */
 function handler(tour) {
-  const el_audios = Array.from(tour.container[0].querySelectorAll(":scope audio"));
+  const el_avs = Array.from(tour.container[0].querySelectorAll(":scope audio,:scope video"));
 
   // No vimeo, stop here.
-  if (el_audios.length === 0) return;
+  if (el_avs.length === 0) return;
 
   // Add reference to tourstop from embedded iframe
-  el_audios.forEach((el) => {
+  el_avs.forEach((el) => {
     el.el_tourstop = el.closest('.tour > .container');
-    el.el_tourstop.classList.add('contains-httpaudio');
+    el.el_tourstop.classList.add('contains-httpav');
     // Split attribute into array, filter off empty entries (i.e. when attribute itself is empty)
     el.autoplay_states = (el.getAttribute('data-ts_autoplay') || '').split(" ").filter(x => x);
   });
 
   return Promise.resolve().then(() => {
     // Attach events to block progression when playing
-    return el_audios.forEach((el) => {
+    return el_avs.forEach((el) => {
       el.addEventListener('play', (e) => {
         const tourstop = e.target.el_tourstop.tourstop;
         const block_name = event.target.src;
@@ -43,9 +44,9 @@ function handler(tour) {
       });
     })
   }).then(() => {
-    // Attach observers for any autoplaying audio
-    tour.tourstop_observer('.contains-httpaudio', '*', (tour, tourstop, el_ts) => {
-      el_ts.querySelectorAll(":scope audio").forEach((el) => {
+    // Attach observers for any autoplaying AV
+    tour.tourstop_observer('.contains-httpav', '*', (tour, tourstop, el_ts) => {
+      el_ts.querySelectorAll(":scope audio,:scope video").forEach((el) => {
         if (window.getComputedStyle(el_ts).visibility !== 'visible') {
           // Shouldn't ever play whilst invisible
           el.pause();

--- a/modules/embed.py
+++ b/modules/embed.py
@@ -92,6 +92,19 @@ def media_embed(url, **kwargs):
             element_data=element_data,
         )
 
+    # https://commons.wikimedia.org/wiki/Commons:File_types#Video
+    m = re.fullmatch(r'https://commons.wikimedia.org/wiki/File:(.+\.(ogv|webm|mpg|mpeg))', url)
+    if m:
+        # NB: There's an embedded player we could use, but there's no way to control it over the iframe barrrier
+        return """<div class="embed-video"><video controls
+          src="https://commons.wikimedia.org/w/index.php?title=Special:Redirect/file/{name}"
+          {element_data}
+          ></video><a class="copyright" href="{url}">©</a></div>""".format(
+            title=m.group(1),
+            name=m.group(1),
+            url=url,
+            element_data=element_data,
+        )
 
     # Fall back to linking
     return """<a href="{url}" style="font-weight:bold">{url}</a>""".format(

--- a/tests/unit/test_modules_embed.py
+++ b/tests/unit/test_modules_embed.py
@@ -106,6 +106,16 @@ class TestEmbed(unittest.TestCase):
             'title="title">©</a></div>',
         ])
 
+        self.assertEqual(media_embed('https://commons.wikimedia.org/wiki/File:Intense_bone_fluorescence_reveals_hidden_patterns_in_pumpkin_toadlets_-_video_1_-_41598_2019_41959_MOESM2_ESM.webm'), [
+            '<div',
+            'class="embed-video"><video',
+            'controls',
+            'src="https://commons.wikimedia.org/w/index.php?title=Special:Redirect/file/Intense_bone_fluorescence_reveals_hidden_patterns_in_pumpkin_toadlets_-_video_1_-_41598_2019_41959_MOESM2_ESM.webm"',
+            '></video><a',
+            'class="copyright"',
+            'href="https://commons.wikimedia.org/wiki/File:Intense_bone_fluorescence_reveals_hidden_patterns_in_pumpkin_toadlets_-_video_1_-_41598_2019_41959_MOESM2_ESM.webm">©</a></div>',
+        ])
+
 if __name__ == '__main__':
     import sys
 


### PR DESCRIPTION
This creates ``<video>`` tags for any wikimedia video, as we currently do with audio.

As their API is identical, we can support autoplay for both audio and video by renaming the HTML audio handler.

This means the video in @jrosindell 's frogs tour should now work.

Fixes #721 