### PR TITLE
Fix invalid pinpoints

### DIFF
--- a/OZprivate/rawJS/OZTreeModule/src/navigation/pinpoint.js
+++ b/OZprivate/rawJS/OZTreeModule/src/navigation/pinpoint.js
@@ -131,7 +131,10 @@ export function resolve_pinpoints(pinpoint_or_pinpoints, extra_metadata={}) {
   * Return a pinpoint string pointing at (node)
   */
 export function node_to_pinpoint(node) {
-  if (!node.ott && !node.latin_name) return null;
+  if (!node.ott && !node.latin_name) {
+    if (node.ozid) return "@_ozid=" + node.ozid;
+    return null;
+  };
   return [
     "@",
     node.latin_name ? tidy_latin(node.latin_name) : '',

--- a/OZprivate/rawJS/OZTreeModule/src/ui/search_manager.js
+++ b/OZprivate/rawJS/OZTreeModule/src/ui/search_manager.js
@@ -285,14 +285,16 @@ class SearchManager {
     // uses search match and pluralize
     let vernacular = record[cols["vernacular"]];
     let latinName  = record[cols["name"]];
-    let ott = record[cols["ott"]];
-    let id = record[cols["id"]];
-    let extra_vernaculars = record[cols["extra_vernaculars"]];
-    let id_decider = is_leaf? -1:1;
-    let tidy_common = vernacular ? capitalizeFirstLetter(vernacular) : null; // ready for printing in UI
     
     // "latin names" starting or ending with underscore are "fake" in OneZoom
-    let row = [tidy_common, latinName && !latinName.startsWith("_") ? latinName : null, id * id_decider];
+    latinName = latinName && !latinName.startsWith("_") && !latinName.endsWith("_") ? latinName : null;
+    let ott = record[cols["ott"]];
+    let extra_vernaculars = record[cols["extra_vernaculars"]];
+    let ozid = is_leaf ? -record[cols["id"]] : record[cols["id"]];
+
+    let tidy_common = vernacular ? capitalizeFirstLetter(vernacular) : null; // ready for printing in UI
+    
+    let row = [tidy_common, latinName, ozid];
     let score_result = overall_search_score(toSearchFor, latinName, lang, vernacular, extra_vernaculars);
     if (score_result.length < 2) {
         row = row.concat(score_result)
@@ -302,7 +304,7 @@ class SearchManager {
         let extra = OZstrings["Also called:"] + " " + extra_vernaculars[score_result[1]]
         row = row.concat([score_result[0], {info_type: "Extra Vernacular", text: extra}])
     }
-    row.pinpoint = node_to_pinpoint({ ott: ott, latin_name: latinName });
+    row.pinpoint = node_to_pinpoint({ ott: ott, latin_name: latinName, ozid });
     return row;
   }
 }

--- a/OZprivate/rawJS/OZTreeModule/tests/test_search_manager.js
+++ b/OZprivate/rawJS/OZTreeModule/tests/test_search_manager.js
@@ -1,0 +1,45 @@
+import test from 'tape';
+import search_manager from '../src/ui/search_manager';
+
+test('search_manager', function (t) {
+    t.ok(search_manager);
+    t.ok(search_manager.compile_searchbox_data);
+    const cols = {
+        "vernacular": 0,
+        "name": 1,
+        "ott": 2,
+        "extra_vernaculars": 3,
+        "id": 4,
+    }
+    let result;
+    // With latin name
+    result = search_manager.compile_searchbox_data("", "en", [
+        "Test case",
+        "Testicus Casicus",
+        null,
+        [],
+        12345,
+    ], cols, false);
+    t.deepEqual(result.pinpoint, "@Testicus_Casicus", "Can use latin name as pinpoint when no ott");
+    
+    // Fake latin name - prefix
+    result = search_manager.compile_searchbox_data("", "en", [
+        "Test case",
+        "_Testicus Casicus",
+        null,
+        [],
+        12345,
+    ], cols, false);
+    t.deepEqual(result.pinpoint, "@_ozid=12345", "Ignores fake latin name with underscore prefix when no ott");
+
+    // Fake latin name - suffix
+    result = search_manager.compile_searchbox_data("", "en", [
+        "Test case",
+        "Testicus Casicus_",
+        null,
+        [],
+        12345,
+    ], cols, false);
+    t.deepEqual(result.pinpoint, "@_ozid=12345", "Ignores fake latin name with underscore suffix when no ott");
+    t.end();
+});


### PR DESCRIPTION
Fixes #879 

Previously, we were not properly ignoring 'name' fields when they have a trailing underscore, causing us to create invalid pinpoints for some search results (e.g. 'Tortoises', 'Big cats', 'Foxes'). This fixes that by properly ignoring those and then using the ozid in cases where there is no other data to make a pinpoint from.