### PR TITLE
modules/embed: Allow overriding by supplying a dict #651

### DIFF
--- a/controllers/tour.py
+++ b/controllers/tour.py
@@ -62,7 +62,11 @@ media
             "https://commons.wikimedia.org/wiki/File:Rose_of_Jericho.gif",
         ],
 
-    Any media will autoplay when arriving at the tourstop, and stop when leaving.
+    By default media will autoplay when arriving at the tourstop, and stop when leaving. You can override with:
+
+        media: [
+            {"url": "https://commons.wikimedia.org/wiki/File:Turdus_philomelos.ogg", "ts_autoplay": "tsstate-transition_in tsstate-active_wait"}
+        ],
 """
 from pymysql.err import IntegrityError
 

--- a/modules/embed.py
+++ b/modules/embed.py
@@ -27,15 +27,27 @@ def embedize_url(url, email):
     ))
 
 
-def media_embed(url, **kwargs):
-    """Generate media embed code for given URL"""
+def media_embed(url, defaults=dict()):
+    """
+    Generate media embed code for given URL
+    - url: Either a URI in recognised format or dict(url: "https://", **opts), where (opts) & (defaults) are merged
+    - defaults: data-x options to set on the HTML, can be overriden by (opts)
+    """
     request = current.request
+
+    # If url is a dict, merge provided options with the defaults
+    if isinstance(url, dict):
+        opts = {**defaults, **url}
+        url = opts['url']
+    else:
+        opts = defaults
+        url = url
 
     # Join together extra element data
     element_data = ' '.join('data-%s="%s"' % (
         key,
         html.escape(value),
-    ) for key, value in kwargs.items())
+    ) for key, value in opts.items() if key != 'url' and value is not None)
 
     m = re.fullmatch(r'https://www.youtube.com/embed/(.+)', url)
     if m:

--- a/tests/unit/test_modules_embed.py
+++ b/tests/unit/test_modules_embed.py
@@ -62,7 +62,7 @@ class TestEmbed(unittest.TestCase):
             'frameborder="0"',
             '></iframe></div>',
         ])
-        self.assertEqual(media_embed('https://www.youtube.com/embed/12345', ts_autoplay="tsstate-active_wait", camel='"yes"'), [
+        self.assertEqual(media_embed('https://www.youtube.com/embed/12345', defaults=dict(ts_autoplay="tsstate-active_wait", camel='"yes"')), [
             '<div',
             'class="embed-video"><iframe',
             'class="embed-youtube"',
@@ -71,6 +71,26 @@ class TestEmbed(unittest.TestCase):
             'frameborder="0"',
             'data-ts_autoplay="tsstate-active_wait"',
             'data-camel="&quot;yes&quot;"',
+            '></iframe></div>',
+        ])
+        # Can override defaults by providing a dict
+        self.assertEqual(media_embed(dict(url='https://www.youtube.com/embed/12345', ts_autoplay="nothanks"), defaults=dict(ts_autoplay="tsstate-active_wait")), [
+            '<div',
+            'class="embed-video"><iframe',
+            'class="embed-youtube"',
+            'type="text/html"',
+            'src="https://www.youtube.com/embed/12345?enablejsapi=1&playsinline=1&origin=None://127.0.0.1:8000"',
+            'frameborder="0"',
+            'data-ts_autoplay="nothanks"',
+            '></iframe></div>',
+        ])
+        self.assertEqual(media_embed(dict(url='https://www.youtube.com/embed/12345', ts_autoplay=None), defaults=dict(ts_autoplay="tsstate-active_wait")), [
+            '<div',
+            'class="embed-video"><iframe',
+            'class="embed-youtube"',
+            'type="text/html"',
+            'src="https://www.youtube.com/embed/12345?enablejsapi=1&playsinline=1&origin=None://127.0.0.1:8000"',
+            'frameborder="0"',
             '></iframe></div>',
         ])
 

--- a/views/tour/data.html
+++ b/views/tour/data.html
@@ -55,7 +55,7 @@ ts_fields = (  # HTML fields that can be added to container
     {{for k, tag in ts_fields:}}{{if tdata.get(k, ''):}}
     <{{=tag}} class="{{=k}}">{{=T(tdata[k])}}</{{=tag}}>{{pass}}{{pass}}
     {{if len(tdata.get('media', [])) > 0:}}{{for url in tdata['media']:}}
-      {{=XML(media_embed(url, ts_autoplay='tsstate-active_wait'))}}
+      {{=XML(media_embed(url, defaults=dict(ts_autoplay='tsstate-active_wait')))}}
     {{pass}}{{pass}}
 
     <div class="actions"><a href="#share-modal" class="tour_pause oz-pill pill-share" style="float: right" uk-toggle>{{=T('Share')}}</a></div>


### PR DESCRIPTION
Allow media embeds to use a dict, in which case we override default options, meaning the following will work:

```json
                "media": [
                    "https://commons.wikimedia.org/wiki/File:Turdus_philomelos_-_Western_Springs_Lakeside_Park.jpg",
                    {"url": "https://commons.wikimedia.org/wiki/File:Turdus_philomelos.ogg", "ts_autoplay": "tsstate-transition_in tsstate-active_wait"}
                ]
```

Overriding with ``null`` will turn that option off.

Fixes #651 

