### PR TITLE
Don't let location dropdown overflow page

### DIFF
--- a/OZprivate/scss/tree.scss
+++ b/OZprivate/scss/tree.scss
@@ -200,7 +200,7 @@ body.loading #UI #loading_spinner {
     }
 }
     
-.ui-controls [uk-dropdown] {
+[uk-dropdown] {
     /* make sure dropdowns always fit in the viewport, but don't cover header (or possibly get lost under Safari URL bar) */
     max-height: calc(100vh - 8rem);
     overflow-y: auto;
@@ -234,7 +234,6 @@ ul.ui-controls.button-label-hidden {
     font-size: small;
     text-align: center;
     padding:0;
-    min-height: 100%; /*aligned to bottom of control buttons, so make sure we are the same height as containing control buttons*/
 }
 
 


### PR DESCRIPTION
Fixes #930

Before:
<img width="863" alt="image" src="https://github.com/user-attachments/assets/38c932d7-d7f9-45e1-8c6f-f8568e197b21" />

After:
<img width="862" alt="image" src="https://github.com/user-attachments/assets/6d3ae1e6-7229-48e5-89e5-db22f8383d9b" />
(it's scrollable)