### PR TITLE
Tour search

### DIFF
--- a/OZprivate/rawJS/OZTreeModule/docs/JSinterface.markdown
+++ b/OZprivate/rawJS/OZTreeModule/docs/JSinterface.markdown
@@ -80,10 +80,6 @@ This contains all the data stored in an instance (e.g. id2ott mapping, tree?)
 ### onezoom.config
 {{src/global_config.md}}
 
-### onezoom.search_manager
-
-{{src/api/search_manager.md}}
-
 ##Prerequisites
 
 The data fed into the 

--- a/OZprivate/rawJS/OZTreeModule/src/OZentry.js
+++ b/OZprivate/rawJS/OZTreeModule/src/OZentry.js
@@ -4,7 +4,6 @@ import 'babel-polyfill';
 import './libs/requestAnimationFrame';
 import get_controller from './controller/controller';
 import api_manager from './api/api_manager';
-import search_manager from './api/search_manager';
 import process_taxon_list from './api/process_taxon_list';
 import { init as garbage_collection_start } from './factory/garbage_collection';
 import { spec_num_full, number_convert, view_richness } from './factory/utils'
@@ -108,7 +107,6 @@ function setup(
 
   oz.controller.public_oz = oz;  // Let the controller get at the public interface
   oz.config = config;
-  oz.search_manager = search_manager;
   oz.add_hook = add_hook;
 
   // use setTimeout so that loading screen is displayed before build tree starts.
@@ -139,18 +137,4 @@ function setup(
   return oz;
 }
 
-/**
- * This function returns an object containing API helpers
- * User can use this object to call API helpers without creating a OneZoom instance.
- * 
- * @param {Object} server_urls - A named key:value dict of urls that the api manager etc needs to fire
- *     off AJAX requests. See global_config.js for the list of necessary names
- */
-function api_utils_setup(server_urls) {
-  api_manager.set_urls(server_urls)
-  return {
-    search_manager: search_manager,
-  }
-}
-
-export {setup as default, api_utils_setup};
+export { setup as default };

--- a/OZprivate/rawJS/OZTreeModule/src/OZentry.js
+++ b/OZprivate/rawJS/OZTreeModule/src/OZentry.js
@@ -109,8 +109,6 @@ function setup(
   oz.controller.public_oz = oz;  // Let the controller get at the public interface
   oz.config = config;
   oz.search_manager = search_manager;
-  // TO DO - use data_repo passed in to the entry function, so we don't need to include it in the initial JS
-  oz.search_manager.add_data_repo(oz.data_repo);
   oz.add_hook = add_hook;
 
   // use setTimeout so that loading screen is displayed before build tree starts.

--- a/OZprivate/rawJS/OZTreeModule/src/OZentry.js
+++ b/OZprivate/rawJS/OZTreeModule/src/OZentry.js
@@ -150,7 +150,6 @@ function api_utils_setup(server_urls) {
   api_manager.set_urls(server_urls)
   return {
     search_manager: search_manager,
-    process_taxon_list: process_taxon_list
   }
 }
 

--- a/OZprivate/rawJS/OZTreeModule/src/OZui.js
+++ b/OZprivate/rawJS/OZTreeModule/src/OZui.js
@@ -1,9 +1,9 @@
 import search_manager from './ui/search_manager';
-import { searchPopulate } from './ui/search.js';
+import { searchPopulate, setup_location_list } from './ui/search.js';
 import { fullLeafBase, fullLeaf, natural_theme } from './ui/leaf_draw.js';
 import { sortList, teaseTour } from './ui/tours_list.js';
 
-export { search_manager, searchPopulate };
+export { search_manager, searchPopulate, setup_location_list };
 
 export const leaf_draw = {
   fullLeafBase: fullLeafBase,

--- a/OZprivate/rawJS/OZTreeModule/src/OZui.js
+++ b/OZprivate/rawJS/OZTreeModule/src/OZui.js
@@ -1,4 +1,4 @@
-import search_manager from './api/search_manager';
+import search_manager from './ui/search_manager';
 import { searchPopulate } from './ui/search.js';
 import { fullLeafBase, fullLeaf, natural_theme } from './ui/leaf_draw.js';
 import { sortList, teaseTour } from './ui/tours_list.js';

--- a/OZprivate/rawJS/OZTreeModule/src/OZui.js
+++ b/OZprivate/rawJS/OZTreeModule/src/OZui.js
@@ -1,8 +1,9 @@
+import search_manager from './api/search_manager';
 import { searchPopulate } from './ui/search.js';
 import { fullLeafBase, fullLeaf, natural_theme } from './ui/leaf_draw.js';
 import { sortList, teaseTour } from './ui/tours_list.js';
 
-export { searchPopulate };
+export { search_manager, searchPopulate };
 
 export const leaf_draw = {
   fullLeafBase: fullLeafBase,

--- a/OZprivate/rawJS/OZTreeModule/src/api/api_manager.js
+++ b/OZprivate/rawJS/OZTreeModule/src/api/api_manager.js
@@ -71,7 +71,23 @@ class APIManager {
       });
     }).then((data) => data.tours);
   }
-  
+
+  /**
+   * Call /tour/search.json?query=(searchString)
+   * @return Promise of parsed result
+   */
+  tour_search(searchString) {
+    return new Promise((resolve, reject) => {
+      api_wrapper({
+        method: 'get',
+        url: '/tour/search.json',
+        data: { query: searchString },
+        success: resolve,
+        error: (res) => reject("Failed to talk to server: " + res),
+      });
+    }).then((data) => data.results);
+  }
+
   /**
    * @params {String} query
    */

--- a/OZprivate/rawJS/OZTreeModule/src/api/search_manager.js
+++ b/OZprivate/rawJS/OZTreeModule/src/api/search_manager.js
@@ -14,6 +14,14 @@ class SearchManager {
     this.search_timer = null;
     this.last_search = null;
   }
