### PR TITLE
modules/sponsorship: Force copying username on expire-repurchase #645

### DIFF
--- a/models/db.py
+++ b/models/db.py
@@ -468,6 +468,7 @@ db.define_table('reservations',
     # a login, we will always use the reservations.username value.
     # The reservations.username field is optional but needed if the user is to have a
     # "public" page of all their sponsorships 
+    # NB: Ideally the default of this field would be None, not "" - https://github.com/OneZoom/OZtree/issues/645
     Field('e_mail', type='string', length=200, requires=IS_EMPTY_OR(IS_EMAIL())),
     Field('twitter_name', type='text'),
     Field('allow_contact', type=boolean, default=False),

--- a/modules/sponsorship.py
+++ b/modules/sponsorship.py
@@ -350,6 +350,8 @@ def reservation_confirm_payment(basket_code, total_paid_pence, basket_fields):
                 # Renewal of expired entry, bump verified_time, keep old reserve time
                 fields_to_update['verified_time'] = request.now
                 fields_to_update['reserve_time'] = prev_row.reserve_time
+                # NB: The default of username is "", not None, so "r[k] is None" below may not notice - https://github.com/OneZoom/OZtree/issues/645
+                fields_to_update["username"] = prev_row.username
                 if prev_row.partner_name:
                     fields_to_update['partner_name'] = prev_row.partner_name
 

--- a/tests/unit/util.py
+++ b/tests/unit/util.py
@@ -254,7 +254,10 @@ def purchase_reservation(otts = 1, basket_details = None, paypal_details = None,
 
 
 def verify_reservation(reservation_row, **kwargs):
-    """Emulate verification logic in controllers/manage.py:SPONSOR_UPDATE"""
+    """
+    Emulate verification logic in controllers/manage.py:SPONSOR_UPDATE
+    and return the username
+    """
     # Add verified options
     reservation_row.update_record(
         verified_time=current.request.now,
@@ -269,3 +272,4 @@ def verify_reservation(reservation_row, **kwargs):
         username=username,
         **kwargs,
     )
+    return username


### PR DESCRIPTION
The default of the username field is '', not None. This means our default copying machinations may not trigger.

This was a problem in production, resulting in:

  https://github.com/hyanwong/OZtree/commit/548ecbce15f24fc2f89e148dd282efde91953857

This is essentially a forward-port of that commit, without the linting.

This isn't actually an immediate problem though, thanks to:

  https://github.com/OneZoom/OZtree/commit/5f81922c8833a5cd12aa024dc2faf02ecc211599

...which NULLs old records to preserve view counts, meaning it's very unlikely that we recreate a record on expire-repurchase.

However, the unit test is still valuable, and there's not much harm in forcing the username field.