### PR TITLE
Issue 732 tourstop element visibility

### DIFF
--- a/OZprivate/scss/tour.scss
+++ b/OZprivate/scss/tour.scss
@@ -48,6 +48,16 @@
     /* tour_final only makes sense at the end */
     > .container:not(.ts-last) .tour_final { display: none }
     &:not(&[data-state=tstate-paused]) > .container.ts-last .tour_final { display: block }
+
+    /* Content can use the .visible-* classes too */
+    > .container .visible-transition_in, > .container .visible-transition_out, > .container .visible-active_wait {
+      display: none!important; /* NB: Should work above any attempts to do display: block */
+    }
+    > .container[data-state=tsstate-transition_in] .visible-transition_in,
+    > .container[data-state=tsstate-transition_out] .visible-transition_out,
+    > .container[data-state=tsstate-active_wait] .visible-active_wait {
+      display: unset!important;
+    }
 }
 
 #tour_wrapper > .tour.layout-def {

--- a/controllers/tour.py
+++ b/controllers/tour.py
@@ -36,7 +36,13 @@ Both ``template_data`` and ``tourstop_shared`` can have the same content;
 title
     Title of tourstop, included at top of pop-up.
 window_text
-    Body text of tourstop.
+    Body text of tourstop. Can either be a single string, or an array of multiple items, which can also include visibility:
+
+        "window_text": [
+            "This text is visible whenever the tourstop is visible",
+            { "visible-transition_in": true, "text": "This text is only visible on transition_in" },
+            { "visible-transition_in": true, "visible-active_wait": true, "text": "This text is visible both transition_in and active_wait" }
+        ],
 comment
     Ignored comment section, for tour authors.
 visible-transition_in / visible-transition_out / hidden-active_wait
@@ -67,6 +73,9 @@ media
         media: [
             {"url": "https://commons.wikimedia.org/wiki/File:Turdus_philomelos.ogg", "ts_autoplay": "tsstate-transition_in tsstate-active_wait"}
         ],
