### PR TITLE
Require a config flag to enable auto translation

### DIFF
--- a/models/db.py
+++ b/models/db.py
@@ -42,7 +42,7 @@ else:
 ## Configure i18n
 T.set_current_languages('en', 'en-en')
 # Allow translators to add new languages e.g. on the test (beta) site, but not on prod
-T.is_writable = is_testing
+T.is_writable = is_testing and myconf.get('general.allow_translation_string_writing')
 #ALL pages can set ?lang=XXX to override the browser default for translating strings
 if request.vars.lang:
     T.force(request.vars.lang)

--- a/private/appconfig.ini.example
+++ b/private/appconfig.ini.example
@@ -31,6 +31,8 @@ url        = https://www.sandbox.paypal.com
 save_to_tmp_file_dir =
 
 [general]
+; Enable "automatic translations" behavior. Ignored unless is_testing is also set
+; allow_translation_string_writing = 1
 
 [images]
 ; * url_base: get thumbnail images from this source. If not


### PR DESCRIPTION
Fixes #832

I've tested it:
- With no flag
- With flag set to 0
- With flag set to 1