### PR TITLE
More tour media enhancements

### DIFF
--- a/controllers/tour.py
+++ b/controllers/tour.py
@@ -66,7 +66,10 @@ media
         media: [
             "https://www.youtube.com/embed/ayOmAJwCMlM",
             "https://commons.wikimedia.org/wiki/File:Rose_of_Jericho.gif",
+            "frogs/Various_frogs_and_toads.jpeg"
         ],
+
+    In the final case, the URL will be expanded to "https://onezoom.github.io/tours/frogs/Various_frogs_and_toads.jpeg".
 
     By default media will autoplay when arriving at the tourstop, and stop when leaving. You can override with:
 

--- a/modules/embed.py
+++ b/modules/embed.py
@@ -1,6 +1,7 @@
 import html
 import os.path
 import re
+import urllib.parse
 import urllib.request
 
 from gluon import current
@@ -49,11 +50,15 @@ def media_embed(url, defaults=dict()):
         opts = defaults.copy()
         opts['url'] = url
 
+    # URLs should be relative to any URL base
+    if opts.get('url_base'):
+        opts['url'] = urllib.parse.urljoin(opts['url_base'], opts['url'])
+
     # Join together extra element data
     opts['element_data'] = ' '.join('data-%s="%s"' % (
         key,
         html.escape(value),
-    ) for key, value in opts.items() if key not in ('url', 'alt', 'title') and value is not None and value is not True)
+    ) for key, value in opts.items() if key not in ('url', 'url_base', 'alt', 'title') and value is not None and value is not True)
 
     # List of classes from all true options
     opts['klass'] = ''.join(' %s' % (

--- a/modules/embed.py
+++ b/modules/embed.py
@@ -7,6 +7,8 @@ from gluon import current
 from gluon.http import HTTP
 from gluon.utils import web2py_uuid
 
+import img
+
 def embedize_url(url, email):
     request = current.request
     db = current.db
@@ -57,6 +59,22 @@ def media_embed(url, defaults=dict()):
     opts['klass'] = ''.join(' %s' % (
         html.escape(key),
     ) for key, value in opts.items() if key != 'url' and value is True)
+
+    m = re.fullmatch(r'imgsrc:(\d+):(\d+)', opts['url'])
+    if m:
+        opts['src_url'] = img.url(opts['url'])
+        opts['url'] = '/tree/pic_info/%s/%s' % (
+            m.group(1),
+            m.group(2),
+        )
+        if not opts.get('alt'):
+            opts['alt'] = ""
+        if not opts.get('title'):
+            opts['title'] = ""
+        return """<a class="embed-image{klass}" title="{title}" href="{url}" {element_data}><img
+          src="{src_url}"
+          alt="{alt}"
+        /><span class="copyright">©</span></a>""".format(**opts)
 
     m = re.fullmatch(r'https://www.youtube.com/embed/(.+)', opts['url'])
     if m:

--- a/tests/unit/test_modules_embed.py
+++ b/tests/unit/test_modules_embed.py
@@ -62,6 +62,18 @@ class TestEmbed(unittest.TestCase):
             'style="font-weight:bold">https://www.wibble.com/some_file.bin</a>',
         ])
 
+        self.assertEqual(media_embed('imgsrc:99:27732437'), [
+            '<a',
+            'class="embed-image"',
+            'title=""',
+            'href="/tree/pic_info/99/27732437"',
+            '><img',
+            'src="http://127.0.0.1:8000/OZtree/static/FinalOutputs/img/99/437/27732437.jpg"',
+            'alt=""',
+            '/><span',
+            'class="copyright">©</span></a>',
+        ])
+
         self.assertEqual(media_embed('https://www.youtube.com/embed/12345'), [
             '<div',
             'class="embed-video"><iframe',

--- a/tests/unit/test_modules_embed.py
+++ b/tests/unit/test_modules_embed.py
@@ -73,6 +73,11 @@ class TestEmbed(unittest.TestCase):
             '/><span',
             'class="copyright">©</span></a>',
         ])
+        # Base doesn't rewrite imgsrc: URLs
+        self.assertEqual(
+            media_embed('imgsrc:99:27732437'),
+            media_embed('imgsrc:99:27732437', defaults=dict(url_base="https://moo.com/base")),
+        )
 
         self.assertEqual(media_embed('https://www.youtube.com/embed/12345'), [
             '<div',
@@ -198,6 +203,11 @@ class TestEmbed(unittest.TestCase):
             '/><span',
             'class="copyright">©</span></a>',
         ])
+        # Can use a URL base
+        self.assertEqual(
+            media_embed('https://onezoom.github.io/tours/frogs/Various_frogs_and_toads.jpeg'),
+            media_embed('frogs/Various_frogs_and_toads.jpeg', defaults=dict(url_base='https://onezoom.github.io/tours/')),
+        )
 
 if __name__ == '__main__':
     import sys

--- a/views/tour/data.html
+++ b/views/tour/data.html
@@ -57,7 +57,7 @@ ts_fields = (  # HTML fields that can be added to container
     <{{=tag}} class="{{=' '.join(key for key, value in content_dict.items() if value is True)}}"
         >{{=T(content_dict['text'])}}</{{=tag}}>{{pass}}{{pass}}{{pass}}
     {{if len(tdata.get('media', [])) > 0:}}{{for url in tdata['media']:}}
-      {{=XML(media_embed(url, defaults=dict(ts_autoplay='tsstate-active_wait')))}}
+      {{=XML(media_embed(url, defaults=dict(ts_autoplay='tsstate-active_wait', url_base='https://onezoom.github.io/tours/')))}}
     {{pass}}{{pass}}
 
     <div class="actions"><a href="#share-modal" class="tour_pause oz-pill pill-share" style="float: right" uk-toggle>{{=T('Share')}}</a></div>


### PR DESCRIPTION
Make tour media URLs relative to https://onezoom.github.io/tours/

Support imgsrc: in media URLs.

References #741 