### PR TITLE
navigation/setup_page: Add default pinpoint for /life

### DIFF
--- a/OZprivate/rawJS/OZTreeModule/src/global_config.js
+++ b/OZprivate/rawJS/OZTreeModule/src/global_config.js
@@ -39,6 +39,10 @@ config.search_jump_mode = "flight";
  */
 config.home_ott_id = null
 
+/** @property {string} default_init_pinpoint - Default initial pinpoint if none specified in the URL, i.e. "/life/"
+ */
+config.default_init_pinpoint = '@Metazoa=691846';
+
 config.api = {
   /* These configure how API calls are made, and to where.
      Those ending in _api are mostly null and will be set

--- a/OZprivate/rawJS/OZTreeModule/src/navigation/setup_page.js
+++ b/OZprivate/rawJS/OZTreeModule/src/navigation/setup_page.js
@@ -26,12 +26,12 @@ function setup_page_by_state(controller, state) {
     return state.hasOwnProperty('highlights') ? controller.highlight_replace(state.highlights) : null;
   }).then(function () {
     tree_state.url_parsed = true;
-    // Skip move if no pinpoint
-    if (!state.pinpoint) return;
     if (!init) {
-      // Not init-ing tree, so fly to new location
-      return controller.default_move_to(state.pinpoint);
+      // Not init-ing tree, so fly to new location if given
+      return state.pinpoint ? controller.default_move_to(state.pinpoint) : undefined;
     }
+    // On init, move to default_init_pinpoint if none given
+    if (!state.pinpoint) state.pinpoint = config.default_init_pinpoint;
     if (!config.home_ott_id) {
         // No home_ott_id set yet, use current (initial) pinpoint as home
         // so a homepage Carnivorans link resets to Carnivorans, e.g.

--- a/OZprivate/rawJS/OZTreeModule/src/navigation/state.js
+++ b/OZprivate/rawJS/OZTreeModule/src/navigation/state.js
@@ -105,8 +105,7 @@ function parse_url_base(location) {
 
 // Pull pinpoint out of pathname, e.g. @Eukaryota=304358
 function parse_pathname(state, pathname) {
-    if (!pathname) return;
-    state.pinpoint = pathname.indexOf("@") === -1 ? null : pathname.slice(pathname.indexOf("@"));
+    state.pinpoint = pathname && pathname.indexOf("@") > -1 ? pathname.replace(/^[^@]*/, '') : undefined;
 }
 
 /// pathname should equal pinpoint


### PR DESCRIPTION
When visiting /life/ without a pinpoint, the tree isn't centered, do an intial flight to properly init the tree.

This also gives us a better default location than "All life", which isn't great visually or scientifically.

Fixes #742