### PR TITLE
Issue 781 markdown in tours

### DIFF
--- a/OZprivate/scss/tour.scss
+++ b/OZprivate/scss/tour.scss
@@ -110,6 +110,10 @@
     flex-shrink: 10;
     overflow-y: auto;
   }
+  .window_text > p:last-child {
+    /* Remove margins from final paragraph within window_text */
+    margin-bottom: 0;
+  }
 
   .tour_container > iframe, .tour_container > a.embed-image, .tour_container > .embed-audio, .tour_container > .embed-video {
     flex-grow: 1000;

--- a/modules/embed.py
+++ b/modules/embed.py
@@ -123,7 +123,7 @@ def media_embed(url, defaults=dict()):
             return """<div class="embed-audio{klass}"><audio controls
               src="{src_url}"
               {element_data}
-              ></audio><a class="copyright" href="{url}" title="title">©</a></div>""".format(**opts)
+              ></audio><a class="copyright" href="{url}">©</a></div>""".format(**opts)
         if m.group(2) in ('ogv', 'webm', 'mpg', 'mpeg'):
             return """<div class="embed-video{klass}"><video controls
               src="{src_url}"
@@ -150,7 +150,7 @@ def media_embed(url, defaults=dict()):
             return """<div class="embed-audio{klass}"><audio controls
               src="{src_url}"
               {element_data}
-              ></audio><a class="copyright" href="{url}" title="title">©</a></div>""".format(**opts)
+              ></audio><a class="copyright" href="{url}">©</a></div>""".format(**opts)
         if m.group(2) in ('ogv', 'webm', 'mpg', 'mpeg'):
             return """<div class="embed-video{klass}"><video controls
               src="{src_url}"

--- a/modules/markdown.py
+++ b/modules/markdown.py
@@ -1,0 +1,21 @@
+from gluon import current
+from gluon.contrib.markdown.markdown2 import Markdown
+
+def markdown(text):
+    if not hasattr(current, 'oz_markdown'):
+        current.oz_markdown = Markdown(
+            safe_mode="escape",
+        )
+
+    return current.oz_markdown.convert(text)
+
+if __name__ == '__main__':
+    import sys
+
+    if current.globalenv['is_testing'] != True:
+        raise RuntimeError("Do not run tests in production environments, ensure is_testing = True")
+    suite = unittest.TestSuite()
+    suite.addTest(unittest.makeSuite(TestEmbed))
+    result = unittest.TextTestRunner(verbosity=2).run(suite)
+    if not result.wasSuccessful():
+        sys.exit(1)

--- a/tests/unit/test_modules_embed.py
+++ b/tests/unit/test_modules_embed.py
@@ -193,8 +193,7 @@ class TestEmbed(unittest.TestCase):
             'src="https://commons.wikimedia.org/w/index.php?title=Special:Redirect/file/Turdus_philomelos.ogg"',
             '></audio><a',
             'class="copyright"',
-            'href="https://commons.wikimedia.org/wiki/File:Turdus_philomelos.ogg"',
-            'title="title">©</a></div>',
+            'href="https://commons.wikimedia.org/wiki/File:Turdus_philomelos.ogg">©</a></div>',
         ])
 
         self.assertEqual(media_embed('https://commons.wikimedia.org/wiki/File:Intense_bone_fluorescence_reveals_hidden_patterns_in_pumpkin_toadlets_-_video_1_-_41598_2019_41959_MOESM2_ESM.webm'), [

--- a/tests/unit/test_modules_markdown.py
+++ b/tests/unit/test_modules_markdown.py
@@ -1,0 +1,42 @@
+"""
+Run with::
+
+    ./web2py-run tests/unit/test_modules_markdown.py
+
+"""
+import re
+import unittest
+
+from gluon.globals import Request
+from gluon.http import HTTP
+
+from applications.OZtree.tests.unit import util
+
+import markdown
+
+
+class TestMarkdown(unittest.TestCase):
+    maxDiff = None
+
+    def test_markdown_safemode(self):
+        """Raw HTML isn't allowed"""
+        self.assertEqual(markdown.markdown("""
+*Hello there*
+
+<b>I am in your HTML</b>
+""").strip(), """
+<p><em>Hello there</em></p>
+
+<p>&lt;b&gt;I am in your HTML&lt;/b&gt;</p>
+""".strip())
+
+if __name__ == '__main__':
+    import sys
+
+    if current.globalenv['is_testing'] != True:
+        raise RuntimeError("Do not run tests in production environments, ensure is_testing = True")
+    suite = unittest.TestSuite()
+    suite.addTest(unittest.makeSuite(TestMarkdown))
+    result = unittest.TextTestRunner(verbosity=2).run(suite)
+    if not result.wasSuccessful():
+        sys.exit(1)

--- a/views/tour/data.html
+++ b/views/tour/data.html
@@ -1,5 +1,6 @@
 {{
 from applications.OZtree.modules.embed import media_embed
+from applications.OZtree.modules.markdown import markdown
 ts_classes = (  # CSS classes that can be added to template_data as boolean properties
     'visible-transition_in',
     'visible-transition_in_wait',
@@ -55,7 +56,7 @@ ts_fields = (  # HTML fields that can be added to container
     {{for k, tag in ts_fields:}}{{if tdata.get(k, ''):}}{{for value in tdata[k] if isinstance(tdata[k], list) else [tdata[k]]:}}
     {{content_dict = value if isinstance(value, dict) else dict(text=value)}}
     <{{=tag}} class="{{=k}} {{=' '.join(key for key, value in content_dict.items() if value is True)}}"
-        >{{=T(content_dict['text'])}}</{{=tag}}>{{pass}}{{pass}}{{pass}}
+        >{{=XML(markdown(content_dict['text']))}}</{{=tag}}>{{pass}}{{pass}}{{pass}}
     {{if len(tdata.get('media', [])) > 0:}}{{for url in tdata['media']:}}
       {{=XML(media_embed(url, defaults=dict(ts_autoplay='tsstate-active_wait', url_base='https://onezoom.github.io/tours/')))}}
     {{pass}}{{pass}}

--- a/views/tour/data.html
+++ b/views/tour/data.html
@@ -54,7 +54,7 @@ ts_fields = (  # HTML fields that can be added to container
     </div>
     {{for k, tag in ts_fields:}}{{if tdata.get(k, ''):}}{{for value in tdata[k] if isinstance(tdata[k], list) else [tdata[k]]:}}
     {{content_dict = value if isinstance(value, dict) else dict(text=value)}}
-    <{{=tag}} class="{{=' '.join(key for key, value in content_dict.items() if value is True)}}"
+    <{{=tag}} class="{{=k}} {{=' '.join(key for key, value in content_dict.items() if value is True)}}"
         >{{=T(content_dict['text'])}}</{{=tag}}>{{pass}}{{pass}}{{pass}}
     {{if len(tdata.get('media', [])) > 0:}}{{for url in tdata['media']:}}
       {{=XML(media_embed(url, defaults=dict(ts_autoplay='tsstate-active_wait', url_base='https://onezoom.github.io/tours/')))}}


### PR DESCRIPTION
Put tour window_text content through web2py's bundled markdown parser.

Enable ``safe_mode``, so we at least don't allow raw HTML, but we will want to revisit this before allowing user generated content, as links (e.g.) would still be possible.

Fixes #781 