### PR TITLE
views/tour: Add tour_final button to exit the tour at the end

### DIFF
--- a/OZprivate/rawJS/OZTreeModule/src/tour/handler/UIEvents.js
+++ b/OZprivate/rawJS/OZTreeModule/src/tour/handler/UIEvents.js
@@ -10,6 +10,7 @@
  *           <span class='button tour_backward'>← {{=T('Previous')}}</span>
  *           <span class='button tour_resume'>{{=T('Resume tutorial')}}</span>
  *           <span class='button tour_exit'>{{=T('Exit tutorial')}}</span>
+ *           <span class='button tour_final'>{{=T('Exit tutorial')}}</span>
  *           <span class='button tour_forward'>{{=T('Skip')}} →</span>
  *           <span class='button tour_goto stop_5'>{{=('Visit stop')}} 5</span>
  *           <select class="tour_goto"><option value="5">5</option</select>
@@ -18,7 +19,7 @@
  *     </div>
  *
  * On clicking ``tour_backward`` / ``tour_forward``, the tour will go backwards/forwards.
- * On clicking ``tour_exit``, the tour will close.
+ * On clicking ``tour_exit`` / ``tour_final``, the tour will close.
  *
  * When the tour is paused (e.g. as a result of user interaction) the ``tour_resume`` button will be visible,
  * clicking it will resume the tour.
@@ -32,7 +33,7 @@ function handler(tour) {
   const document = tour.container[0].ownerDocument;
 
   tour.container.click((e) => {
-    var target = $(e.target).closest('.tour_forward,.tour_backward,.tour_goto,.tour_play,.tour_pause,.tour_resume,.tour_exit,.exit_confirm,.exit_cancel');
+    var target = $(e.target).closest('.tour_forward,.tour_backward,.tour_goto,.tour_play,.tour_pause,.tour_resume,.tour_exit,.tour_final,.exit_confirm,.exit_cancel');
 
     if (target.length === 0) return;
     if (target.hasClass('tour_forward')) return tour.user_forward()
@@ -41,6 +42,7 @@ function handler(tour) {
     if (target.hasClass('tour_pause')) return tour.user_pause()
     if (target.hasClass('tour_resume')) return tour.user_resume()
     if (target.hasClass('tour_exit')) return tour.user_exit()
+    if (target.hasClass('tour_final')) return tour.user_exit()
     if (target[0].tagName !== 'SELECT' && target[0].classList.contains('tour_goto')) {
       let m = target[0].className.match(/(?:\W|^)stop_(\d+)/);
 

--- a/OZprivate/scss/tour.scss
+++ b/OZprivate/scss/tour.scss
@@ -39,10 +39,15 @@
     .tour_resume { display: none }
     &[data-state=tstate-paused] .tour_resume { display: initial }
     &[data-state=tstate-paused] .tour_forward { display: none }
+    &[data-state=tstate-paused] .tour_final { display: none }
 
     /* tour_backward & tour_forward don't make sense at beginning / end */
     > .container.ts-first .tour_backward { opacity: 0.5 }
-    > .container.ts-last .tour_forward { opacity: 0.5 }
+    > .container.ts-last .tour_forward { display: none; }
+
+    /* tour_final only makes sense at the end */
+    > .container:not(.ts-last) .tour_final { display: none }
+    &:not(&[data-state=tstate-paused]) > .container.ts-last .tour_final { display: block }
 }
 
 #tour_wrapper > .tour.layout-def {
@@ -214,7 +219,7 @@
         flex-grow: 1;
     }
 
-    .tour_backward, .tour_forward, .tour_resume {
+    .tour_backward, .tour_forward, .tour_resume, .tour_final {
       @extend %oz-drop-shadow-active;
       border: 0;
       height: 35px;
@@ -230,13 +235,13 @@
     .tour_backward {
       background-image: url(../images/oz-leftarrow-darkbg.svg);
     }
-    .tour_forward, .tour_resume {
+    .tour_forward, .tour_resume, .tour_final {
       background-image: url(../images/oz-rightarrow-darkbg.svg);
       background-position: right;
       padding-right: 40px;
     }
 
-    .tour_backward, .tour_forward, .tour_resume {
+    .tour_backward, .tour_forward, .tour_resume, .tour_final {
       font-size: inherit;
       border: 1px solid #242A22;
     }
@@ -247,7 +252,7 @@
       text-indent: 35px;
       padding-right: 10px;
     }
-    .tour_forward, .tour_resume {
+    .tour_forward, .tour_resume, .tour_final {
       background-position: right;
       border-radius: 5px calc(35px / 2) calc(35px / 2) 5px;
       border-right: none;

--- a/views/tour/data.html
+++ b/views/tour/data.html
@@ -75,6 +75,7 @@ ts_fields = (  # HTML fields that can be added to container
       </span>
       <button class="tour_resume">{{=T('Resume')}}</button>
       <button class="tour_forward">{{=T('Next')}}</button>
+      <button class="tour_final">{{=T('Exit')}}</button>
     </div>
   </div>
 {{pass}}


### PR DESCRIPTION
Instead of a greyed out next, add a tour_final button type, that we only show on the final stop (unlike tour_exit, which we use for the close button at the top).

Fixes #735 