### PR TITLE
Unit tests errors & CI

### DIFF
--- a/.github/workflows/test-client.yml
+++ b/.github/workflows/test-client.yml
@@ -1,0 +1,28 @@
+name: OZTreeModule CI
+
+on:
+  push:
+    branches:
+      - main
+      - production
+    tags:
+      - 'v*'
+  pull_request:
+    branches:
+      - main
+      - production
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18.x'
+      - run: npm ci
+      - run: npm run build --if-present
+      - run: npm test

--- a/OZprivate/rawJS/OZTreeModule/src/navigation/state.js
+++ b/OZprivate/rawJS/OZTreeModule/src/navigation/state.js
@@ -105,7 +105,9 @@ function parse_url_base(location) {
 
 // Pull pinpoint out of pathname, e.g. @Eukaryota=304358
 function parse_pathname(state, pathname) {
-    state.pinpoint = pathname && pathname.indexOf("@") > -1 ? pathname.replace(/^[^@]*/, '') : undefined;
+    if (pathname) {
+        state.pinpoint = pathname.indexOf("@") > -1 ? pathname.replace(/^[^@]*/, '') : null;
+    }
 }
 
 /// pathname should equal pinpoint

--- a/tests/unit/test_modules_tour.py
+++ b/tests/unit/test_modules_tour.py
@@ -83,21 +83,21 @@ class TestModuleTour(unittest.TestCase):
         # Search in both title and description
         out = tour.tour_search("things")
         self.assertEqual(
-            [o.identifier for o in out],
+            [o.identifier for o in out if o.identifier.startswith('UT::')],
             [tour1['identifier'], tour2['identifier']],
         )
 
         # String only in description
         out = tour.tour_search("stuff")
         self.assertEqual(
-            [o.identifier for o in out],
+            [o.identifier for o in out if o.identifier.startswith('UT::')],
             [tour2['identifier']],
         )
 
         # String only in title
         out = tour.tour_search("first")
         self.assertEqual(
-            [o.identifier for o in out],
+            [o.identifier for o in out if o.identifier.startswith('UT::')],
             [tour1['identifier']],
         )
 


### PR DESCRIPTION
Fix some failing tests as a result of previous commits.

Also, add some CI for the client, so there's less chance of pushes breaking tests.