+
+  /**
+   * Configure the URLs to use when searching
+   */
+  set_urls(server_urls) {
+    api_manager.set_urls(server_urls);
+    this._urls_configured = true;
+  }
     
   /**
    * The main function for carrying out text string searches
@@ -25,6 +33,10 @@ class SearchManager {
    * @param {function} onSend - the function that gets executed when the search has been sent to the server
    */
   full_search(toSearchFor, callback, search_delay=400, onSend=null) {
+    // If not yet configured, look for configuration in global environment
+    if (!this._urls_configured && global.window && window.server_urls) {
+      this.set_urls(window.server_urls);
+    }
     
     if ((!this.last_search)||(this.last_search != toSearchFor))
     {

--- a/OZprivate/rawJS/OZTreeModule/src/api/search_manager.js
+++ b/OZprivate/rawJS/OZTreeModule/src/api/search_manager.js
@@ -14,15 +14,6 @@ class SearchManager {
     this.search_timer = null;
     this.last_search = null;
   }
-
-  /**
-   * Add a data repo, which reduces the number of future requests that might be made when 
-   * navigating around the tree. Only really useful when there is a OneZoom canvas present.
-   * @param {Object} data_repo - If given, cache search results in this data repo
-   */
-  add_data_repo(data_repo) {
-    this.data_repo = data_repo;
-  }
     
   /**
    * The main function for carrying out text string searches

--- a/OZprivate/rawJS/OZTreeModule/src/controller/controller_highlight.js
+++ b/OZprivate/rawJS/OZTreeModule/src/controller/controller_highlight.js
@@ -28,7 +28,7 @@ export default function (Controller) {
     ).then((highlights) => {
       highlight_update(this.root, highlights);
       this.trigger_refresh_loop();
-      return highlights[0];
+      return highlights[highlights.length - 1];
     });
   };
 
@@ -37,7 +37,7 @@ export default function (Controller) {
    * @param highlight_str Highlight string, see src/projection/highlight/highlight.js for definition
    */
   Controller.prototype.highlight_remove = function (highlight_str) {
-      highlight_update(this.root, current_highlights().filter((h) => h.str === highlight_str));
+      highlight_update(this.root, current_highlights().filter((h) => h.str !== highlight_str));
       this.trigger_refresh_loop();
 
       return Promise.resolve();

--- a/OZprivate/rawJS/OZTreeModule/src/controller/controller_search.js
+++ b/OZprivate/rawJS/OZTreeModule/src/controller/controller_search.js
@@ -7,50 +7,6 @@ import config from '../global_config';
 
 export default function (Controller) {
       
-  /**
-   * Add marked area by OZid
-   * @param OZid_to_mark is the OneZoom id of the node / leaf that should be marked
-   * @param area_code is the code that we want to associate with this marked area, if 
-   *    nothing is entered we identify the area with the ID as given by OZid_to_mark
-   * @param mark_color should give the color to use for marking. If null the system will
-   *    select a new color from the theme colour palette
-   */
-    Controller.prototype.mark_area = function(OZid_to_mark,area_code,mark_color) {
-        if (area_code) throw new Error("area_code no longer supported");
-
-        return this.highlight_add('path:' + (mark_color || '') + '@_ozid=' + OZid_to_mark).then(function (mark) {
-          return mark.color;
-        });
-    }
-    
-    /**
-     * Remove marked area by area codes
-     * @param OZid_to_mark is the OneZoom id of the node / leaf that should be unmarked
-     */
-    Controller.prototype.unmark_area = function(OZid_to_mark) {
-        if (area_code) throw new Error("area_code no longer supported");
-
-        return this.highlight_remove('path:' + (mark_color || '') + '@_ozid=' + OZid_to_mark);
-    }
-    
-    /**
-     * Remove all marked areas
-     */
-    Controller.prototype.clear_all_marked_areas = function() {
-        return this.highlight_replace([]);
-    }
-    
-    /**
-     * Returns marked area list, as expected by advanced_search UI
-     */
-    Controller.prototype.list_all_marked = function() {
-        return this.highlight_detail().filter((h) => {
-          return h.type === 'path' && h.ozids[0] === 1;
-        }).map((h) => {
-          return [h.ozids[1], h.color];
-        });
-    }
-    
     /**
      * A higher level function, which moves to the given location using
      * whatever move method is defined as the default (in config.search_jump_mode).

--- a/OZprivate/rawJS/OZTreeModule/src/controller/controller_search.js
+++ b/OZprivate/rawJS/OZTreeModule/src/controller/controller_search.js
@@ -11,14 +11,12 @@ export default function (Controller) {
      * A higher level function, which moves to the given location using
      * whatever move method is defined as the default (in config.search_jump_mode).
      * @param dest Where we want to go to
-     * @param input_type How is (dest) defined? 'ozid', 'pinpoint', 'ancestor' (dest is a list of pinpoints). Defaults to 'pinpoint'
+     * @param input_type How is (dest) defined? 'pinpoint' or 'ancestor' (dest is a list of pinpoints). Defaults to 'pinpoint'
      */
     Controller.prototype.default_move_to = function(dest, input_type) {
         var p;
 
-        if (input_type === 'ozid') {
-          p = Promise.resolve({ozid: dest});
-        } else if (input_type === 'ancestor') {
+        if (input_type === 'ancestor') {
           p = resolve_pinpoints(dest).then((pinpoints) => {
             // After resolving pinpoints, find the common ancestor and use that
             // NB: This returns a node, not a pinpoint object. But has an ozid property just the same

--- a/OZprivate/rawJS/OZTreeModule/src/tour/TourStop.js
+++ b/OZprivate/rawJS/OZTreeModule/src/tour/TourStop.js
@@ -21,7 +21,6 @@ class TourStopClass {
     this.blocks = new Set()
     this.tour = tour
     this.controller = this.tour.onezoom.controller
-    this.data_repo = this.tour.onezoom.data_repo
     this.container = container
     container[0].tourstop = this  // Add a link back from the DOM element to the class
     this.goto_next_timer = null

--- a/OZprivate/rawJS/OZTreeModule/src/ui/search.js
+++ b/OZprivate/rawJS/OZTreeModule/src/ui/search.js
@@ -71,7 +71,7 @@ function searchPopulate(searchbox, original_search, search_result, click_callbac
             if (window.is_testing) { console.log("Hiding no_result section of dropdown"); }
             $('.no_results', dropdown).hide();
             if (!is_sponsored(search_result[0])) {
-                $(".search_hits", dropdown).append($('<dt></dt>').text(OZstrings['NameHits']))
+                $(".search_hits", dropdown).append($('<dt></dt>').text(OZstrings['Search results']))
             }
             var sponsored=false;
             $.each(search_result, function(index) {

--- a/OZprivate/rawJS/OZTreeModule/src/ui/search.js
+++ b/OZprivate/rawJS/OZTreeModule/src/ui/search.js
@@ -63,27 +63,43 @@ function searchPopulate(searchbox, original_search, search_result) {
         if (window.is_testing) { console.log("Hiding popular species section of dropdown"); }
         $('.popular_species', dropdown).hide();
         $('.search_hits', dropdown).empty();
-        if (search_result.length == 0) {
+        if (search_result.tree.length + search_result.tour.length == 0) {
             $('.no_results', dropdown).show();
         } else {
             if (window.is_testing) { console.log("Hiding no_result section of dropdown"); }
             $('.no_results', dropdown).hide();
-            if (!is_sponsored(search_result[0])) {
-                $(".search_hits", dropdown).append($('<dt></dt>').text(OZstrings['Search results']))
-            }
-            var sponsored=false;
-            $.each(search_result, function(index) {
+
+            $.each(search_result.tour, function(index) {
+                var result = this;
+                console.log(result);
+
+                if (index === 0) {
+                    $(".search_hits", dropdown).append($('<dt>').text(OZstrings['Tours']));
+                }
+                $(".search_hits", dropdown).append($('<dd>')
+                    .attr("data-href", result.href)
+                    .append($('<a>')
+                        .attr("href", '?tour=' + encodeURIComponent(result.url))
+                        .text(result.title) ));
+            });
+
+            var prev_sponsored = null;  // NB: Always show a header at start
+            $.each(search_result.tree, function(index) {
+                 var result = this;
+
                  if (index==200) {
                     //we have shown 200 items already
                     $(".search_hits", dropdown).append(
                         $('<dd></dd>').html("<em>(only showing top 200 hits)</em>"))
                     return false
                  }
-                 var result = this;
-                 if ((sponsored==false) && (is_sponsored(result))) {
-                 $(".search_hits", dropdown).append($('<dt class="sponsorhits"></dt>').html(OZstrings['SponsorHits']))
-                 sponsored=true;
+
+                 // Append header when section type changes
+                 if (prev_sponsored === null || prev_sponsored !== is_sponsored(result)) {
+                     prev_sponsored = is_sponsored(result);
+                     $(".search_hits", dropdown).append($('<dt></dt>').text(OZstrings[prev_sponsored ? 'SponsorHits' : 'Search results']));
                  }
+
                  var tempHTML = compile_names(result);
                  tempHTML += compile_extra(result);
                  $(".search_hits", dropdown).append(

--- a/OZprivate/rawJS/OZTreeModule/src/ui/search.js
+++ b/OZprivate/rawJS/OZTreeModule/src/ui/search.js
@@ -91,7 +91,6 @@ function searchPopulate(searchbox, original_search, search_result) {
                                                     // Attach compile_searchbox_data() results to reconstitute on advanced_search_box click
                                                     .attr("data-vernacular", result[0])
                                                     .attr("data-sciname", result[1])
-                                                    .attr("data-OZid", result[2])
                                                     .attr("data-pinpoint", result.pinpoint)
                                                     .html(tempHTML));
                  })
@@ -120,7 +119,6 @@ function setup_location_list(target, locations_json) {
         // Attach compile_searchbox_data()-esque results to reconstitute on advanced_search_box click
         .attr("data-vernacular", taxon.vernacular)
         .attr("data-sciname", taxon.sciname)
-        .attr("data-OZid", taxon.ozid)
         .attr("data-pinpoint", '@=' + taxon.ott)
         .html($('<p>').html($('<a>')
           .attr('href', taxon.href)

--- a/OZprivate/rawJS/OZTreeModule/src/ui/search.js
+++ b/OZprivate/rawJS/OZTreeModule/src/ui/search.js
@@ -103,4 +103,45 @@ function searchPopulate(searchbox, original_search, search_result, click_callbac
     }
 }
 
-export { searchPopulate };
+/* Add a set of species (e.g. popular species) to a target list,
+ * by using the onezoom.utils.process_taxon_list() function
+ * to map OTT ids to OneZoom IDs / vernacular names.
+ * The parameter 'click_callback_id_name' should be a
+ * callback that is fired when an item is clicked on in the list
+ * (called with event, OZid, item_name, sci_name, dropdown)
+ */
+function setup_location_list(target, locations_json, click_callback_id_name) {
+    target.empty();
+    onezoom.utils.process_taxon_list(
+        locations_json,
+        function(ott, result) {
+            // Reconstitute compile_searchbox_data() format
+            var given_name = result[0],
+                sciname = result[1],
+                OZid = result[2];
+
+            if (OZid) {
+                target.append(
+                    $('<dd>').html(
+                        $('<p>')
+                            .html(given_name?$('<span></span>').text(given_name):$('<i></i>').text(sciname))
+                            .addClass('taxon_location_button')
+                            .attr("draggable","true")
+                            .attr("id",'menuitem'+OZid.toString())
+                            .attr("data-OZid",OZid.toString())
+                            .data('result', result)
+                            .click(function(event) {
+                                click_callback_id_name(event, result);
+                            })
+                            .on('dragstart', function(event){
+                                 event.originalEvent.dataTransfer.setData('drop_id', $(this).attr('id'));
+                                 event.originalEvent.dataTransfer.setData('taxon', true);
+                            })
+                    )
+                );
+            }
+        },
+        function(header) {target.append($('<dt>').text(OZstrings.hasOwnProperty(header)?OZstrings[header]:header))});
+}
+
+export { searchPopulate, setup_location_list };

--- a/OZprivate/rawJS/OZTreeModule/src/ui/search_manager.js
+++ b/OZprivate/rawJS/OZTreeModule/src/ui/search_manager.js
@@ -144,6 +144,11 @@ class SearchManager {
    * @param {string} image_source - 'best_verified', 'best_pd', or 'best_any'
    */
   lookup_nodes(node_ids, callback, image_source) {
+    // If not yet configured, look for configuration in global environment
+    if (!this._urls_configured && global.window && window.server_urls) {
+      this.set_urls(window.server_urls);
+    }
+
     let nodes_searched_for = node_ids.splice(0,400);
     let leaves_arr = nodes_searched_for.filter(x => !isNaN(x) && x < 0).map(Math.abs);
     let nodes_arr  = nodes_searched_for.filter(x => !isNaN(x) && x > 0);

--- a/OZprivate/rawJS/OZTreeModule/src/ui/search_manager.js
+++ b/OZprivate/rawJS/OZTreeModule/src/ui/search_manager.js
@@ -1,5 +1,5 @@
 import api_manager from '../api/api_manager';
-import node_details_api from './node_details';
+import node_details_api from '../api/node_details';
 import { node_to_pinpoint } from '../navigation/pinpoint';
 import {capitalizeFirstLetter, max} from '../util/index'; // basic tools
 

--- a/OZprivate/rawJS/OZTreeModule/src/ui/search_manager.js
+++ b/OZprivate/rawJS/OZTreeModule/src/ui/search_manager.js
@@ -38,9 +38,9 @@ class SearchManager {
       this.set_urls(window.server_urls);
     }
     
-    if ((!this.last_search)||(this.last_search != toSearchFor))
-    {
-      
+    // If the last search was the same, don't do anything
+    if ( this.last_search && this.last_search === toSearchFor ) return;
+
     clearTimeout(this.search_timer);
     let originalSearch = toSearchFor; // we want to return the original search string back to the UI.
     // detect if the search string has something in relating to sponsorship and catch that after running the text through the translation services.
@@ -59,38 +59,22 @@ class SearchManager {
         if (toSearchFor.length == 0) return; // no point searching for nothing
         
         // this is a time out for the search
-        this.search_timer = setTimeout(function() {
+        this.search_timer = setTimeout(() => {
             if (onSend) onSend(); // this informs the UI that an API request has now been made.
-            // this calls the API
-            api_manager.search({
-                dont_resend: true,
-                data: {
-                query: toSearchFor
-                },
-                success: function(res) {
-                // this sorts the results
-                    this.last_search = null;
-                    let newRes1 = self.populateByNodeResults(toSearchFor, res.nodes);
-                    // this calls the API again for sponsor search
-                    self.searchForSponsor(toSearchFor, function(res) {
-                        let newRes = newRes1.concat(res);
-                        // sort the results based on quality retuned with the search results.
-                        // this sorts the results
-                        newRes.sort(function(a, b) {
-                            if (a[3] < b[3]) {
-                                return 1;
-                            } else if (a[3] == b[3]) {
-                                return 0;
-                            } else {
-                                return -1;
-                            }
-                        });
-                        callback(originalSearch,toSearchFor,newRes);
-                    }, "all");
-                }
+
+            return Promise.all([
+                this.searchForTree(toSearchFor),
+                new Promise((resolve) => this.searchForSponsor(toSearchFor, resolve)),
+            ]).then((data) => {
+                this.last_search = null;
+                let res = self.populateByNodeResults(toSearchFor, data[0].nodes);
+                res = res.concat(data[1]);
+                // Sort the results based on quality retuned with the search results.
+                res.sort((a, b) => a[3] < b[3] ? 1 : a[3] == b[3]? 0 : -1);
+
+                return callback(originalSearch, toSearchFor, res);
             });
         }, search_delay);
-    }
     }
   }
   // Notes: the Python server side API calls to server throws out punctuation except for 
@@ -98,6 +82,19 @@ class SearchManager {
   // It will also sort out what happens if only 2 characters are requested by requiring exact match to return anything.
   // It will also strip out leading spaces and punctations on the search for sponsors only
     
+  /**
+   * Search on tree for (toSearchFor)
+   */
+  searchForTree(toSearchFor) {
+    return new Promise((resolve) => {
+      api_manager.search({
+        dont_resend: true,
+        data: { query: toSearchFor },
+        success: resolve,
+      });
+    });
+  }
+
   /**
    * Search specifically within sponsorship fields.
    * @param {string} toSearchFor - the string to search for within sponsor fields (name, message)

--- a/OZprivate/rawJS/OZTreeModule/src/ui/search_manager.js
+++ b/OZprivate/rawJS/OZTreeModule/src/ui/search_manager.js
@@ -65,6 +65,7 @@ class SearchManager {
             return Promise.all([
                 this.searchForTree(toSearchFor),
                 new Promise((resolve) => this.searchForSponsor(toSearchFor, resolve)),
+                api_manager.tour_search(toSearchFor),
             ]).then((data) => {
                 this.last_search = null;
                 let res = self.populateByNodeResults(toSearchFor, data[0].nodes);
@@ -72,7 +73,10 @@ class SearchManager {
                 // Sort the results based on quality retuned with the search results.
                 res.sort((a, b) => a[3] < b[3] ? 1 : a[3] == b[3]? 0 : -1);
 
-                return callback(originalSearch, toSearchFor, res);
+                return callback(originalSearch, toSearchFor, {
+                    tree: res,
+                    tour: data[2],
+                });
             });
         }, search_delay);
     }

--- a/controllers/tour.py
+++ b/controllers/tour.py
@@ -300,3 +300,19 @@ def list():
             out['rest'].append(t)
 
     return out
+
+
+def search():
+    session.forget(response)
+    language = request.vars.lang or request.env.http_accept_language or 'en'
+    searchFor = request.vars.query
+
+    results = tour.tour_search(searchFor, language)
+    for t in results:
+        # Splice in tour_url to DB row
+        t['url'] = tour.tour_url(t)
+
+    return dict(
+        lang=language,
+        results=results.as_list(),
+    )

--- a/modules/OZfunc.py
+++ b/modules/OZfunc.py
@@ -508,8 +508,8 @@ def nodes_info_from_string(
             sql = query7.format(otts=ott_ids)
             reservations_res = db.executesql(sql)
 
+    tours_res = []
     if len(leafOtts) or len(nodeOtts):
-        tours_res = []
         if include_tours_by_ott:
             for ott, tours in tours_related_to_ott(leafOtts | nodeOtts, full_meta=False).items():
                 tours_res.append([ott, [t.identifier for t in tours]])

--- a/modules/tour.py
+++ b/modules/tour.py
@@ -21,3 +21,27 @@ def tours_related_to_ott(otts, full_meta=False):
 def tour_url(tour_row):
     """Convert tour row to a tour URL"""
     return '/tour/data.html/%s' % tour_row.identifier
+
+
+def tour_search(searchFor, language='en'):
+    """Find all tours matching free-text (query)"""
+    db = current.db
+    lang_primary = language.split(',')[0].split("-")[0].lower()
+
+    query = (db.tour.lang == lang_primary)
+    for w in searchFor.replace("%","").replace("_", " ").split():
+        if len(w) < 3:
+            # Ignore stop words
+            next
+
+        # Add query item for each search term
+        query = query & (
+            # http://web2py.com/books/default/chapter/29/06/the-database-abstraction-layer#like-ilike-regexp-startswith-endswith-contains-upper-lower
+            db.tour.title.contains(w, case_sensitive=False) |
+            db.tour.description.contains(w, case_sensitive=False) |
+            # http://web2py.com/books/default/chapter/29/06/the-database-abstraction-layer#list-type-and-contains
+            db.tour.keywords.contains(w, case_sensitive=False) |
+            False
+        )
+
+    return db(query).select(db.tour.ALL, orderby=(db.tour.title))

--- a/tests/benchmarking/API/test_textsearch.py
+++ b/tests/benchmarking/API/test_textsearch.py
@@ -183,11 +183,11 @@ def make_js_translation_code():
     """
     To restrict load on the server, the ordering of returned results is done in javascript
     using the overall_search_score function. We can run this using js2py by
-    extracting all the plain functions in OZTreeModule/src/api/search_manager.js and looking for
+    extracting all the plain functions in OZTreeModule/src/ui/search_manager.js and looking for
     lines bounded by a start line of  ^function... and an end line of ^}
     Since it is very slow to convert the JS to JS5, we keep a copy of the converted code locally
     """
-    js_fn = os.path.join(web2py_app_dir,'OZprivate','rawJS','OZTreeModule','src','api','search_manager.js')
+    js_fn = os.path.join(web2py_app_dir,'OZprivate','rawJS','OZTreeModule','src','ui','search_manager.js')
     cache_fn = os.path.join(script_path,"BlatSearch.code_cache")
     
     js_modtime = os.path.getmtime(js_fn)

--- a/tests/unit/test_modules_tour.py
+++ b/tests/unit/test_modules_tour.py
@@ -74,6 +74,32 @@ class TestModuleTour(unittest.TestCase):
             visible_in_search=tour1['visible_in_search'],
         )]})
 
+    def test_tour_search(self):
+        db = current.db
+        leaves = [db(db.ordered_leaves.ott == ott).select(db.ordered_leaves.ALL)[0] for ott in util.find_unsponsored_otts(10)]
+        tour1 = util.create_tour([l.ott for l in leaves[0:1]], title="Test tour first", description="A tour with things")
+        tour2 = util.create_tour([l.ott for l in leaves[1:2]], title="Test tour things", description="A tour with stuff")
+
+        # Search in both title and description
+        out = tour.tour_search("things")
+        self.assertEqual(
+            [o.identifier for o in out],
+            [tour1['identifier'], tour2['identifier']],
+        )
+
+        # String only in description
+        out = tour.tour_search("stuff")
+        self.assertEqual(
+            [o.identifier for o in out],
+            [tour2['identifier']],
+        )
+
+        # String only in title
+        out = tour.tour_search("first")
+        self.assertEqual(
+            [o.identifier for o in out],
+            [tour1['identifier']],
+        )
 
 if __name__ == '__main__':
     import sys

--- a/views/default/spl_elsewhere.html
+++ b/views/default/spl_elsewhere.html
@@ -6,7 +6,6 @@
 {{if is_testing: response.meta.viewfile, response.meta.date_accessed = response.view, request.now}}{{pass}}
 {{extend ('popup.html' if 'popup' in request.vars else 'uikit_layout.html')}}
 {{import img}}
-{{include '../static/OZTreeModule/dist/OZui.html'}}
 
 {{block masthead}}
 {{if 'popup' not in request.vars:}}

--- a/views/default/spl_elsewhere_not.html
+++ b/views/default/spl_elsewhere_not.html
@@ -5,7 +5,6 @@
 {{if is_testing: response.meta.viewfile, response.meta.date_accessed = response.view, request.now}}{{pass}}
 {{extend ('popup.html' if 'popup' in request.vars else 'uikit_layout.html')}}
 
-{{include '../static/OZTreeModule/dist/OZui.html'}}
 {{import img}}
 {{block masthead}}
 {{if 'popup' not in request.vars:}}

--- a/views/default/sponsor_leaf.html
+++ b/views/default/sponsor_leaf.html
@@ -22,7 +22,6 @@ response.files.append(URL('static', 'OZSponsor/sponsor_leaf.css'))
 response.files.append(URL('static', 'OZSponsor/EOLqueries.js'))
 response.files.append(URL('static','css/content_pages.css'))
 }}
-{{include '../static/OZTreeModule/dist/OZui.html'}}
 {{import img}}
 {{if is_testing: response.meta.viewfile, response.meta.date_accessed = response.view, request.now}}{{pass}}
 {{extend ('popup.html' if 'popup' in request.vars else 'uikit_layout.html')}}

--- a/views/developer/embed_edit.html
+++ b/views/developer/embed_edit.html
@@ -52,7 +52,7 @@
               <button   class="main-icon" uk-icon="icon: search"></button>
             </div>
             <input id="input_url_search" class="uk-search-input" type="search" placeholder="{{=T('Search all life...')}}" />
-            <input type="hidden" name="initmark" value="" />
+            <input type="hidden" name="highlight" value="" />
           </div>
           <div uk-dropdown="pos: bottom-left; offset: 0" class="search_dropdown selectable uk-overflow-auto">
             <div class="no_results">{{=T("No results found")}}</div>
@@ -62,7 +62,7 @@
         <br/>
       </div></div>
       <p>
-        <button id="button_clear_initmark" class="uk-button oz-pill" disabled>Clear highlight</button>
+        <button id="button_clear_highlight" class="uk-button oz-pill" disabled>Clear highlight</button>
       </p>
 
       <label><span class="uk-form-label">{{=T('Image sources')}}</span>
@@ -153,8 +153,8 @@
             if (hidden_el.name === '_pinpoint') {
                 hidden_el.value = href.replace(/^.*\//, '');
                 form_embed_edit.elements['otthome'].value = href.replace(/^.*\=/, '');
-            } else if (hidden_el.name === 'initmark') {
-                hidden_el.value = href.replace(/^.*\=/, '');
+            } else if (hidden_el.name === 'highlight') {
+                hidden_el.value = 'path:' + href.replace(/^.*\//, '');
             } else {
                 throw new Error("Unknown hidden element name" + hidden_el);
             }
@@ -196,9 +196,11 @@
             }
         });
 
-    document.getElementById('button_clear_initmark').addEventListener('click', function (e) {
+    document.getElementById('button_clear_highlight').addEventListener('click', function (e) {
         e.preventDefault();
-        form_embed_edit.elements['initmark'].value = "";
+        form_embed_edit.elements['highlight'].value = "";
+        // Search search input
+        form_embed_edit.elements['highlight'].previousElementSibling.value = "";
         form_embed_edit.dispatchEvent(new Event('change'));
     });
 
@@ -214,7 +216,7 @@
             return encodeURIComponent(x.name) + "=" + encodeURIComponent(x.value);
         }).join("&");
 
-        document.getElementById('button_clear_initmark').disabled = !(form_embed_edit.elements['initmark'].value);
+        document.getElementById('button_clear_highlight').disabled = !(form_embed_edit.elements['highlight'].value);
 
         iframe_embed_preview.src = url;
         document.getElementById('form_embed_email').elements.url.value = url;

--- a/views/developer/embed_edit.html
+++ b/views/developer/embed_edit.html
@@ -136,6 +136,30 @@
     var form_embed_edit = document.getElementById('form_embed_edit'),
         iframe_embed_preview = document.getElementById('iframe_embed_preview');
 
+    $('.search_dropdown', form_embed_edit)
+        .click(function(event) {
+            var searchbox = $(this.parentElement);
+            var search_input = searchbox.find('.searchinput input[type=search]')
+            var hidden_el = searchbox.find('input[type=hidden]')[0];
+            var ddEl = event.target.closest('dd');
+            var href = $(ddEl).find('a').attr('href');
+
+            if (!href) return;  // Ignore non-links
+            event.preventDefault();  // Don't follow links
+
+            // Populate search input with current item, so it's more obvious what's selected
+            search_input.val($(event.target).closest('dd').text());
+
+            if (hidden_el.name === '_pinpoint') {
+                hidden_el.value = href.replace(/^.*\//, '');
+                form_embed_edit.elements['otthome'].value = href.replace(/^.*\=/, '');
+            } else if (hidden_el.name === 'initmark') {
+                hidden_el.value = href.replace(/^.*\=/, '');
+            } else {
+                throw new Error("Unknown hidden element name" + hidden_el);
+            }
+            form_embed_edit.dispatchEvent(new Event('change'));
+        });
     $('.searchinput input', form_embed_edit)
         .blur(function(event) {
             // if we have an already-selected location, and we lose focus, we simply revert
@@ -171,24 +195,8 @@
             OZui.search_manager.full_search(
                 search_term,
                 function(original_string, actual_search, results) {
-                    OZui.searchPopulate(searchbox, original_string, results, function (event) {
-                        event.preventDefault();  // Don't follow links
-                        var hidden_el = searchbox.find('input[type=hidden]')[0];
-                        var href = $(event.target).closest('a').attr('href');
-
-                        // Populate search input with current item, so it's more obvious what's selected
-                        search_input.val($(event.target).closest('dd').text());
-
-                        if (hidden_el.name === '_pinpoint') {
-                            hidden_el.value = href.replace(/^.*\//, '');
-                            form_embed_edit.elements['otthome'].value = href.replace(/^.*\=/, '');
-                        } else if (hidden_el.name === 'initmark') {
-                            hidden_el.value = href.replace(/^.*\=/, '');
-                        } else {
-                            throw new Error("Unknown hidden element name" + hidden_el);
-                        }
-                        form_embed_edit.dispatchEvent(new Event('change'));
-                    })},
+                    OZui.searchPopulate(searchbox, original_string, results);
+                },
                 delay_ms,
                 function() {
                     {{if is_testing:}}console.log("Search for '" + search_term + "' sent to OneZoom API from advanced search");{{pass}}

--- a/views/developer/embed_edit.html
+++ b/views/developer/embed_edit.html
@@ -175,10 +175,6 @@
             var searchbox = $(this).closest('.searchbox');
             var searchresult = $('.searchresult', searchbox);
             var dropdown = $('.search_dropdown', searchbox);
-            if (searchresult.attr('data-OZid')) {
-                onezoom.controller.unmark_area(searchresult.attr('data-OZid'));
-                searchresult.attr('data-OZid','');
-            }
             if (search_term.length==0) {
                 {{if is_testing:}}console.log("Hiding no_result section of dropdown");{{pass}}
                 $('.no_results', dropdown).hide();

--- a/views/developer/embed_edit.html
+++ b/views/developer/embed_edit.html
@@ -161,13 +161,6 @@
             form_embed_edit.dispatchEvent(new Event('change'));
         });
     $('.searchinput input', form_embed_edit)
-        .blur(function(event) {
-            // if we have an already-selected location, and we lose focus, we simply revert
-            var searchbox = $(event.currentTarget).closest('.searchbox');
-            if ($('.searchresult', searchbox).attr('data-OZid')) {
-                searchbox.addClass('result_displayed_in_box');
-            }
-        })
         .on('keyup', function(event) {
 
             var search_input = $(this);

--- a/views/developer/embed_edit.html
+++ b/views/developer/embed_edit.html
@@ -136,15 +136,6 @@
     var form_embed_edit = document.getElementById('form_embed_edit'),
         iframe_embed_preview = document.getElementById('iframe_embed_preview');
 
-    // Wire up search box to update url field
-    var search_manager = OZentry.api_utils_setup({
-      /* These fill out the equivalently named variables in OneZoom global_config.
-         They need to be defined in this file to avoid hard-coding them into the OneZoom js code
-         They are coded with the full URL so that they can be used remotely (e.g. in a partial install) */
-      search_api: "{{try:}}{{=myconf.take('API.search')}}{{except:}}{{=URL('API','search_node.json', scheme=True, host=True)}}{{pass}}",
-      search_sponsor_api: "{{try:}}{{=myconf.take('API.search_sponsor')}}{{except:}}{{=URL('API','search_for_sponsor.json', scheme=True, host=True)}}{{pass}}",
-    }).search_manager;
-
     $('.searchinput input', form_embed_edit)
         .blur(function(event) {
             // if we have an already-selected location, and we lose focus, we simply revert
@@ -168,7 +159,7 @@
                 {{if is_testing:}}console.log("Hiding no_result section of dropdown");{{pass}}
                 $('.no_results', dropdown).hide();
                 $('.search_hits', dropdown).empty();
-                search_manager.full_search(""); // this clears the search
+                OZui.search_manager.full_search(""); // this clears the search
                 $('.searchinput', searchbox).removeClass('waiting_for_search_result');
             } else {
                 var delay_ms = 1000;
@@ -177,7 +168,7 @@
                 }
             if ((search_term.replace(/ /g,'').length > 2)||((search_term.replace(/ /g,'').length > 1)&&(delay_ms == 1))) { // we're never going to search for a single character
 
-            search_manager.full_search(
+            OZui.search_manager.full_search(
                 search_term,
                 function(original_string, actual_search, results) {
                     OZui.searchPopulate(searchbox, original_string, results, function (event) {

--- a/views/developer/embed_edit.html
+++ b/views/developer/embed_edit.html
@@ -161,6 +161,11 @@
             form_embed_edit.dispatchEvent(new Event('change'));
         });
     $('.searchinput input', form_embed_edit)
+        .on('keydown', function(event) {
+            // Stop UI-kit from nullifying space
+            // https://github.com/uikit/uikit/blob/8313ce565be686952ab6edf8a7caee5fdfcca08c/src/js/core/toggle.js#L138-L151
+            event.stopPropagation();
+        })
         .on('keyup', function(event) {
 
             var search_input = $(this);

--- a/views/layout.html
+++ b/views/layout.html
@@ -43,6 +43,8 @@
     {{if is_testing:}}<script>window.is_testing = true;</script>{{pass}}
     <script>var OZstrings={{include 'treeviewer/js_strings.json'}};</script>
     {{include '../static/OZTreeModule/dist/OZ_main.html'}}
+    {{include '../static/OZTreeModule/dist/OZui.html'}}
+    {{include 'treeviewer/server_urls.html' }}
 
     {{block head}}{{end}}
     {{

--- a/views/layout.html
+++ b/views/layout.html
@@ -116,10 +116,6 @@
             var searchbox = $(this).closest('.searchbox');
             var searchresult = $('.searchresult', searchbox);
             var dropdown = $('.search_dropdown', searchbox);
-            if (searchresult.attr('data-OZid')) {
-                onezoom.controller.unmark_area(searchresult.attr('data-OZid'));
-                searchresult.attr('data-OZid','');
-            }
             if (search_term.length==0) {
                 $('.popular_species', dropdown).show();
                 {{if is_testing:}}console.log("Hiding no_result section of dropdown");{{pass}}

--- a/views/layout.html
+++ b/views/layout.html
@@ -103,13 +103,6 @@
     var box_selector = $('#header_searchnav');
 
     $('.searchinput input', box_selector)
-        .blur(function(event) {
-            // if we have an already-selected location, and we lose focus, we simply revert
-            var searchbox = $(event.currentTarget).closest('.searchbox');
-            if ($('.searchresult', searchbox).attr('data-OZid')) {
-                searchbox.addClass('result_displayed_in_box');
-            }
-        })
         .on('keyup', function(event) {
 
             var search_term = this.value;

--- a/views/layout.html
+++ b/views/layout.html
@@ -101,13 +101,6 @@
 <script>
 (function() {
     var box_selector = $('#header_searchnav');
-    var search_manager = OZentry.api_utils_setup({
-      /* These fill out the equivalently named variables in OneZoom global_config.
-         They need to be defined in this file to avoid hard-coding them into the OneZoom js code
-         They are coded with the full URL so that they can be used remotely (e.g. in a partial install) */
-      search_api: "{{try:}}{{=myconf.take('API.search')}}{{except:}}{{=URL('API','search_node.json', scheme=True, host=True)}}{{pass}}",
-      search_sponsor_api: "{{try:}}{{=myconf.take('API.search_sponsor')}}{{except:}}{{=URL('API','search_for_sponsor.json', scheme=True, host=True)}}{{pass}}",
-    }).search_manager;
 
     $('.searchinput input', box_selector)
         .blur(function(event) {
@@ -132,7 +125,7 @@
                 {{if is_testing:}}console.log("Hiding no_result section of dropdown");{{pass}}
                 $('.no_results', dropdown).hide();
                 $('.search_hits', dropdown).empty();
-                search_manager.full_search(""); // this clears the search
+                OZui.search_manager.full_search(""); // this clears the search
                 $('.searchinput', searchbox).removeClass('waiting_for_search_result');
             } else {
                 //$('.searchinput', searchbox).addClass('waiting_for_search_result');
@@ -142,7 +135,7 @@
                 }
             if ((search_term.replace(/ /g,'').length > 2)||((search_term.replace(/ /g,'').length > 1)&&(delay_ms == 1))) { // we're never going to search for a single character
 
-            search_manager.full_search(
+            OZui.search_manager.full_search(
                 search_term,
                 function(original_string, actual_search, results) {
                     OZui.searchPopulate(searchbox, original_string, results, function () {return null;})},

--- a/views/layout.html
+++ b/views/layout.html
@@ -138,7 +138,8 @@
             OZui.search_manager.full_search(
                 search_term,
                 function(original_string, actual_search, results) {
-                    OZui.searchPopulate(searchbox, original_string, results, function () {return null;})},
+                    OZui.searchPopulate(searchbox, original_string, results);
+                },
                 delay_ms,
                 function() {
                     {{if is_testing:}}console.log("Search for '" + search_term + "' sent to OneZoom API from advanced search");{{pass}}

--- a/views/popup.html
+++ b/views/popup.html
@@ -39,6 +39,8 @@
     <!--[if lt IE 9]>
         <script src="{{=URL('static','js/respond-1.4.2.min.js')}}"></script>
         <![endif]-->
+    {{include '../static/OZTreeModule/dist/OZui.html'}}
+    {{include 'treeviewer/server_urls.html' }}
     {{block head}}{{end}}
   </head>
   <body class="popuped">

--- a/views/tour/list.html
+++ b/views/tour/list.html
@@ -1,7 +1,6 @@
 {{response.title='OneZoom: Available Tours'}}
 {{response.files.append(URL('static', 'css/content_pages.css'))}}
 {{extend ('popup.html' if 'popup' in request.vars else 'uikit_layout.html')}}
-{{include '../static/OZTreeModule/dist/OZui.html'}}
     
 {{block masthead}}
 <div class="home-heading uk-padding-small">

--- a/views/tour/search.json
+++ b/views/tour/search.json
@@ -1,0 +1,6 @@
+{{
+from gluon.serializers import json
+
+response.write(json(response._vars), escape=False)
+response.headers['Content-Type'] = 'application/json; charset=utf-8'
+}}

--- a/views/treeviewer/js_strings.json
+++ b/views/treeviewer/js_strings.json
@@ -101,7 +101,7 @@ OZstrings = {
     ### Stuff in the tree viewer
     'Current location':T('Current location'),
     'Popular places':T('Popular places'),
-    'NameHits':T('Search results'),
+    'Search results':T('Search results'),
     'NoEmailFromMD':T('Sorry, you can’t send an email directly from this display. Please use your own email program, and contact us at: '),
     'SponsorHits':T('Sponsorships'),
 }

--- a/views/treeviewer/js_strings.json
+++ b/views/treeviewer/js_strings.json
@@ -104,6 +104,7 @@ OZstrings = {
     'Search results':T('Search results'),
     'NoEmailFromMD':T('Sorry, you can’t send an email directly from this display. Please use your own email program, and contact us at: '),
     'SponsorHits':T('Sponsorships'),
+    'Tours':T('Tours'),
 }
 try:
    from gluon.serializers import json

--- a/views/treeviewer/layout.html
+++ b/views/treeviewer/layout.html
@@ -247,47 +247,6 @@ function load_tab(tab_content) {
   window.setTimeout(function() { ifrm.focus(); }, 0);
 }
 
-/* Add a set of species (e.g. popular species) to a target list, 
- * by using the onezoom.utils.process_taxon_list() function
- * to map OTT ids to OneZoom IDs / vernacular names.
- * The parameter 'click_callback_id_name' should be a
- * callback that is fired when an item is clicked on in the list
- * (called with event, OZid, item_name, sci_name, dropdown)
- */
-function setup_location_list(target, locations_json, click_callback_id_name) {
-    target.empty();
-    onezoom.utils.process_taxon_list(
-        locations_json,
-        function(ott, result) {
-            // Reconstitute compile_searchbox_data() format
-            var given_name = result[0],
-                sciname = result[1],
-                OZid = result[2];
-
-            if (OZid) {
-                target.append(
-                    $('<dd>').html(
-                        $('<p>')
-                            .html(given_name?$('<span></span>').text(given_name):$('<i></i>').text(sciname))
-                            .addClass('taxon_location_button')
-                            .attr("draggable","true")
-                            .attr("id",'menuitem'+OZid.toString())
-                            .attr("data-OZid",OZid.toString())
-                            .data('result', result)
-                            .click(function(event) {
-                                click_callback_id_name(event, result);
-                            })
-                            .on('dragstart', function(event){
-                                 event.originalEvent.dataTransfer.setData('drop_id', $(this).attr('id'));
-                                 event.originalEvent.dataTransfer.setData('taxon', true);
-                            })
-                    )
-                );
-            }
-        },
-        function(header) {target.append($('<dt>').text(OZstrings.hasOwnProperty(header)?OZstrings[header]:header))});
-}
-
 var previous_location_codes;
 /* Function to call when location menu is clicked
  * will be filled out with call to API using update_location_menu(onezoom.controller.get_my_location())
@@ -534,7 +493,7 @@ function add_advanced_searchbox(result, col) {
             }
         });
         
-    setup_location_list($('.popular_species', box_selector), locations_json, UI_reset_marked_via_event);
+    OZui.setup_location_list($('.popular_species', box_selector), locations_json, UI_reset_marked_via_event);
 
     // Set-up from initial parameters
     // Reconstitute compile_searchbox_data() format
@@ -972,7 +931,7 @@ function setupUI() {
         event.stopPropagation();
     });
 
-    setup_location_list($('#searchnav .search-basic .popular_species'), locations_json, 
+    OZui.setup_location_list($('#searchnav .search-basic .popular_species'), locations_json, 
         // Reconstitute compile_searchbox_data() format
         function(event, result) {closeAndLeap(event, result[2], $('#searchnav .search-basic'))});
 

--- a/views/treeviewer/layout.html
+++ b/views/treeviewer/layout.html
@@ -358,11 +358,6 @@ function UI_move_to_common_ancestor(searchbox, event) {
     closeAndLeap(event, pinpoints, $('#search-advanced #searchboxes'), 'ancestor');
 }
 
-function UI_reset_marked_via_event(event, result) {
-    //fired when an item is selected in an advanced dropdown
-    UI_reset_marked($(event.currentTarget).closest('.searchbox'), result, event);
-}
-
 function toggleAdvancedSearch(state) {
     //toggles advanced search mode, or switches it on (state=true) or off (state=false)
     if (state == null) {
@@ -439,6 +434,25 @@ function add_advanced_searchbox(result, col) {
             };
         })
         
+    $('.search_dropdown', box_selector)
+      .click(function(event) {
+        // Don't follow links directly
+        event.preventDefault();
+        event.stopPropagation();
+
+        var elItem = event.target.closest('dd');
+        if ($(elItem).attr('data-OZid')) {
+          UI_reset_marked($(event.currentTarget).closest('.searchbox'), {
+            // Recreate a compile_searchbox_data() format
+            0: $(elItem).attr('data-vernacular'),
+            1: $(elItem).attr('data-sciname'),
+            2: parseInt($(elItem).attr('data-OZid'), 10),
+            "pinpoint":  $(elItem).attr('data-pinpoint'),
+          }, event);
+        }
+        return false;
+      });
+
     $('.searchinput input', box_selector)
         .blur(function(event) {
             // if we have an already-selected location, and we lose focus, we simply revert
@@ -477,11 +491,7 @@ function add_advanced_searchbox(result, col) {
             OZui.search_manager.full_search(
                 search_term,
                 function(original_string, actual_search, results) {
-                    OZui.searchPopulate(searchbox, original_string, results, function (event, result) {
-                        // NB: result defined by compile_searchbox_data()
-                        event.preventDefault();  // Don't follow links
-                        return UI_reset_marked_via_event(event, result);
-                    });
+                    OZui.searchPopulate(searchbox, original_string, results);
                 },
                 delay_ms,
                 function() {
@@ -493,7 +503,7 @@ function add_advanced_searchbox(result, col) {
             }
         });
         
-    OZui.setup_location_list($('.popular_species', box_selector), locations_json, UI_reset_marked_via_event);
+    OZui.setup_location_list($('.popular_species', box_selector), locations_json);
 
     // Set-up from initial parameters
     // Reconstitute compile_searchbox_data() format
@@ -636,20 +646,19 @@ function setupUI() {
       .on("drop", function(event) {
         event.preventDefault();  
         event.stopPropagation();
-        if (event.originalEvent.dataTransfer.getData('taxon')) {
-            var dropped_item = $('#' + event.originalEvent.dataTransfer.getData('drop_id'))
+        if (event.originalEvent.dataTransfer.getData('result')) {
             //find the first unused advanced search box
             var to_fill = $('#search-advanced .searchresult:not([data-OZid])').first().closest('.searchbox');
             if (to_fill.length) {
                 UI_reset_marked(
                     to_fill,
                     // Use data set by setup_location_list / load_into_searchbox
-                    dropped_item.data('result')
+                    JSON.parse(event.originalEvent.dataTransfer.getData('result'))
                 );
             } else {
                 add_advanced_searchbox(
                     // Use data set by setup_location_list / load_into_searchbox
-                    dropped_item.data('result')
+                    JSON.parse(event.originalEvent.dataTransfer.getData('result'))
                 );
             }
             toggleAdvancedSearch(true);
@@ -667,6 +676,17 @@ function setupUI() {
         event.preventDefault();
       })
     
+    $('#searchnav .search-basic .search_dropdown')
+      .click(function(event) {
+        // Don't follow links directly
+        event.preventDefault();
+        event.stopPropagation();
+
+        // Strip /life/ and set_treestate of link
+        var ddEl = event.target.closest('dd');
+        closeAndLeap(event, parseInt(ddEl.getAttribute("data-OZid"), 10), $('#searchnav .search-basic'));
+      });
+
     $('#searchnav .search-basic .searchinput input')
       .keyup(function(event) {
         var search_term = this.value;
@@ -692,11 +712,7 @@ function setupUI() {
              OZui.search_manager.full_search(
                                                 search_term,
                                                 function(original_string, actual_search, results) {
-                                                OZui.searchPopulate(searchbox, original_string, results, function(event, result) {
-                                                    event.preventDefault();  // Don't follow links
-                                                    // Reconstitute compile_searchbox_data() format
-                                                    closeAndLeap(event, result[2], $('#searchnav .search-basic'));
-                                                })
+                                                    OZui.searchPopulate(searchbox, original_string, results);
                                                 },
                                                 delay_ms,
                                                 function() {
@@ -931,9 +947,7 @@ function setupUI() {
         event.stopPropagation();
     });
 
-    OZui.setup_location_list($('#searchnav .search-basic .popular_species'), locations_json, 
-        // Reconstitute compile_searchbox_data() format
-        function(event, result) {closeAndLeap(event, result[2], $('#searchnav .search-basic'))});
+    OZui.setup_location_list($('#searchnav .search-basic .popular_species'), locations_json);
 
     // Give treeviewer a chance to parse state, then configure advanced search if on
     window.setTimeout(function () {

--- a/views/treeviewer/layout.html
+++ b/views/treeviewer/layout.html
@@ -36,6 +36,7 @@ request.vars.links = setup_params['UI_layer']['vars'].get('links')
   <!-- do not change the next line in any way. The exact format is used for partial installs -->
   <div id="OZ_js_modules" data-include="../static/OZTreeModule/dist/OZ_main.html">
   {{include "../static/OZTreeModule/dist/OZ_main.html"}}
+  {{include '../static/OZTreeModule/dist/OZui.html'}}
   </div>
 
   <!-- treeviewer constants -->

--- a/views/treeviewer/layout.html
+++ b/views/treeviewer/layout.html
@@ -307,8 +307,7 @@ function update_location_menu(loc_root) {
 function load_into_searchbox(searchbox, result, highlight) {
     // Reconstitute compile_searchbox_data() format
     var given_name = result[0],
-        sciname = result[1],
-        OZIDin = result[2];
+        sciname = result[1];
     var colour = highlight.color;
 
     //Place a non-editable box of the selected item [given_name (/sci_name/)]
@@ -326,7 +325,6 @@ function load_into_searchbox(searchbox, result, highlight) {
     }
     searchresult.attr('data-highlight', highlight.str);
     searchresult.attr('data-href', result.pinpoint);
-    searchresult.attr('data-OZid', OZIDin);
     searchresult.data('result', result);
     searchbox.addClass('result_displayed_in_box');
     //once the svg is loaded into the icon, change the colour of the icon
@@ -447,12 +445,12 @@ function add_advanced_searchbox(result, highlight) {
         event.stopPropagation();
 
         var elItem = event.target.closest('dd');
-        if ($(elItem).attr('data-OZid')) {
+        if ($(elItem).attr('data-pinpoint')) {
           UI_reset_marked($(event.currentTarget).closest('.searchbox'), {
             // Recreate a compile_searchbox_data() format
             0: $(elItem).attr('data-vernacular'),
             1: $(elItem).attr('data-sciname'),
-            2: parseInt($(elItem).attr('data-OZid'), 10),
+            2: 0, // NB: Was OZid, now redundant
             "pinpoint":  $(elItem).attr('data-pinpoint'),
           }, event);
         }
@@ -463,7 +461,7 @@ function add_advanced_searchbox(result, highlight) {
         .blur(function(event) {
             // if we have an already-selected location, and we lose focus, we simply revert
             var searchbox = $(event.currentTarget).closest('.searchbox');
-            if ($('.searchresult', searchbox).attr('data-OZid')) {
+            if ($('.searchresult', searchbox).attr('data-href')) {
                 searchbox.addClass('result_displayed_in_box');
             }
         })
@@ -659,7 +657,7 @@ function setupUI() {
         event.stopPropagation();
         if (event.originalEvent.dataTransfer.getData('result')) {
             //find the first unused advanced search box
-            var to_fill = $('#search-advanced .searchresult:not([data-OZid])').first().closest('.searchbox');
+            var to_fill = $('#search-advanced .searchresult:not([data-highlight])').first().closest('.searchbox');
             if (to_fill.length) {
                 UI_reset_marked(
                     to_fill,

--- a/views/treeviewer/layout.html
+++ b/views/treeviewer/layout.html
@@ -211,7 +211,7 @@ var locations_json = '{{=XML(setup_params.get("locations_json") or "[]")}}';
     global_config.js. These refer to items in the viewer_UI file */
 
 
-function closeAndLeap(event, dest, original_searchbox, input_type) {
+function closeAndLeap(event, href, original_searchbox, input_type) {
     //TODO: add hit in search count.
     // add_hit_in_search_count(OZIDin);
     var dropdown = $(".search_dropdown", original_searchbox)
@@ -220,7 +220,12 @@ function closeAndLeap(event, dest, original_searchbox, input_type) {
             globals.UI_callbacks.closeAll();
         }
     }
-    if (dest) onezoom.controller.default_move_to(dest, input_type || 'ozid');
+    if (input_type === 'ancestor') {
+        onezoom.controller.default_move_to(href, 'ancestor');
+    } else {
+        // Strip /life/ from any URL, update tree state
+        onezoom.controller.set_treestate(href.replace(/^\/[A-Z_\-/]+/i, ''));
+    }
 }
 
 
@@ -320,6 +325,7 @@ function load_into_searchbox(searchbox, result, highlight) {
         $('input',searchresult).attr('value',(given_name || '') + (sciname || ''));
     }
     searchresult.attr('data-highlight', highlight.str);
+    searchresult.attr('data-href', result.pinpoint);
     searchresult.attr('data-OZid', OZIDin);
     searchresult.data('result', result);
     searchbox.addClass('result_displayed_in_box');
@@ -405,8 +411,8 @@ function add_advanced_searchbox(result, highlight) {
     $('.searchresult .icon-beside-input .main-icon', box_selector)
         .on('click',function(event) {
                {{if is_testing:}}console.log("icon clicked for jumping");{{pass}}
-            var OZid = parseInt($(event.currentTarget).closest('.searchresult').attr('data-OZid'), 10);
-            if (OZid) closeAndLeap(event, OZid, box_selector);
+            var href = $(event.currentTarget).closest('.searchresult').attr('data-href');
+            if (href) closeAndLeap(event, href, box_selector);
             event.preventDefault();
             event.stopPropagation();
         })
@@ -687,9 +693,8 @@ function setupUI() {
         event.preventDefault();
         event.stopPropagation();
 
-        // Strip /life/ and set_treestate of link
         var ddEl = event.target.closest('dd');
-        closeAndLeap(event, parseInt(ddEl.getAttribute("data-OZid"), 10), $('#searchnav .search-basic'));
+        closeAndLeap(event, $(ddEl).find('a').attr('href'), $('#searchnav .search-basic'));
       });
 
     $('#searchnav .search-basic .searchinput input')

--- a/views/treeviewer/layout.html
+++ b/views/treeviewer/layout.html
@@ -503,7 +503,7 @@ function add_advanced_searchbox(result, col) {
                 {{if is_testing:}}console.log("Hiding no_result section of dropdown");{{pass}}
                 $('.no_results', dropdown).hide();
                 $('.search_hits', dropdown).empty();
-                onezoom.search_manager.full_search(""); // this clears the search
+                OZui.search_manager.full_search(""); // this clears the search
                 $('.searchinput', searchbox).removeClass('waiting_for_search_result');
             } else {
                 //$('.searchinput', searchbox).addClass('waiting_for_search_result');
@@ -515,7 +515,7 @@ function add_advanced_searchbox(result, col) {
             
             //if (search_term.replace(/ /g,'').length > 1) { // we're never going to search for a single character
             
-            onezoom.search_manager.full_search(
+            OZui.search_manager.full_search(
                 search_term,
                 function(original_string, actual_search, results) {
                     OZui.searchPopulate(searchbox, original_string, results, function (event, result) {
@@ -718,7 +718,7 @@ function setupUI() {
             {{if is_testing:}}console.log("Hiding no_result section of dropdown");{{pass}}
             $('.no_results', dropdown).hide();
             $('.search_hits', dropdown).empty();
-            onezoom.search_manager.full_search("");
+            OZui.search_manager.full_search("");
             $('.searchinput', searchbox).removeClass('waiting_for_search_result');
         } else {
             var delay_ms = 1000;
@@ -730,7 +730,7 @@ function setupUI() {
              
              // we want to test for whether the search is working already or not....
              
-             onezoom.search_manager.full_search(
+             OZui.search_manager.full_search(
                                                 search_term,
                                                 function(original_string, actual_search, results) {
                                                 OZui.searchPopulate(searchbox, original_string, results, function(event, result) {
@@ -987,7 +987,7 @@ function setupUI() {
                colours[existing_searchresults[i][0]]=existing_searchresults[i][1]
             }
             //must look up the names & values via the API
-            onezoom.search_manager.lookup_nodes(ids, function(result) {
+            OZui.search_manager.lookup_nodes(ids, function(result) {
                // Reconstitute compile_searchbox_data() format
                var OZIDin = result[2];
                add_advanced_searchbox(result, colours[OZIDin]);

--- a/views/treeviewer/layout.html
+++ b/views/treeviewer/layout.html
@@ -299,11 +299,12 @@ function update_location_menu(loc_root) {
   }
 }
 
-function load_into_searchbox(searchbox, result, colour) {
+function load_into_searchbox(searchbox, result, highlight) {
     // Reconstitute compile_searchbox_data() format
     var given_name = result[0],
         sciname = result[1],
         OZIDin = result[2];
+    var colour = highlight.color;
 
     //Place a non-editable box of the selected item [given_name (/sci_name/)]
     //over the top of the original search box and replace the search icon
@@ -318,6 +319,7 @@ function load_into_searchbox(searchbox, result, colour) {
     } else {
         $('input',searchresult).attr('value',(given_name || '') + (sciname || ''));
     }
+    searchresult.attr('data-highlight', highlight.str);
     searchresult.attr('data-OZid', OZIDin);
     searchresult.data('result', result);
     searchbox.addClass('result_displayed_in_box');
@@ -330,21 +332,19 @@ function load_into_searchbox(searchbox, result, colour) {
 
 function UI_reset_marked(searchbox, result, event) {
     // Reconstitute compile_searchbox_data() format
-    var given_name = result[0],
-        sciname = result[1],
-        OZIDin = result[2];
 
     //create a new mark, and load into a searchbox 
     var searchresult = $('.searchresult', searchbox);
     {{if is_testing:}}console.log("Hiding search dropdown");{{pass}}
     UIkit.dropdown($('.search_dropdown', searchbox)).hide();
-    if (searchresult.attr('data-OZid')) {
-        onezoom.controller.unmark_area(parseInt(searchresult.attr('data-OZid'), 10));
+    if (searchresult.attr('data-highlight')) {
+        onezoom.controller.highlight_remove(searchresult.attr('data-highlight'));
     }
-    var colour = onezoom.controller.mark_area(OZIDin);
-    load_into_searchbox(searchbox, result, colour);
-    {{if is_testing:}}console.log("Marking " + OZIDin + " with " + colour);{{pass}}
-    UI_move_to_common_ancestor(event);
+    return onezoom.controller.highlight_add('path:' + result.pinpoint).then(function (highlight) {
+      load_into_searchbox(searchbox, result, highlight);
+      {{if is_testing:}}console.log("Marking " + result.pinpoint + " with " + highlight.color);{{pass}}
+      UI_move_to_common_ancestor(event);
+    });
 }
 
 function UI_move_to_common_ancestor(searchbox, event) {
@@ -377,7 +377,7 @@ function toggleAdvancedSearch(state) {
     }
 }
 
-function add_advanced_searchbox(result, col) {
+function add_advanced_searchbox(result, highlight) {
     /* Add an advanced searchbox, and attach all the necessary listeners.
      * This is done dynamically so that we can add and remove them easily.
      * If any parameters are given, we set the box to those values
@@ -387,8 +387,8 @@ function add_advanced_searchbox(result, col) {
     $('.remove-searchbox', box_selector)
         .click(function(event) {
             var searchbox = $(event.currentTarget).closest('.searchbox');
-            var highlighted = parseInt($('.searchresult', searchbox).attr('data-OZid'), 10);
-            if (highlighted) onezoom.controller.unmark_area(highlighted);
+            var highlight_str = $('.searchresult', searchbox).attr('data-highlight');
+            if (highlight_str) onezoom.controller.highlight_remove(highlight_str);
             searchbox.remove();
             if ($('#search-advanced #searchboxes li').length == 0) {
                 toggleAdvancedSearch(false);
@@ -467,9 +467,8 @@ function add_advanced_searchbox(result, col) {
             var searchbox = $(this).closest('.searchbox');
             var searchresult = $('.searchresult', searchbox);
             var dropdown = $('.search_dropdown', searchbox);
-            if (searchresult.attr('data-OZid')) {
-                onezoom.controller.unmark_area(parseInt(searchresult.attr('data-OZid'), 10));
-                searchresult.attr('data-OZid','');
+            if (searchresult.attr('data-highlight')) {
+                onezoom.controller.highlight_remove(searchresult.attr('data-highlight'));
             }
             if (search_term.length==0) {
                 $('.popular_species', dropdown).show();
@@ -508,10 +507,16 @@ function add_advanced_searchbox(result, col) {
     // Set-up from initial parameters
     // Reconstitute compile_searchbox_data() format
     if (result && result[2]) {
-        if (!col) col = onezoom.controller.mark_area(OZid);
+        if (!highlight) {
+            // Fake a pinpoint, so we can at least carry on. Not ideal but not sure this is used anyway.
+            highlight = {
+                str: 'path:' + result.pinpoint,
+                color: 'grey',
+            };
+        }
         //look up this OZid, and use OZid, name, sciname, colour to show the result
         //use a timeout to allow the icon time to load, so we can colour it
-        load_into_searchbox(box_selector, result, col);
+        load_into_searchbox(box_selector, result, highlight);
     }
 }
 
@@ -951,19 +956,20 @@ function setupUI() {
 
     // Give treeviewer a chance to parse state, then configure advanced search if on
     window.setTimeout(function () {
-        var existing_searchresults = onezoom.controller.list_all_marked();
-        if (existing_searchresults.length) {
-            var colours = {};
-            var ids = [];
-            for(var i=0; i<existing_searchresults.length; i++) {
-               ids.push(existing_searchresults[i][0]);
-               colours[existing_searchresults[i][0]]=existing_searchresults[i][1]
-            }
+        var highlights = onezoom.controller.highlight_detail().filter(function (h) {
+            return h.type === 'path' && h.ozids[0] === 1;
+        });
+        if (highlights.length) {
+            var highlight_map = {};
+            var ids = highlights.map(function (h) {
+                highlight_map[h.ozids[1]] = h;
+                return h.ozids[1];
+            });
+
             //must look up the names & values via the API
             OZui.search_manager.lookup_nodes(ids, function(result) {
                // Reconstitute compile_searchbox_data() format
-               var OZIDin = result[2];
-               add_advanced_searchbox(result, colours[OZIDin]);
+               add_advanced_searchbox(result, highlight_map[result[2]]);
             },'best_pd');
             toggleAdvancedSearch(true);
         } else {
@@ -972,7 +978,7 @@ function setupUI() {
             add_advanced_searchbox();
             toggleAdvancedSearch(false);
         }
-    }, 100);
+    }, 1000);
 
     $(document).triggerHandler("setupUI", onezoom);
 }

--- a/views/treeviewer/layout.html
+++ b/views/treeviewer/layout.html
@@ -697,7 +697,8 @@ function setupUI() {
         event.stopPropagation();
 
         var ddEl = event.target.closest('dd');
-        closeAndLeap(event, $(ddEl).find('a').attr('href'), $('#searchnav .search-basic'));
+        var href = $(ddEl).find('a').attr('href');
+        if (href) closeAndLeap(event, href, $('#searchnav .search-basic'));
       });
 
     $('#searchnav .search-basic .searchinput input')

--- a/views/treeviewer/layout.html
+++ b/views/treeviewer/layout.html
@@ -465,6 +465,11 @@ function add_advanced_searchbox(result, highlight) {
                 searchbox.addClass('result_displayed_in_box');
             }
         })
+        .on('keydown', function(event) {
+            // Stop UI-kit from nullifying space
+            // https://github.com/uikit/uikit/blob/8313ce565be686952ab6edf8a7caee5fdfcca08c/src/js/core/toggle.js#L138-L151
+            event.stopPropagation();
+        })
         .on('keyup', function(event) {
             
             var search_term = this.value;
@@ -696,6 +701,11 @@ function setupUI() {
       });
 
     $('#searchnav .search-basic .searchinput input')
+      .on('keydown', function(event) {
+        // Stop UI-kit from nullifying space
+        // https://github.com/uikit/uikit/blob/8313ce565be686952ab6edf8a7caee5fdfcca08c/src/js/core/toggle.js#L138-L151
+        event.stopPropagation();
+      })
       .keyup(function(event) {
         var search_term = this.value;
         var searchbox = $(this).closest('.searchbox');

--- a/views/treeviewer/otop.html
+++ b/views/treeviewer/otop.html
@@ -358,7 +358,7 @@ document.addEventListener('DOMContentLoaded', function () {
 </script>
 <script>
       $(document).ready(function() {
-          var m, tutorial_slideshow, homo_sapiens_metacode;
+          var m, tutorial_slideshow;
 
           // Copy HTML to page body (we don't have a template slot to add it server-side)
           tutorial_slideshow = document.createElement('DIV');
@@ -372,12 +372,7 @@ document.addEventListener('DOMContentLoaded', function () {
           tutorial_slideshow.addEventListener('hidden', function (e) {
               var slideshow = UIkit.slideshow(tutorial_slideshow.querySelector('.uk-slideshow'));
 
-              if (homo_sapiens_metacode) {
-                  onezoom.controller.fly_on_tree_to(null, homo_sapiens_metacode);
-              }
-
-              // Reset slideshow, disable flight / animation for subsequent displays
-              homo_sapiens_metacode = null;
+              onezoom.controller.set_treestate('@Homo_Sapiens');
               slideshow.stopAutoplay();
               slideshow.show(0);
           });
@@ -393,15 +388,5 @@ document.addEventListener('DOMContentLoaded', function () {
 
           // Show on startup
           UIkit.modal(tutorial_slideshow).show();
-
-          // Find Homo-sapiens ready for hiding
-          window.setTimeout(function () {
-              OZui.search_manager.full_search('Homo Sapiens', function (latin_name, cname, res) {
-                  if (res.length < 1) {
-                      throw new Error("Could not find Homo Sapiens node");
-                  }
-                  homo_sapiens_metacode = res[0][2];
-              }, search_delay=0);
-          }, 100);
       });
 </script>

--- a/views/treeviewer/otop.html
+++ b/views/treeviewer/otop.html
@@ -396,7 +396,7 @@ document.addEventListener('DOMContentLoaded', function () {
 
           // Find Homo-sapiens ready for hiding
           window.setTimeout(function () {
-              onezoom.search_manager.full_search('Homo Sapiens', function (latin_name, cname, res) {
+              OZui.search_manager.full_search('Homo Sapiens', function (latin_name, cname, res) {
                   if (res.length < 1) {
                       throw new Error("Could not find Homo Sapiens node");
                   }

--- a/views/treeviewer/otop_MD.html
+++ b/views/treeviewer/otop_MD.html
@@ -354,7 +354,7 @@ document.addEventListener('DOMContentLoaded', function () {
 </script>
 <script>
       $(document).ready(function() {
-          var tutorial_slideshow, homo_sapiens_metacode;
+          var tutorial_slideshow;
 
           // Copy HTML to page body (we don't have a template slot to add it server-side)
           tutorial_slideshow = document.createElement('DIV');
@@ -368,12 +368,7 @@ document.addEventListener('DOMContentLoaded', function () {
           tutorial_slideshow.addEventListener('hidden', function (e) {
               var slideshow = UIkit.slideshow(tutorial_slideshow.querySelector('.uk-slideshow'));
 
-              if (homo_sapiens_metacode) {
-                  onezoom.controller.fly_on_tree_to(null, homo_sapiens_metacode);
-              }
-
-              // Reset slideshow, disable flight / animation for subsequent displays
-              homo_sapiens_metacode = null;
+              onezoom.controller.set_treestate('@Homo_Sapiens');
               slideshow.stopAutoplay();
               slideshow.show(0);
           });
@@ -384,15 +379,5 @@ document.addEventListener('DOMContentLoaded', function () {
 
           // Show on startup
           UIkit.modal(tutorial_slideshow).show();
-
-          // Find Homo-sapiens ready for hiding
-          window.setTimeout(function () {
-              OZui.search_manager.full_search('Homo Sapiens', function (latin_name, cname, res) {
-                  if (res.length < 1) {
-                      throw new Error("Could not find Homo Sapiens node");
-                  }
-                  homo_sapiens_metacode = res[0][2];
-              }, search_delay=0);
-          }, 100);
       });
 </script>

--- a/views/treeviewer/otop_MD.html
+++ b/views/treeviewer/otop_MD.html
@@ -387,7 +387,7 @@ document.addEventListener('DOMContentLoaded', function () {
 
           // Find Homo-sapiens ready for hiding
           window.setTimeout(function () {
-              onezoom.search_manager.full_search('Homo Sapiens', function (latin_name, cname, res) {
+              OZui.search_manager.full_search('Homo Sapiens', function (latin_name, cname, res) {
                   if (res.length < 1) {
                       throw new Error("Could not find Homo Sapiens node");
                   }

--- a/views/uikit_layout.html
+++ b/views/uikit_layout.html
@@ -95,6 +95,11 @@
     var box_selector = $('#header_searchnav');
 
     $('.searchinput input', box_selector)
+        .on('keydown', function(event) {
+            // Stop UI-kit from nullifying space
+            // https://github.com/uikit/uikit/blob/8313ce565be686952ab6edf8a7caee5fdfcca08c/src/js/core/toggle.js#L138-L151
+            event.stopPropagation();
+        })
         .on('keyup', function(event) {
 
             var search_term = this.value;

--- a/views/uikit_layout.html
+++ b/views/uikit_layout.html
@@ -95,13 +95,6 @@
     var box_selector = $('#header_searchnav');
 
     $('.searchinput input', box_selector)
-        .blur(function(event) {
-            // if we have an already-selected location, and we lose focus, we simply revert
-            var searchbox = $(event.currentTarget).closest('.searchbox');
-            if ($('.searchresult', searchbox).attr('data-OZid')) {
-                searchbox.addClass('result_displayed_in_box');
-            }
-        })
         .on('keyup', function(event) {
 
             var search_term = this.value;

--- a/views/uikit_layout.html
+++ b/views/uikit_layout.html
@@ -36,7 +36,9 @@
 
     {{if is_testing:}}<script>window.is_testing = true;</script>{{pass}}
     {{include '../static/OZTreeModule/dist/OZ_main.html'}}
+    {{include '../static/OZTreeModule/dist/OZui.html'}}
     <script>var OZstrings={{include 'treeviewer/js_strings.json'}}</script>
+    {{include 'treeviewer/server_urls.html' }}
   </head>
   <body class="standalone">
     <!--[if lt IE 8]><p class="browserupgrade">You are using an <strong>outdated</strong> browser. Please <a href="http://browsehappy.com/">upgrade your browser</a> to improve your experience.</p><![endif]-->

--- a/views/uikit_layout.html
+++ b/views/uikit_layout.html
@@ -108,10 +108,6 @@
             var searchbox = $(this).closest('.searchbox');
             var searchresult = $('.searchresult', searchbox);
             var dropdown = $('.search_dropdown', searchbox);
-            if (searchresult.attr('data-OZid')) {
-                onezoom.controller.unmark_area(searchresult.attr('data-OZid'));
-                searchresult.attr('data-OZid','');
-            }
             if (search_term.length==0) {
                 $('.popular_species', dropdown).show();
                 {{if is_testing:}}console.log("Hiding no_result section of dropdown");{{pass}}

--- a/views/uikit_layout.html
+++ b/views/uikit_layout.html
@@ -93,13 +93,6 @@
 <script>
 (function() {
     var box_selector = $('#header_searchnav');
-    var search_manager = OZentry.api_utils_setup({
-      /* These fill out the equivalently named variables in OneZoom global_config.
-         They need to be defined in this file to avoid hard-coding them into the OneZoom js code
-         They are coded with the full URL so that they can be used remotely (e.g. in a partial install) */
-      search_api: "{{try:}}{{=myconf.take('API.search')}}{{except:}}{{=URL('API','search_node.json', scheme=True, host=True)}}{{pass}}",
-      search_sponsor_api: "{{try:}}{{=myconf.take('API.search_sponsor')}}{{except:}}{{=URL('API','search_for_sponsor.json', scheme=True, host=True)}}{{pass}}",
-    }).search_manager;
 
     $('.searchinput input', box_selector)
         .blur(function(event) {
@@ -124,7 +117,7 @@
                 {{if is_testing:}}console.log("Hiding no_result section of dropdown");{{pass}}
                 $('.no_results', dropdown).hide();
                 $('.search_hits', dropdown).empty();
-                search_manager.full_search(""); // this clears the search
+                OZui.search_manager.full_search(""); // this clears the search
                 $('.searchinput', searchbox).removeClass('waiting_for_search_result');
             } else {
                 //$('.searchinput', searchbox).addClass('waiting_for_search_result');
@@ -134,7 +127,7 @@
                 }
             if ((search_term.replace(/ /g,'').length > 2)||((search_term.replace(/ /g,'').length > 1)&&(delay_ms == 1))) { // we're neve
 
-            search_manager.full_search(
+            OZui.search_manager.full_search(
                 search_term,
                 function(original_string, actual_search, results) {
                     OZui.searchPopulate(searchbox, original_string, results, function () {return null;});

--- a/views/uikit_layout.html
+++ b/views/uikit_layout.html
@@ -130,7 +130,7 @@
             OZui.search_manager.full_search(
                 search_term,
                 function(original_string, actual_search, results) {
-                    OZui.searchPopulate(searchbox, original_string, results, function () {return null;});
+                    OZui.searchPopulate(searchbox, original_string, results);
                     dropdown.find('dd').addClass('leafout');
                     dropdown.find('a').attr('target', '_blank');
                 },


### PR DESCRIPTION
With the following, entering e.g. "Frogs" in the search box will add a separate section to the results with the "Frogs and Toads" tour, clicking it will cause the tour to start.

* There's no fancy free-text search, we whitespace-split and search for each, as we do with sponsorship. This also won't be indexable, but OTOH the tours table will be small enough to remain in MySQL memory for the forseeable.
* We re-use the search dropdown in advanced search, content pages & embed editor. There is a lot of refactoring to try and keep all of these use-cases working. This needs properly re-thinking into a javascript component that hides away the guts of the search dropdown.
* The advanced search is reworked to use the new highlights controller API. The backwards compatibility to the old didn't really do what we needed, resulting in quite a few bugs.
* A bunch more Javascript UI is moved to ``src/ui``
* Similarly, the embed editor expected to set ``initmark=ozid``, which makes no sense as ozid is a temporary identifier. This now uses the highlight API too.
* Overrides for #738 have been added for good measure.

Fixes #540, #738