### PR TITLE
Remove default pinpoint config 

### DIFF
--- a/OZprivate/rawJS/OZTreeModule/src/controller/controller_anim.js
+++ b/OZprivate/rawJS/OZTreeModule/src/controller/controller_anim.js
@@ -392,9 +392,13 @@ export default function (Controller) {
       // Leap to node
       return this.leap_to(dest_OZid, into_node=into_node)
         .then(() => {
-          // Zoom out marginally
-          // TODO: This will refuse to go back further than a given point, but that's much futher back than before
-          this.zoomout(tree_state.widthres / 2, tree_state.heightres / 2, 0.1, true);
+          if (dest_OZid === 1) {
+            // Tree root, so zoom *in* marginally & zoom back out
+            this.zoomin(tree_state.widthres / 2, tree_state.heightres / 2, 0.4, true);
+          } else {
+            // Zoom out marginally
+            this.zoomout(tree_state.widthres / 2, tree_state.heightres / 2, 0.1, true);
+          }
           // Fly back in again
           return this.fly_on_tree_to(null, dest_OZid, into_node=into_node);
         })

--- a/OZprivate/rawJS/OZTreeModule/src/global_config.js
+++ b/OZprivate/rawJS/OZTreeModule/src/global_config.js
@@ -39,10 +39,6 @@ config.search_jump_mode = "flight";
  */
 config.home_ott_id = null
 
-/** @property {string} default_init_pinpoint - Default initial pinpoint if none specified in the URL, i.e. "/life/"
- */
-config.default_init_pinpoint = '@Metazoa=691846';
-
 config.api = {
   /* These configure how API calls are made, and to where.
      Those ending in _api are mostly null and will be set

--- a/OZprivate/rawJS/OZTreeModule/src/navigation/setup_page.js
+++ b/OZprivate/rawJS/OZTreeModule/src/navigation/setup_page.js
@@ -30,8 +30,8 @@ function setup_page_by_state(controller, state) {
       // Not init-ing tree, so fly to new location if given
       return state.pinpoint ? controller.default_move_to(state.pinpoint) : undefined;
     }
-    // On init, move to default_init_pinpoint if none given
-    if (!state.pinpoint) state.pinpoint = config.default_init_pinpoint;
+    // On init, move to tree root if no other pinpoint given
+    if (!state.pinpoint) state.pinpoint = '@_ozid=1';
     if (!config.home_ott_id) {
         // No home_ott_id set yet, use current (initial) pinpoint as home
         // so a homepage Carnivorans link resets to Carnivorans, e.g.


### PR DESCRIPTION
We decided having an extra tree-dependent config option wasn't worth the heart-ache, so removing.

Mitigate my concerns about pzoom to @biota by pzooming out, as a special case.

Fixes #742