### PR TITLE
controllers/default: 303 redirect after sponsor_renew_request

### DIFF
--- a/controllers/default.py
+++ b/controllers/default.py
@@ -631,10 +631,11 @@ def sponsor_renew_request():
         INPUT(_name='user_identifier', _class="uk-input uk-margin-bottom"),
         INPUT(_type='submit', _class="oz-pill pill-leaf"))
     if form.accepts(request.vars, session=None):
-        response.flash = sponsor_renew_request_logic(
+        session.flash = sponsor_renew_request_logic(
             form.vars.user_identifier.strip(),
             mailer=ozmail.get_mailer()
         )
+        redirect(URL())
     return dict(
         form=form,
     )


### PR DESCRIPTION
To avoid potential resent emails on refresh, send a 303 redirect to the current page after successful e-mail send.

This means we need to store the flash message in the session, which isn't ideal, but is already on our radar anyway.

Fixes #841 