### PR TITLE
views/life_MD: Disable tours in museum display #810

### DIFF
--- a/views/treeviewer/UI_layer.load
+++ b/views/treeviewer/UI_layer.load
@@ -139,7 +139,7 @@ advSchbx='<li class="searchbox uk-search uk-search-default"><div><div class="sea
 </div>
 
 <div class="ui-bottomleft">
-  <ul class="ui-controls uk-iconnav uk-iconnav-vertical">
+  <ul class="ui-controls ui-controls-tours uk-iconnav uk-iconnav-vertical">
     <li id="toursButton">
       <div class="icon-container">
         <a href="#tours-modal" uk-toggle uk-icon="icon: location"></a>

--- a/views/treeviewer/life_MDmouse.html
+++ b/views/treeviewer/life_MDmouse.html
@@ -49,6 +49,7 @@ setup_params = {
 .ui-controls #hideControlsButton,
 .ui-controls #howToUseButton { display: block; }
 
+.ui-controls.ui-controls-tours { display: none; }
 .ui-controls #settingsButton { display: none; }
 </style>
 <!-- bespoke css file for museum display -->

--- a/views/treeviewer/life_MDtouch.html
+++ b/views/treeviewer/life_MDtouch.html
@@ -46,6 +46,7 @@ setup_params = {
 .ui-controls #hideControlsButton,
 .ui-controls #howToUseButton { display: block; }
 
+.ui-controls.ui-controls-tours { display: none; }
 .ui-controls #settingsButton { display: none; }
 </style>
 <!-- bespoke css file for museum display -->


### PR DESCRIPTION
The tours contain media copyright links we can't remove, and once followed you're outside the onezoom sandbox.

We either need to pop-up-ize them like we do with wikipedia, or pull an attribution line in javascript. Either is relatively fiddly.

Disable tours for now. NB: the tours tab is already disabled, so we just have to hide the controls at the side.