### PR TITLE
Support "new" tours in homepage startpoints

### DIFF
--- a/controllers/default.py
+++ b/controllers/default.py
@@ -12,6 +12,7 @@ import json
 from collections import OrderedDict
 
 import ozmail
+import tour
 from embed import embedize_url
 from sponsorship import (
     sponsorship_enabled, reservation_total_counts, clear_reservation, get_reservation,
@@ -80,17 +81,20 @@ def index():
             carousel.append(key)
         elif r.category == 'homepage_red':
             threatened.append(key)
+
+        text_titles[key] = ""
         if r.image_url:
             images[key] = {'url': r.image_url}
-        if r.tour_identifier:
-            hrefs[key] = URL('life/' + r.tour_identifier)
-            title = db(db.tours.identifier == r.tour_identifier).select(db.tours.name).first()
-            text_titles[key] = title.name if title else r.tour_identifier
-        else:
-            text_titles[key] = ""
         if r.ott:
-            # We might still want to find e.g. an image, even if we are looking at a tour
             startpoints_ott_map[r.ott] = key
+
+        if r.tour_identifier:
+            t = db(db.tour.identifier == r.tour_identifier).select(db.tour.ALL).first()
+
+            text_titles[key] = t.title or r.tour_identifier
+            hrefs[key] = URL('life', vars = dict(tour = tour.tour_url(t)))
+            if t.image_url:
+                images[key] = {'url': img.url(t.image_url)}
 
     # Pick 5 random threatened spp 
     random.seed(request.now.month*100 + request.now.day)

--- a/controllers/default.py
+++ b/controllers/default.py
@@ -74,27 +74,27 @@ def index():
             (db.tree_startpoints.partner_identifier == None)
         ).select(
             db.tree_startpoints.ott, db.tree_startpoints.category,
-            db.tree_startpoints.image_url, db.tree_startpoints.tour_identifier,
+            db.tree_startpoints.image_url,
+            db.tour.ALL,
+            left=db.tour.on(db.tree_startpoints.tour_identifier == db.tour.identifier),
             orderby = db.tree_startpoints.id):
-        key = r.tour_identifier or str(r.ott)
-        if r.category == 'homepage_main':
+        key = r.tour.identifier or str(r.tree_startpoints.ott)
+        if r.tree_startpoints.category == 'homepage_main':
             carousel.append(key)
-        elif r.category == 'homepage_red':
+        elif r.tree_startpoints.category == 'homepage_red':
             threatened.append(key)
 
         text_titles[key] = ""
-        if r.image_url:
-            images[key] = {'url': r.image_url}
-        if r.ott:
-            startpoints_ott_map[r.ott] = key
+        if r.tree_startpoints.image_url:
+            images[key] = {'url': r.tree_startpoints.image_url}
+        if r.tree_startpoints.ott:
+            startpoints_ott_map[r.tree_startpoints.ott] = key
 
-        if r.tour_identifier:
-            t = db(db.tour.identifier == r.tour_identifier).select(db.tour.ALL).first()
-
-            text_titles[key] = t.title or r.tour_identifier
-            hrefs[key] = URL('life', vars = dict(tour = tour.tour_url(t)))
-            if t.image_url:
-                images[key] = {'url': img.url(t.image_url)}
+        if r.tour.identifier:
+            text_titles[key] = r.tour.title or r.tour.identifier
+            hrefs[key] = URL('life', vars = dict(tour = tour.tour_url(r.tour)))
+            if r.tour.image_url:
+                images[key] = {'url': img.url(r.tour.image_url)}
 
     # Pick 5 random threatened spp 
     random.seed(request.now.month*100 + request.now.day)

--- a/controllers/default.py
+++ b/controllers/default.py
@@ -227,12 +227,6 @@ def footer_sponsor_items():
     return dict()
 
 
-def homepage_animation_template():
-    """
-    The html fragment used as a template for the embedded animation on the homepage
-    """
-    return dict()
-
 @require_https_if_nonlocal()
 def user():
     """

--- a/controllers/tour.py
+++ b/controllers/tour.py
@@ -76,21 +76,16 @@ import tour
 def homepage_animation():
     # OTTs from the tree_startpoints table
     startpoints_ott_map, hrefs, titles, text_titles = {}, {}, {}, {}
-    carousel, anim, threatened = [], [], []
+    anim = []
     for r in db(
-            (db.tree_startpoints.category.startswith('homepage')) &
+            (db.tree_startpoints.category == 'homepage_anim') &
             (db.tree_startpoints.partner_identifier == None)
         ).select(
             db.tree_startpoints.ott, db.tree_startpoints.category,
             db.tree_startpoints.image_url, db.tree_startpoints.tour_identifier,
             orderby = db.tree_startpoints.id):
         key = r.tour_identifier or str(r.ott)
-        if r.category.endswith("main"):
-            carousel.append(key)
-        elif r.category.endswith("anim"):
-            anim.append(key)
-        elif r.category.endswith("red"):
-            threatened.append(key)
+        anim.append(key)
         if r.tour_identifier:
             hrefs[key] = URL('default', 'life/' + r.tour_identifier)
             title = db(db.tours.identifier == r.tour_identifier).select(db.tours.name).first()


### PR DESCRIPTION
The homepage did support tour startpoints, but it hadn't been updated for some time, and was expecting an old DB structure.

With this, we can add tours into the "tour_identifier" field, and they populate in the carousel.

Fixes #545 