### PR TITLE
navigation/state: deparse states missing a pinpoint #785

### DIFF
--- a/OZprivate/rawJS/OZTreeModule/src/navigation/state.js
+++ b/OZprivate/rawJS/OZTreeModule/src/navigation/state.js
@@ -112,7 +112,8 @@ function parse_pathname(state, pathname) {
 
 /// pathname should equal pinpoint
 function deparse_pathname(state) {
-    return state.url_base + state.pinpoint;
+    // NB: In some cases, pinpoint may be null: https://github.com/OneZoom/OZtree/issues/785
+    return state.url_base + (state.pinpoint || '');
 }
 
 /**

--- a/OZprivate/rawJS/OZTreeModule/tests/test_navigation_state.js
+++ b/OZprivate/rawJS/OZTreeModule/tests/test_navigation_state.js
@@ -91,5 +91,8 @@ test('deparse_state', function (t) {
     test_url_match("http://onezoom.example.com/life/@=6794#x1402,y364,w1.4013");
     test_url_match("http://onezoom.example.com/life/@Myzopoda_aurita?otthome=%40_ancestor%3D983483%3D3600795");
 
+    // URLs without a pinpoint pass through unscathed
+    test_url_match("http://onezoom.example.com/life/?tour=%2Fmoo%2Foink.html");
+
     t.end();
 });


### PR DESCRIPTION
If a state doesn't have a pinpoint, we shouldn't be appending null to it.

Why this is the case I'm not sure, but this should at least stop URLs filling with "null/".