### PR TITLE
Improve use of bespoke images in tours #741

### DIFF
--- a/modules/embed.py
+++ b/modules/embed.py
@@ -1,4 +1,5 @@
 import html
+import os.path
 import re
 import urllib.request
 
@@ -35,19 +36,23 @@ def media_embed(url, defaults=dict()):
     """
     request = current.request
 
+    def humanise_url(url):
+        """Turn a url into something more human-readable"""
+        return os.path.splitext(os.path.basename(url))[0].replace('_', ' ')
+
     # If url is a dict, merge provided options with the defaults
     if isinstance(url, dict):
         opts = {**defaults, **url}
         url = opts['url']
     else:
-        opts = defaults
+        opts = defaults.copy()
         url = url
 
     # Join together extra element data
     element_data = ' '.join('data-%s="%s"' % (
         key,
         html.escape(value),
-    ) for key, value in opts.items() if key != 'url' and value is not None and value is not True)
+    ) for key, value in opts.items() if key not in ('url', 'alt', 'title') and value is not None and value is not True)
 
     # List of classes from all true options
     klass = ''.join(' %s' % (
@@ -87,20 +92,27 @@ def media_embed(url, defaults=dict()):
 
     m = re.fullmatch(r'https://commons.wikimedia.org/wiki/File:(.+\.(gif|jpg|jpeg|png|svg))', url)
     if m:
+        if not opts.get('alt'):
+            opts['alt'] = humanise_url(m.group(1))
+        if not opts.get('title'):
+            opts['title'] = m.group(1)
         # TODO: Fetch & cache image metadata,
         return """<a class="embed-wikimedia{klass}" title="{title}" href="{url}" {element_data}><img
           src="https://commons.wikimedia.org/w/index.php?title=Special:Redirect/file/{name}"
-          alt="{name}"
+          alt="{alt}"
         /><span class="copyright">©</span></a>""".format(
             klass=klass,
-            title=m.group(1),
+            title=opts['title'],
             name=m.group(1),
+            alt=opts['alt'],
             url=url,
             element_data=element_data,
         )
 
     m = re.fullmatch(r'https://commons.wikimedia.org/wiki/File:(.+\.(ogg|mp3))', url)
     if m:
+        if not opts.get('title'):
+            opts['title'] = m.group(1)
         # TODO: There's a dedicated audio player embed we should probably use. The purpose here
         #       is more to demonstrate HTML audio than wikipedia commons in particular.
         return """<div class="embed-audio{klass}"><audio controls
@@ -108,7 +120,7 @@ def media_embed(url, defaults=dict()):
           {element_data}
           ></audio><a class="copyright" href="{url}" title="title">©</a></div>""".format(
             klass=klass,
-            title=m.group(1),
+            title=opts['title'],
             name=m.group(1),
             url=url,
             element_data=element_data,
@@ -117,13 +129,15 @@ def media_embed(url, defaults=dict()):
     # https://commons.wikimedia.org/wiki/Commons:File_types#Video
     m = re.fullmatch(r'https://commons.wikimedia.org/wiki/File:(.+\.(ogv|webm|mpg|mpeg))', url)
     if m:
+        if not opts.get('title'):
+            opts['title'] = m.group(1)
         # NB: There's an embedded player we could use, but there's no way to control it over the iframe barrrier
         return """<div class="embed-video{klass}"><video controls
           src="https://commons.wikimedia.org/w/index.php?title=Special:Redirect/file/{name}"
           {element_data}
           ></video><a class="copyright" href="{url}">©</a></div>""".format(
             klass=klass,
-            title=m.group(1),
+            title=opts.get('title', ''),
             name=m.group(1),
             url=url,
             element_data=element_data,
@@ -132,12 +146,15 @@ def media_embed(url, defaults=dict()):
     # Fallback without copyright link
     m = re.fullmatch(r'(.+\.(gif|jpg|jpeg|png|svg))', url)
     if m:
+        if not opts.get('alt'):
+            opts['alt'] = humanise_url(url)
         return """<a class="embed-image{klass}" {element_data}><img
           src="{url}"
-          alt=""
+          alt="{alt}"
         /></a>""".format(
             klass=klass,
             url=url,
+            alt=opts['alt'],
             element_data=element_data,
         )
     m = re.fullmatch(r'(.+\.(ogg|mp3))', url)

--- a/modules/embed.py
+++ b/modules/embed.py
@@ -129,6 +129,28 @@ def media_embed(url, defaults=dict()):
             element_data=element_data,
         )
 
+    # Fallback without copyright link
+    m = re.fullmatch(r'(.+\.(gif|jpg|jpeg|png|svg))', url)
+    if m:
+        return """<a class="embed-image{klass}" {element_data}><img
+          src="{url}"
+          alt=""
+        /></a>""".format(
+            klass=klass,
+            url=url,
+            element_data=element_data,
+        )
+    m = re.fullmatch(r'(.+\.(ogg|mp3))', url)
+    if m:
+        return """<div class="embed-audio{klass}"><audio controls
+          src="{url}"
+          {element_data}
+          ></audio></div>""".format(
+            klass=klass,
+            url=url,
+            element_data=element_data,
+        )
+
     # Fall back to linking
     return """<a href="{url}" style="font-weight:bold">{url}</a>""".format(
         url=url,

--- a/tests/unit/test_modules_embed.py
+++ b/tests/unit/test_modules_embed.py
@@ -49,8 +49,16 @@ class TestEmbed(unittest.TestCase):
 
         self.assertEqual(media_embed('https://www.wibble.com/some_image.jpg'), [
             '<a',
-            'href="https://www.wibble.com/some_image.jpg"',
-            'style="font-weight:bold">https://www.wibble.com/some_image.jpg</a>',
+            'class="embed-image"',
+            '><img',
+            'src="https://www.wibble.com/some_image.jpg"',
+            'alt=""',
+            '/></a>',
+        ])
+        self.assertEqual(media_embed('https://www.wibble.com/some_file.bin'), [
+            '<a',
+            'href="https://www.wibble.com/some_file.bin"',
+            'style="font-weight:bold">https://www.wibble.com/some_file.bin</a>',
         ])
 
         self.assertEqual(media_embed('https://www.youtube.com/embed/12345'), [

--- a/tests/unit/test_modules_embed.py
+++ b/tests/unit/test_modules_embed.py
@@ -52,7 +52,8 @@ class TestEmbed(unittest.TestCase):
             'class="embed-image"',
             '><img',
             'src="https://www.wibble.com/some_image.jpg"',
-            'alt=""',
+            'alt="some',
+            'image"',
             '/></a>',
         ])
         self.assertEqual(media_embed('https://www.wibble.com/some_file.bin'), [
@@ -143,7 +144,9 @@ class TestEmbed(unittest.TestCase):
             'href="https://commons.wikimedia.org/wiki/File:Rose_of_Jericho.gif"',
             '><img',
             'src="https://commons.wikimedia.org/w/index.php?title=Special:Redirect/file/Rose_of_Jericho.gif"',
-            'alt="Rose_of_Jericho.gif"',
+            'alt="Rose',
+            'of',
+            'Jericho"',
             '/><span',
             'class="copyright">©</span></a>',
         ])


### PR DESCRIPTION
* Allow linking to any images, even if we don't know where to send users for copyright information
* Parse alt tags from filenames, so bespoke images in a repository can use the filenames as an alt tag: ``Pumkin_toadlet_walking_on_leaf.jpeg``.