### PR TITLE
Allow tours to include youtube clips

### DIFF
--- a/OZprivate/rawJS/OZTreeModule/src/tour/handler/Youtube.js
+++ b/OZprivate/rawJS/OZTreeModule/src/tour/handler/Youtube.js
@@ -51,6 +51,10 @@ function handler(tour) {
           if (event.data == YT.PlayerState.ENDED) {
             tourstop.block_remove(block_name);
           } else if (event.data == YT.PlayerState.PLAYING && tourstop.state === iframe.autoplay_states.slice(-1)[0]) {
+            if (el.ozStartPos === undefined) {  // NB: not falsey, since startPos may be 0
+                // First time we've seen a player start, record start time.
+                el.ozStartPos = Math.floor(window.YT.get(el.id).getCurrentTime());
+            }
             tourstop.block_add(block_name);
           }
           // NB; Ignore other events, particularly UNSTARTED since this happens after end
@@ -65,7 +69,11 @@ function handler(tour) {
 
         if (player.getPlayerState() === YT.PlayerState.PLAYING && window.getComputedStyle(el_ts).visibility !== 'visible') {
           // Shouldn't ever play whilst invisible
-          player.stopVideo();
+          player.pauseVideo();
+          // Reset to start
+          // NB: We can't use stopVideo() to do this, since it will also clear any video clip from the URL
+          // NB: We also can't do seekTo(0), since seekTo() isn't relative to a clip
+          if (el.ozStartPos !== undefined) player.seekTo(el.ozStartPos);
         } else if (el.autoplay_states.indexOf(tourstop.state) > -1) {
           player.playVideo();
 

--- a/OZprivate/rawJS/OZTreeModule/src/tour/handler/Youtube.js
+++ b/OZprivate/rawJS/OZTreeModule/src/tour/handler/Youtube.js
@@ -63,7 +63,7 @@ function handler(tour) {
       el_ts.querySelectorAll(":scope iframe.embed-youtube").forEach((el) => {
         const player = window.YT.get(el.id);
 
-        if (window.getComputedStyle(el_ts).visibility !== 'visible') {
+        if (player.getPlayerState() === YT.PlayerState.PLAYING && window.getComputedStyle(el_ts).visibility !== 'visible') {
           // Shouldn't ever play whilst invisible
           player.stopVideo();
         } else if (el.autoplay_states.indexOf(tourstop.state) > -1) {

--- a/OZprivate/rawJS/OZTreeModule/src/tour/handler/Youtube.js
+++ b/OZprivate/rawJS/OZTreeModule/src/tour/handler/Youtube.js
@@ -40,7 +40,7 @@ function handler(tour) {
     }
   }).then(() => {
     // Create a new player object for every existing iframe & block progression when playing
-    return Promise.all(el_yts.map((el_yt) => new Promise((resolve) => new YT.Player(el_yt, {
+    return Promise.all(el_yts.map((el) => new Promise((resolve) => new YT.Player(el, {
       events: {
         onReady: resolve,
         onStateChange: function (event) {
@@ -61,15 +61,17 @@ function handler(tour) {
     // Attach observers for any autoplaying video
     tour.tourstop_observer('.contains-youtube', '*', (tour, tourstop, el_ts) => {
       el_ts.querySelectorAll(":scope iframe.embed-youtube").forEach((el) => {
+        const player = window.YT.get(el.id);
+
         if (window.getComputedStyle(el_ts).visibility !== 'visible') {
           // Shouldn't ever play whilst invisible
-          window.YT.get(el.id).stopVideo();
+          player.stopVideo();
         } else if (el.autoplay_states.indexOf(tourstop.state) > -1) {
-          window.YT.get(el.id).playVideo();
+          player.playVideo();
 
           // Check to see if final block should be added
           if (tourstop.state === el.autoplay_states.slice(-1)[0]) {
-            if (window.YT.get(el.id).getPlayerState() === YT.PlayerState.PLAYING) {
+            if (player.getPlayerState() === YT.PlayerState.PLAYING) {
               tourstop.block_add(el.src);
             }
           }

--- a/modules/embed.py
+++ b/modules/embed.py
@@ -90,6 +90,8 @@ def media_embed(url, defaults=dict()):
             type="text/html"
             src="{url}{qs_continuation}enablejsapi=1&playsinline=1&origin={origin}"
             frameborder="0"
+            allow="autoplay; fullscreen"
+            allowfullscreen
             {element_data}
         ></iframe></div>""".format(**opts)
 

--- a/tests/unit/test_modules_embed.py
+++ b/tests/unit/test_modules_embed.py
@@ -86,6 +86,9 @@ class TestEmbed(unittest.TestCase):
             'type="text/html"',
             'src="https://www.youtube.com/embed/12345?enablejsapi=1&playsinline=1&origin=None://127.0.0.1:8000"',
             'frameborder="0"',
+            'allow="autoplay;',
+            'fullscreen"',
+            'allowfullscreen',
             '></iframe></div>',
         ])
         self.assertEqual(media_embed('https://www.youtube.com/embed/12345?clip=sausage'), [
@@ -95,6 +98,9 @@ class TestEmbed(unittest.TestCase):
             'type="text/html"',
             'src="https://www.youtube.com/embed/12345?clip=sausage&enablejsapi=1&playsinline=1&origin=None://127.0.0.1:8000"',
             'frameborder="0"',
+            'allow="autoplay;',
+            'fullscreen"',
+            'allowfullscreen',
             '></iframe></div>',
         ])
         self.assertEqual(media_embed('https://www.youtube.com/embed/12345', defaults=dict(ts_autoplay="tsstate-active_wait", camel='"yes"')), [
@@ -104,6 +110,9 @@ class TestEmbed(unittest.TestCase):
             'type="text/html"',
             'src="https://www.youtube.com/embed/12345?enablejsapi=1&playsinline=1&origin=None://127.0.0.1:8000"',
             'frameborder="0"',
+            'allow="autoplay;',
+            'fullscreen"',
+            'allowfullscreen',
             'data-ts_autoplay="tsstate-active_wait"',
             'data-camel="&quot;yes&quot;"',
             '></iframe></div>',
@@ -116,6 +125,9 @@ class TestEmbed(unittest.TestCase):
             'type="text/html"',
             'src="https://www.youtube.com/embed/12345?enablejsapi=1&playsinline=1&origin=None://127.0.0.1:8000"',
             'frameborder="0"',
+            'allow="autoplay;',
+            'fullscreen"',
+            'allowfullscreen',
             'data-ts_autoplay="nothanks"',
             '></iframe></div>',
         ])
@@ -126,6 +138,9 @@ class TestEmbed(unittest.TestCase):
             'type="text/html"',
             'src="https://www.youtube.com/embed/12345?enablejsapi=1&playsinline=1&origin=None://127.0.0.1:8000"',
             'frameborder="0"',
+            'allow="autoplay;',
+            'fullscreen"',
+            'allowfullscreen',
             '></iframe></div>',
         ])
         # Can set classes using ": true"
@@ -138,6 +153,9 @@ class TestEmbed(unittest.TestCase):
             'type="text/html"',
             'src="https://www.youtube.com/embed/12345?enablejsapi=1&playsinline=1&origin=None://127.0.0.1:8000"',
             'frameborder="0"',
+            'allow="autoplay;',
+            'fullscreen"',
+            'allowfullscreen',
             'data-ts_autoplay="tsstate-active_wait"',
             '></iframe></div>',
         ])


### PR DESCRIPTION
Calling ``stopVideo()`` will clear any current clip, on replay we start at the very beginning on the video. Instead, pause and seek the video to the first position we saw.

As a bonus, enable autoplay for youtube. It was only working on vimeo before because we had only enabled it for vimeo before.

Fixes #737