### PR TITLE
Resurrexct screenshot tool #463

### DIFF
--- a/views/treeviewer/life_expert.html
+++ b/views/treeviewer/life_expert.html
@@ -60,9 +60,14 @@ setup_params = {
                 height: document.getElementById("OneZoomCanvasID").height,
             });
             onezoom.controller.draw_single_frame(context);
-            var svg_content = context.getSerializedSvg(true);
-            /* Change MIME type to trick the browser to download the file instead of displaying it */
-            lnk.href = 'data:image/svg+xml;charset=utf-8,' + encodeURIComponent(svg_content);
+            lnk.href = URL.createObjectURL(new Blob([context.getSerializedSvg(true)], {
+                type: "image/svg+xml",
+            }));
+            lnk.download = 'onezoom.svg';  // Download file, instead of opening in browser
+            window.setTimeout(function () {
+                URL.revokeObjectURL(lnk.href);
+            }, 100);
+
             return true;
         } catch (err) {
             alert("You can't save pictures with embedded images unless you enable '-allow-file-access-from-files' in chrome, or equivalent in other browsers.")


### PR DESCRIPTION
Navigating to data: uris like is no longer kosher. Instead, serialise the SVG into a blob, and set the href to a reference to this.

Fixes #463 