### PR TITLE
Fix location dropdown on mobile

### DIFF
--- a/views/treeviewer/layout.html
+++ b/views/treeviewer/layout.html
@@ -294,7 +294,7 @@ function update_location_menu(loc_root) {
             .click(function() { /* close And Fly */
               if (((document.getElementById("locationDropdown").offsetWidth)*2) > onezoom.tree_state.widthres) {
                 {{if is_testing:}}console.log("Small screen width detected, so closing location box before jump");{{pass}}
-                $("#locationDropdown").hide();
+                UIkit.dropdown($("#locationDropdown")).hide();
               };
               onezoom.controller.default_move_to($(this).data('pinpoint'));
             })


### PR DESCRIPTION
https://github.com/OneZoom/OZtree/issues/883

Previously, it would disappear after the first use.