### PR TITLE
Include periods when stripping /life/ from URL

### DIFF
--- a/views/treeviewer/layout.html
+++ b/views/treeviewer/layout.html
@@ -224,7 +224,7 @@ function closeAndLeap(event, href, original_searchbox, input_type) {
         onezoom.controller.default_move_to(href, 'ancestor');
     } else {
         // Strip /life/ from any URL, update tree state
-        onezoom.controller.set_treestate(href.replace(/^\/[A-Z_\-/]+/i, ''));
+        onezoom.controller.set_treestate(href.replace(/^\/[A-Z_\-/.]+/i, ''));
     }
 }
 


### PR DESCRIPTION
Fixes #843

Note that the period does not need escaping as it appears inside a character class.