### PR TITLE
Don't record tour-set QS options in URL

### DIFF
--- a/OZprivate/rawJS/OZTreeModule/src/navigation/record.js
+++ b/OZprivate/rawJS/OZTreeModule/src/navigation/record.js
@@ -40,6 +40,13 @@ function record_url(controller, options, force) {
   // Don't bother recording if it's basically the same state
   if (!force && current_view_near_previous_view(current_state)) return;
 
+  if (current_state.tour_setting) {
+    // Leave everything alone bar tour---parse existing state, splice tour state in.
+    const tour = current_state.tour_setting;
+    current_state = parse_state(window.location);
+    current_state.tour_setting = tour;
+  }
+
   if (options.replaceURL) {
     window.history.replaceState(null, "", deparse_state(current_state).href);
   } else {
@@ -64,6 +71,7 @@ function current_view_near_previous_view(current_state) {
   if (current_state === null && previous_state !== null) return false;
   else if (current_state !== null && previous_state === null) return false;
   else if (current_state === null && previous_state === null) return true;
+  else if (current_state.tour_setting !== previous_state.tour_setting) return false;
   else if (current_state.vis_type !== previous_state.vis_type) return false;
   else if (current_state.pinpoint === previous_state.pinpoint) {
     //If no tap window open and position not changed a lot, do not record current position into history.

--- a/OZprivate/rawJS/OZTreeModule/src/tour/handler/QsOpts.js
+++ b/OZprivate/rawJS/OZTreeModule/src/tour/handler/QsOpts.js
@@ -25,6 +25,7 @@ function handler(tour) {
                    );
       if (new_qs === '?') return;
 
+      // NB: Because we don't record tour treestate in record_url(), window.location will always be the pre-tour state.
       tourstop.hander_qsopts_old_qs = inverse_qs(new_qs, window.location.search);
       tour.onezoom.controller.set_treestate(new_qs);
     }, (tour, tourstop, el_ts) => {


### PR DESCRIPTION
When there's an active tour, record_url() should only record the tour state in the URL, not everything that the tour has set.

This means that if qs_opts is used in a tour, the URL will always include the pre-tour options, even if the page is reloaded / URL is shared.

Fixes #739 