### PR TITLE
appconfig.ini.example: Set save_to_tmp_file_dir

### DIFF
--- a/private/appconfig.ini.example
+++ b/private/appconfig.ini.example
@@ -27,6 +27,8 @@ separator =
 
 [paypal]
 url        = https://www.sandbox.paypal.com
+; If set to "/var/tmp" e.g, the raw data received from Paypal will be dumped here.
+save_to_tmp_file_dir =
 
 [general]
 


### PR DESCRIPTION
We *have* to set save_to_tmp_file_dir, otherwise PP_process_post falls over. Add an empty default to the example.