### PR TITLE
Rework tourstop mobile handle clicks

### DIFF
--- a/OZprivate/rawJS/OZTreeModule/src/tour/handler/UIEvents.js
+++ b/OZprivate/rawJS/OZTreeModule/src/tour/handler/UIEvents.js
@@ -89,9 +89,9 @@ function handler(tour) {
       return 0;
     }).reduce((acc, a) => acc + a, 0) + 20;  // NB: Not sure where the 20 pixels are coming from
 
-    function resizeTo(elTs, heightStyle, callback) {
+    function resizeTo(elTs, height, callback) {
       elTs.style.transition = 'height 0.3s ease-out';
-      elTs.style.height = heightStyle;
+      elTs.style.height = height + 'px';
       window.setTimeout(() => {
         elTs.style.transition = '';
         if (callback) callback();
@@ -110,16 +110,16 @@ function handler(tour) {
     if (!downInit.move) {
       // If we didn't move, toggle pause/resume
       if (Math.abs(downInit.tourstop.offsetHeight - minimisedHeight) < 3) {
-          resizeTo(downInit.tourstop, '', () => tour.user_resume());
+          resizeTo(downInit.tourstop, downInit.tourstop.ozOrigHeight, () => tour.user_resume());
       } else {
-          resizeTo(downInit.tourstop, minimisedHeight + 'px', () => tour.user_pause());
+          resizeTo(downInit.tourstop, minimisedHeight, () => tour.user_pause());
       }
     } else if (downInit.tourstop.offsetHeight < minimisedHeight * 0.8) {
-      resizeTo(downInit.tourstop, '0px', () => tour.user_exit());
+      resizeTo(downInit.tourstop, 0, () => tour.user_exit());
     } else if (downInit.tourstop.offsetHeight < minimisedHeight * 1.5) {
-      resizeTo(downInit.tourstop, minimisedHeight + 'px', () => tour.user_pause());
+      resizeTo(downInit.tourstop, minimisedHeight, () => tour.user_pause());
     } else {
-      resizeTo(downInit.tourstop, '', () => tour.user_resume());
+      resizeTo(downInit.tourstop, downInit.tourstop.ozOrigHeight, () => tour.user_resume());
     }
     downInit = null;
   };
@@ -131,6 +131,12 @@ function handler(tour) {
       const container = event.target.closest('.container');
       var y = event.touches ? event.touches[0].screenY : event.screenY;
       downInit = {target: event.target, tourstop: container, offset: container.offsetHeight + y};
+      if (!downInit.tourstop.style.height) {
+          // Store natural height
+          downInit.tourstop.ozOrigHeight = downInit.tourstop.offsetHeight;
+          // Fix the height at the current height, so animations work
+          downInit.tourstop.style.height = downInit.tourstop.ozOrigHeight + 'px';
+      }
 
       if (event.touches) {
         document.addEventListener('touchmove', onMouseMove);

--- a/OZprivate/rawJS/OZTreeModule/src/tour/handler/UIEvents.js
+++ b/OZprivate/rawJS/OZTreeModule/src/tour/handler/UIEvents.js
@@ -71,6 +71,7 @@ function handler(tour) {
     if (!downInit) return;
     var y = event.touches ? event.touches[0].screenY : event.screenY;
     downInit.tourstop.style.height = Math.max(downInit.offset - y, 50) + 'px';
+    downInit.move = true;
   };
   const onMouseUp = (event) => {
     const minimisedHeight = Array.from(downInit.tourstop.children).map(function (el) {
@@ -106,7 +107,14 @@ function handler(tour) {
       document.removeEventListener('mouseup', onMouseUp);
     }
 
-    if (downInit.tourstop.offsetHeight < minimisedHeight) {
+    if (!downInit.move) {
+      // If we didn't move, toggle pause/resume
+      if (Math.abs(downInit.tourstop.offsetHeight - minimisedHeight) < 3) {
+          resizeTo(downInit.tourstop, '', () => tour.user_resume());
+      } else {
+          resizeTo(downInit.tourstop, minimisedHeight + 'px', () => tour.user_pause());
+      }
+    } else if (downInit.tourstop.offsetHeight < minimisedHeight * 0.8) {
       resizeTo(downInit.tourstop, '0px', () => tour.user_exit());
     } else if (downInit.tourstop.offsetHeight < minimisedHeight * 1.5) {
       resizeTo(downInit.tourstop, minimisedHeight + 'px', () => tour.user_pause());

--- a/OZprivate/scss/tour.scss
+++ b/OZprivate/scss/tour.scss
@@ -155,7 +155,7 @@
   .header {
     margin: 0 -0.6rem; /* Cancel container padding */
 
-    .tour_exit.handle {
+    .handle {
       border: none;
       margin: 0.3rem auto;
       width: 5rem;
@@ -192,12 +192,12 @@
       }
     }
 
-    .tour_exit.handle { display: block; }
+    .handle { display: block; }
     .tour_exit.button { display: none; }
     @media (orientation: landscape) {
       @media (min-width: 1000px) {
         /* Desktop/tablet landscape mode: Reveal × */
-        .tour_exit.handle { display: none; }
+        .handle { display: none; }
         .tour_exit.button { display: block; }
       }
     }

--- a/views/tour/data.html
+++ b/views/tour/data.html
@@ -49,7 +49,7 @@ ts_fields = (  # HTML fields that can be added to container
        {{pass}}{{pass}}>
     <div class="header">
       <button type="button" class="button tour_exit" uk-icon="icon: close" aria-label="{{=T('Exit tour')}}"></button>
-      <button type="button" class="handle tour_exit" aria-label="{{=T('Exit tour')}}"></button>
+      <button type="button" class="handle" aria-label="{{=T('Exit tour')}}"></button>
       {{if tdata.get('title', ''):}}<h2 class="title">{{=tdata['title']}}</h2>{{pass}}
     </div>
     {{for k, tag in ts_fields:}}{{if tdata.get(k, ''):}}


### PR DESCRIPTION
The click-to-close behaviour of the handle was confusing, especially as it is a mouse-only thing.  Instead:

* Toggle state between paused/resume on a press without move, both for mouse & touch
* Ensure we animate between all states, so you get a visual clue it could be dragged down further.

Fixes #716 