### PR TITLE
Improve the dev container docs.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -18,9 +18,18 @@ If you are using Visual Studio Code, perform the following steps (you will need 
 1. Open the cloned directory in VSCode.
 1. Create a `.env` file in the `.devcontainer` directory and add `WEB_IMAGE_NAME=onezoom/oztree-with-iucn`, changing the value to whatever image name you choose in step 1.
 1. Open the command palette and choose "Dev Containers: Reopen in Container". This may take several minutes to run.
-1. Your repository is mounted at `/opt/web2py/applications/OZtree` and the original production docker container application is mounted at `cp /opt/web2py/applications/OZtree_original`. In order to sync your repository with the production database state, open an integrated terminal and run the following: `cp /opt/web2py/applications/OZtree_original/private/appconfig.ini /opt/web2py/applications/OZtree/private/ && cp /opt/web2py/applications/OZtree_original/databases/*.table /opt/web2py/applications/OZtree/databases/`
+1. Your repository is mounted at `/opt/web2py/applications/OZtree` and the original production docker container application is mounted at `/opt/web2py/applications/OZtree_original`. In order to sync your repository with the production database state, open an integrated terminal and run the following: 
+
+```bash
+cp /opt/web2py/applications/OZtree_original/private/appconfig.ini /opt/web2py/applications/OZtree/private/
+rm -f /opt/web2py/applications/OZtree/databases/*.table
+cp /opt/web2py/applications/OZtree_original/databases/*.table /opt/web2py/applications/OZtree/databases/
+```
+
 1. Run `npm ci && grunt dev`. You will need to rerun `grunt dev` any time you make code changes.
-1. Visit http://localhost:8080 and the website should load! You can also run your own server from the dev container by [running web2py.py directly](#starting-and-shutting-down-web2py).
+1. Run `./web2py-run` to start the server locally.
+1. Load https://localhost:8000/. The first page load can take a long time (10+ minutes) as the database is updated. Do not kill the server while this is running. Future page loads will be much faster.
+1. You can now visit http://localhost:8080 at any time to load the page via nginx + uwsgi! You can also continue to rebuild and run the server with `grunt dev` and `./web2py-run` and use https://localhost:8000/.
 1. (Optional) Once tables are created, and everything is working, you can set `migrate = 0` in `private/appconfig.ini`. This will mean that web2py will not make any changes to table structures in the DB, and also that changes to appconfig.ini will require a web2py restart.
 1. (Optional) [Create a manager account](#creating-auth-users--groups) in the auth table, e.g. so you can [view docs](#documentation).
 1. (Optional) MySQL is available on port 3307 if you wish to debug using local tools outside the container.


### PR DESCRIPTION
Improve the documentation for getting started with a dev container to avoid common pitfalls. This would have helped @jaredkhan get started more easily.