+
+    When a media item is visible can be altered by setting ``"visible-transition_in": true``, the rules working the same as "window_text".
+
 """
 from pymysql.err import IntegrityError
 

--- a/modules/embed.py
+++ b/modules/embed.py
@@ -47,17 +47,23 @@ def media_embed(url, defaults=dict()):
     element_data = ' '.join('data-%s="%s"' % (
         key,
         html.escape(value),
-    ) for key, value in opts.items() if key != 'url' and value is not None)
+    ) for key, value in opts.items() if key != 'url' and value is not None and value is not True)
+
+    # List of classes from all true options
+    klass = ''.join(' %s' % (
+        html.escape(key),
+    ) for key, value in opts.items() if key != 'url' and value is True)
 
     m = re.fullmatch(r'https://www.youtube.com/embed/(.+)', url)
     if m:
-        return """<div class="embed-video"><iframe
+        return """<div class="embed-video{klass}"><iframe
             class="embed-youtube"
             type="text/html"
             src="{url}{qs_continuation}enablejsapi=1&playsinline=1&origin={origin}"
             frameborder="0"
             {element_data}
         ></iframe></div>""".format(
+            klass=klass,
             url=url,
             qs_continuation='&' if "?" in url else "?",
             origin='%s://%s' % (request.env.wsgi_url_scheme, request.env.http_host),
@@ -66,7 +72,7 @@ def media_embed(url, defaults=dict()):
 
     m = re.fullmatch(r'https://player.vimeo.com/video/(.+)', url)
     if m:
-        return """<div class="embed-video"><iframe
+        return """<div class="embed-video{klass}"><iframe
             class="embed-vimeo"
             src="{url}"
             frameborder="0"
@@ -74,6 +80,7 @@ def media_embed(url, defaults=dict()):
             allowfullscreen
             {element_data}
         ></iframe></div>""".format(
+            klass=klass,
             url=url,
             element_data=element_data,
         )
@@ -81,10 +88,11 @@ def media_embed(url, defaults=dict()):
     m = re.fullmatch(r'https://commons.wikimedia.org/wiki/File:(.+\.(gif|jpg|jpeg|png|svg))', url)
     if m:
         # TODO: Fetch & cache image metadata,
-        return """<a class="embed-wikimedia" title="{title}" href="{url}" {element_data}><img
+        return """<a class="embed-wikimedia{klass}" title="{title}" href="{url}" {element_data}><img
           src="https://commons.wikimedia.org/w/index.php?title=Special:Redirect/file/{name}"
           alt="{name}"
         /><span class="copyright">©</span></a>""".format(
+            klass=klass,
             title=m.group(1),
             name=m.group(1),
             url=url,
@@ -95,10 +103,11 @@ def media_embed(url, defaults=dict()):
     if m:
         # TODO: There's a dedicated audio player embed we should probably use. The purpose here
         #       is more to demonstrate HTML audio than wikipedia commons in particular.
-        return """<div class="embed-audio"><audio controls
+        return """<div class="embed-audio{klass}"><audio controls
           src="https://commons.wikimedia.org/w/index.php?title=Special:Redirect/file/{name}"
           {element_data}
           ></audio><a class="copyright" href="{url}" title="title">©</a></div>""".format(
+            klass=klass,
             title=m.group(1),
             name=m.group(1),
             url=url,
@@ -109,10 +118,11 @@ def media_embed(url, defaults=dict()):
     m = re.fullmatch(r'https://commons.wikimedia.org/wiki/File:(.+\.(ogv|webm|mpg|mpeg))', url)
     if m:
         # NB: There's an embedded player we could use, but there's no way to control it over the iframe barrrier
-        return """<div class="embed-video"><video controls
+        return """<div class="embed-video{klass}"><video controls
           src="https://commons.wikimedia.org/w/index.php?title=Special:Redirect/file/{name}"
           {element_data}
           ></video><a class="copyright" href="{url}">©</a></div>""".format(
+            klass=klass,
             title=m.group(1),
             name=m.group(1),
             url=url,

--- a/tests/unit/test_modules_embed.py
+++ b/tests/unit/test_modules_embed.py
@@ -102,6 +102,19 @@ class TestEmbed(unittest.TestCase):
             'frameborder="0"',
             '></iframe></div>',
         ])
+        # Can set classes using ": true"
+        self.assertEqual(media_embed({"url": 'https://www.youtube.com/embed/12345', "peep": True, "poop": True}, defaults=dict(ts_autoplay="tsstate-active_wait")), [
+            '<div',
+            'class="embed-video',
+            'peep',
+            'poop"><iframe',
+            'class="embed-youtube"',
+            'type="text/html"',
+            'src="https://www.youtube.com/embed/12345?enablejsapi=1&playsinline=1&origin=None://127.0.0.1:8000"',
+            'frameborder="0"',
+            'data-ts_autoplay="tsstate-active_wait"',
+            '></iframe></div>',
+        ])
 
         self.assertEqual(media_embed('https://player.vimeo.com/video/12345'), [
             '<div',

--- a/views/tour/data.html
+++ b/views/tour/data.html
@@ -52,8 +52,10 @@ ts_fields = (  # HTML fields that can be added to container
       <button type="button" class="handle" aria-label="{{=T('Exit tour')}}"></button>
       {{if tdata.get('title', ''):}}<h2 class="title">{{=tdata['title']}}</h2>{{pass}}
     </div>
-    {{for k, tag in ts_fields:}}{{if tdata.get(k, ''):}}
-    <{{=tag}} class="{{=k}}">{{=T(tdata[k])}}</{{=tag}}>{{pass}}{{pass}}
+    {{for k, tag in ts_fields:}}{{if tdata.get(k, ''):}}{{for value in tdata[k] if isinstance(tdata[k], list) else [tdata[k]]:}}
+    {{content_dict = value if isinstance(value, dict) else dict(text=value)}}
+    <{{=tag}} class="{{=' '.join(key for key, value in content_dict.items() if value is True)}}"
+        >{{=T(content_dict['text'])}}</{{=tag}}>{{pass}}{{pass}}{{pass}}
     {{if len(tdata.get('media', [])) > 0:}}{{for url in tdata['media']:}}
       {{=XML(media_embed(url, defaults=dict(ts_autoplay='tsstate-active_wait')))}}
     {{pass}}{{pass}}


### PR DESCRIPTION
Allow media & window_text to have CSS classes set against them in JSON, and add some visibility classes to use here.

Fixes #732 