### PR TITLE
Don't round font sizes

### DIFF
--- a/OZprivate/rawJS/OZTreeModule/src/projection/shapes/arc_text_shape.js
+++ b/OZprivate/rawJS/OZTreeModule/src/projection/shapes/arc_text_shape.js
@@ -27,9 +27,9 @@ class ArcTextShape extends BaseShape {
     context.save();    
     // we need a monospaced font in order for this not to look rubbish
     if (this.font_style) {
-      context.font = this.font_style + ' ' + ((Math.floor(this.width)).toString() + 'px courier');
+      context.font = this.font_style + ' ' + (this.width.toString() + 'px courier');
     } else {
-      context.font = ((Math.floor(this.width)).toString() + 'px courier');
+      context.font = (this.width.toString() + 'px courier');
     }
     // context.fillStyle = textColor;
     if (this.do_fill) {

--- a/OZprivate/rawJS/OZTreeModule/src/ui/leaf_draw.js
+++ b/OZprivate/rawJS/OZTreeModule/src/ui/leaf_draw.js
@@ -62,11 +62,11 @@ function autotext(dostroke, fontStyle, fonttype, mintextsize, texttodisp, textx,
         context_in.textAlign = 'left';
         if (fontStyle)
         {
-            context_in.font = fontStyle + ' ' + (Math.floor(defpt+0.5)).toString() + 'px '+fonttype;
+            context_in.font = fontStyle + ' ' + ((defpt+0.5)).toString() + 'px '+fonttype;
         }
         else
         {
-            context_in.font = (Math.floor(defpt+0.5)).toString() + 'px '+ fonttype;
+            context_in.font = ((defpt+0.5)).toString() + 'px '+ fonttype;
         }
         var testw = context_in.measureText(texttodisp).width;
         if (testw > textw)
@@ -75,11 +75,11 @@ function autotext(dostroke, fontStyle, fonttype, mintextsize, texttodisp, textx,
             {
                 if (fontStyle)
                 {
-                    context_in.font = fontStyle + ' ' + (Math.floor(defpt*textw/testw+0.5)).toString() + 'px '+fonttype;
+                    context_in.font = fontStyle + ' ' + ((defpt*textw/testw+0.5)).toString() + 'px '+fonttype;
                 }
                 else
                 {
-                    context_in.font = (Math.floor(defpt*textw/testw+0.5)).toString() + 'px '+fonttype;
+                    context_in.font = ((defpt*textw/testw+0.5)).toString() + 'px '+fonttype;
                 }
                 if (dostroke)
                 {
@@ -118,11 +118,11 @@ function autotext2(dostroke, fontStyle, fonttype, mintextsize, texttodisp, textx
         context_in.textAlign = 'center';
         if (fontStyle)
         {
-            context_in.font = fontStyle + ' ' + (Math.floor(defpt+0.5)).toString() + 'px '+fonttype;
+            context_in.font = fontStyle + ' ' + ((defpt+0.5)).toString() + 'px '+fonttype;
         }
         else
         {
-            context_in.font = (Math.floor(defpt+0.5)).toString() + 'px '+ fonttype;
+            context_in.font = ((defpt+0.5)).toString() + 'px '+ fonttype;
         }
         
         var centerpoint = (texttodisp.length)/3;
@@ -169,11 +169,11 @@ function autotext2(dostroke, fontStyle, fonttype, mintextsize, texttodisp, textx
                         
                         if (fontStyle)
                         {
-                            context_in.font = fontStyle + ' ' + (Math.floor(defpt*textw/testw+0.5)).toString() + 'px '+fonttype;
+                            context_in.font = fontStyle + ' ' + ((defpt*textw/testw+0.5)).toString() + 'px '+fonttype;
                         }
                         else
                         {
-                            context_in.font = (Math.floor(defpt*textw/testw+0.5)).toString() + 'px '+fonttype;
+                            context_in.font = ((defpt*textw/testw+0.5)).toString() + 'px '+fonttype;
                         }
                         if (dostroke)
                         {
@@ -224,11 +224,11 @@ function autotext3(
         context_in.textAlign = 'center';
         if (fontStyle)
         {
-            context_in.font = fontStyle + ' ' + (Math.floor(defpt+0.5)).toString() + 'px '+fonttype;
+            context_in.font = fontStyle + ' ' + ((defpt+0.5)).toString() + 'px '+fonttype;
         }
         else
         {
-            context_in.font = (Math.floor(defpt+0.5)).toString() + 'px '+ fonttype;
+            context_in.font = ((defpt+0.5)).toString() + 'px '+ fonttype;
         }
         
         var centerpoint = (texttodisp.length)/4;
@@ -301,11 +301,11 @@ function autotext3(
                         
                         if (fontStyle)
                         {
-                            context_in.font = fontStyle + ' ' + (Math.floor(defpt*textw/testw+0.5)).toString() + 'px '+fonttype;
+                            context_in.font = fontStyle + ' ' + ((defpt*textw/testw+0.5)).toString() + 'px '+fonttype;
                         }
                         else
                         {
-                            context_in.font = (Math.floor(defpt*textw/testw+0.5)).toString() + 'px '+fonttype;
+                            context_in.font = ((defpt*textw/testw+0.5)).toString() + 'px '+fonttype;
                         }
                         if (dostroke)
                         {

--- a/OZprivate/rawJS/OZTreeModule/src/util/draw.js
+++ b/OZprivate/rawJS/OZTreeModule/src/util/draw.js
@@ -16,9 +16,9 @@ export function auto_text(do_stroke,font_style,text,textx,texty,textw,defpt,cont
     context.textBaseline = 'middle';
     context.textAlign = 'left';
     if (font_style) {
-      context.font = font_style + ' ' + (Math.floor(defpt+0.5)).toString() + 'px '+fonttype;
+      context.font = font_style + ' ' + ((defpt+0.5)).toString() + 'px '+fonttype;
     } else {
-      context.font = (Math.floor(defpt+0.5)).toString() + 'px '+ fonttype;
+      context.font = ((defpt+0.5)).toString() + 'px '+ fonttype;
     }
     let testw = context.measureText(text).width;
     if (testw > textw)
@@ -27,11 +27,11 @@ export function auto_text(do_stroke,font_style,text,textx,texty,textw,defpt,cont
       {
         if (font_style)
         {
-          context.font = font_style + ' ' + (Math.floor(defpt*textw/testw+0.5)).toString() + 'px '+fonttype;
+          context.font = font_style + ' ' + ((defpt*textw/testw+0.5)).toString() + 'px '+fonttype;
         }
         else
         {
-          context.font = (Math.floor(defpt*textw/testw+0.5)).toString() + 'px '+fonttype;
+          context.font = ((defpt*textw/testw+0.5)).toString() + 'px '+fonttype;
         }
         if (do_stroke)
         {
@@ -72,11 +72,11 @@ export function auto_text2(do_stroke,font_style,text,textx,texty,textw,defpt,con
     context.textAlign = 'center';
     if (font_style)
     {
-      context.font = font_style + ' ' + (Math.floor(defpt+0.5)).toString() + 'px '+fonttype;
+      context.font = font_style + ' ' + ((defpt+0.5)).toString() + 'px '+fonttype;
     }
     else
     {
-      context.font = (Math.floor(defpt+0.5)).toString() + 'px '+ fonttype;
+      context.font = ((defpt+0.5)).toString() + 'px '+ fonttype;
     }
     
     let centerpoint = (text.length)/3;
@@ -123,11 +123,11 @@ export function auto_text2(do_stroke,font_style,text,textx,texty,textw,defpt,con
             
             if (font_style)
             {
-              context.font = font_style + ' ' + (Math.floor(defpt*textw/testw+0.5)).toString() + 'px '+fonttype;
+              context.font = font_style + ' ' + ((defpt*textw/testw+0.5)).toString() + 'px '+fonttype;
             }
             else
             {
-              context.font = (Math.floor(defpt*textw/testw+0.5)).toString() + 'px '+fonttype;
+              context.font = ((defpt*textw/testw+0.5)).toString() + 'px '+fonttype;
             }
             if (do_stroke)
             {
@@ -178,11 +178,11 @@ export function auto_text3(do_stroke,font_style,text,textx,texty,textw,defpt,con
         context.textAlign = 'center';
         if (font_style)
         {
-            context.font = font_style + ' ' + (Math.floor(defpt+0.5)).toString() + 'px '+fonttype;
+            context.font = font_style + ' ' + ((defpt+0.5)).toString() + 'px '+fonttype;
         }
         else
         {
-            context.font = (Math.floor(defpt+0.5)).toString() + 'px '+ fonttype;
+            context.font = ((defpt+0.5)).toString() + 'px '+ fonttype;
         }
         
         let centerpoint = (text.length)/4;
@@ -255,11 +255,11 @@ export function auto_text3(do_stroke,font_style,text,textx,texty,textw,defpt,con
                         
                         if (font_style)
                         {
-                            context.font = font_style + ' ' + (Math.floor(defpt*textw/testw+0.5)).toString() + 'px '+fonttype;
+                            context.font = font_style + ' ' + ((defpt*textw/testw+0.5)).toString() + 'px '+fonttype;
                         }
                         else
                         {
-                            context.font = (Math.floor(defpt*textw/testw+0.5)).toString() + 'px '+fonttype;
+                            context.font = ((defpt*textw/testw+0.5)).toString() + 'px '+fonttype;
                         }
                         if (do_stroke)
                         {


### PR DESCRIPTION
Fixes #899 

This is a pretty big improvement for basically no effort so maybe go with this for now.
(See video demos on the issue https://github.com/OneZoom/OZtree/issues/899)

There's still a bit of jitteriness of multi-line text but I think that's more of a limitation of the canvas API: It doesn't seem to let you write text whose baseline isn't on a pixel boundary. 