### PR TITLE
Google analytics rework

### DIFF
--- a/OZprivate/rawJS/OZTreeModule/src/button_manager.js
+++ b/OZprivate/rawJS/OZTreeModule/src/button_manager.js
@@ -37,6 +37,14 @@ export function click_on_button_cb(controller) {
   } else if (global_button_action.action =="fly_node") {
     controller.fly_straight_to(global_button_action.data, true);
   } else if (global_button_action.action =="tap2zoom") {
+    // Report any taps on signposts, leaf & nodes with an OTT to GA
+    if (window.gtag && global_button_action.node && global_button_action.node.ott) {
+      // https://developers.google.com/analytics/devguides/collection/ga4/reference/events?client_type=gtag#select_content
+      window.gtag("event", "select_content", {
+          content_id: "@=" + global_button_action.node.ott,
+      });
+    }
+
     controller.fly_straight_to(global_button_action.data);
   } else if (global_button_action.action =="link") {
     if (typeof config.ui.openCopyright !== 'function') {

--- a/OZprivate/rawJS/OZTreeModule/src/navigation/record.js
+++ b/OZprivate/rawJS/OZTreeModule/src/navigation/record.js
@@ -40,6 +40,11 @@ function record_url(controller, options, force) {
   // Don't bother recording if it's basically the same state
   if (!force && current_view_near_previous_view(current_state)) return;
 
+  // Report change in location to GA
+  if (window.gtag) gtag("event", "scroll", {
+      content_id: current_state.pinpoint,
+  });
+
   if (current_state.tour_setting) {
     // Leave everything alone bar tour---parse existing state, splice tour state in.
     const tour = current_state.tour_setting;

--- a/OZprivate/rawJS/OZTreeModule/src/tour/handler/TsProgress.js
+++ b/OZprivate/rawJS/OZTreeModule/src/tour/handler/TsProgress.js
@@ -31,9 +31,25 @@ function handler(tour) {
           Object.keys(progress).forEach((k) => progress[k] = false);
       }
 
+      // If no tourstops are visited, report start to GA
+      if (window.gtag && Object.keys(progress).every((k) => !progress[k])) {
+        // https://developers.google.com/analytics/devguides/collection/ga4/reference/events?client_type=gtag#level_start
+        window.gtag("event", "level_start", {
+          level_name: tour.tour_setting,
+        });
+      }
+
       progress[tour.curr_step] = true;
       progressStore(tour, progress)
       updateTsProgress(tour, progress);
+
+      // If all tourstops are visited, report end to GA
+      if (window.gtag && Object.keys(progress).every((k) => progress[k])) {
+        // https://developers.google.com/analytics/devguides/collection/ga4/reference/events?client_type=gtag#level_end
+        window.gtag("event", "level_end", {
+          level_name: tour.tour_setting,
+        });
+      }
     });
 
     resolve();

--- a/OZprivate/rawJS/OZTreeModule/src/ui/search.js
+++ b/OZprivate/rawJS/OZTreeModule/src/ui/search.js
@@ -270,7 +270,7 @@ function update_recents_list($target) {
         return;
     }
 
-    const dl = $('<dl>');
+    const dl = $('<dl class="recent_places">');
     $target.append(dl);
     dl.append($('<dt>').text(OZstrings.hasOwnProperty("Recent places") ? OZstrings["Recent places"] : "Recent places"));
     dl.append(recent_places.map(function (recent_place) {

--- a/OZprivate/rawJS/OZTreeModule/src/ui/search_manager.js
+++ b/OZprivate/rawJS/OZTreeModule/src/ui/search_manager.js
@@ -62,6 +62,12 @@ class SearchManager {
         this.search_timer = setTimeout(() => {
             if (onSend) onSend(); // this informs the UI that an API request has now been made.
 
+            // Inform Google Analytics
+            // https://developers.google.com/analytics/devguides/collection/ga4/reference/events?client_type=gtag#search
+            if (window.gtag) gtag("event", "search", {
+                search_term: toSearchFor,
+            });
+
             return Promise.all([
                 this.searchForTree(toSearchFor),
                 new Promise((resolve) => this.searchForSponsor(toSearchFor, resolve)),

--- a/private/appconfig.ini.example
+++ b/private/appconfig.ini.example
@@ -90,3 +90,5 @@ sponsorship_renew_discount = 0.2
 ; -> "Domains", configure your instance domain
 ; -> "Licences", copy/paste the hex key
 ;civicuk_api_key = 123abc123abc123abc123abc123abc123abc123a
+; * ga_code: Uncomment to enable DebugView (Admin (bottom-left) -> Data Display -> DebugView)
+;ga_debugview = yes

--- a/private/appconfig.ini.example
+++ b/private/appconfig.ini.example
@@ -83,7 +83,11 @@ sponsorship_renew_discount = 0.2
 ;        if unset, tracking is off.
 ; To get a code, go to Admin -> Select account -> Select property -> "Data streams"
 ; -> Add/select "web" stream -> Copy code from "Global site tag (gtag.js)"
-; Will begin with UA- or G-
+;    Will begin with UA- or G-
+; NB: "Enhanced measurement" must be disabled:
+; * "Admin" -> "Data collection" -> "Data streams"
+; * Click on stream
+; * "Events" -> Disable "Enhanced measurement"
 ;ga_code = G-ABCABCABCA
 ; * civicuk_api_key: An API key from cookiecontrol by CivicUK
 ; To get a code, log into the https://www.civicuk.com/cookie-control/user-area/

--- a/views/analytics.html
+++ b/views/analytics.html
@@ -9,16 +9,17 @@
 
   window.dataLayer = window.dataLayer || [];
   function gtag() { dataLayer.push(arguments); }
-  gtag('js', new Date());
-  gtag('config', '{{=ga_code}}', { 'anonymize_ip': true });
 
-  // Deny analytics storage before GA loaded
+  // Deny analytics storage before any other gtag() calls, otherwise we get "A tag read consent state before a default was set"
   gtag('consent', 'default', {
     'ad_storage': 'denied',
     'ad_user_data': 'denied',
     'ad_personalization': 'denied',
     'analytics_storage': 'denied'
   });
+
+  gtag('js', new Date());
+  gtag('config', '{{=ga_code}}', { 'anonymize_ip': true });
 
   var cc_config={
     apiKey: '{{=civicuk_api_key}}',

--- a/views/analytics.html
+++ b/views/analytics.html
@@ -16,9 +16,23 @@
     'analytics_storage': 'denied'
   });
 
+  // Strip off querystring / OTT from /life calls, so we don't treat each OTT as a separate page
+  var pv_location = window.location.href;
+  var pv_title = window.document.title;
+  if (window.location.pathname.startsWith("/life")) {
+    pv_location = document.location.href.replace(/(life[^/]*\/)@.*/, '$1');
+    pv_title = "OneZoom tree viewer";
+  }
+
   gtag('js', new Date());
   gtag('config', '{{=ga_code}}', {
       'anonymize_ip': true,
+
+      // NB: 'config' will trigger our page_view event, so these need to be set immediately
+      // https://developers.google.com/analytics/devguides/collection/ga4/reference/config#page_location
+      // https://developers.google.com/analytics/devguides/collection/ga4/reference/config#page_title
+      'page_location': pv_location,
+      'page_title': pv_title,
 
       // Enable debug mode: Change appconfig.ini, Go to Admin (bottom-left) -> Data Display -> DebugView
       {{if ga_debugview:}}'debug_mode': true,{{pass}}

--- a/views/analytics.html
+++ b/views/analytics.html
@@ -1,4 +1,25 @@
 {{# Google analytics tracking code Copyright Google }}
+{{# #### Events recorded into google analytics ####}}
+{{# src/button_manager.js: }}
+{{# * "select_content" event on tap2zoom for signpost/leaf/node with an OTT}}
+{{# src/navigation/record.js: }}
+{{# * "scroll" event when panned/zoomed significantly}}
+{{# src/tour/handler/TsProgress.js: }}
+{{# * "level_start" event on tour start (i.e. the first tourstop is now visited)}}
+{{# * "level_end" event on tour end (i.e. all tourstops are now visited)}}
+{{# src/ui/search_manager.js: }}
+{{# * "search" event on submitting search query to server}}
+{{# views/treeviewer/layout.html: }}
+{{# * "select_item" event on search result / recent / popular link click}}
+{{# * "popup_open" event on popup open / tab change }}
+{{# * "popup_scroll" event if user scrolls and iframe still visible after 5 seconds}}
+{{# * "popup_close" event on popup close}}
+
+{{# #### Debugging methods ####}}
+{{# (1) Disable ga_code in private/appconfig.ini, gtag events sent to JS console}}
+{{# (2) Use https://tagassistant.google.com/ for live debugging }}
+{{# (3) Enable ga_debugview in private/appconfig.ini, use DebugView: https://support.google.com/analytics/answer/7201382?hl=en }}
+
 {{ga_code = myconf.get('analytics.ga_code', default='')}}
 {{ga_debugview = myconf.get('analytics.ga_debugview', default=False)}}
 {{civicuk_api_key = myconf.get('analytics.civicuk_api_key', default='')}}

--- a/views/analytics.html
+++ b/views/analytics.html
@@ -2,11 +2,8 @@
 {{ga_code = myconf.get('analytics.ga_code', default='')}}
 {{civicuk_api_key = myconf.get('analytics.civicuk_api_key', default='')}}
 
-{{if ga_code and civicuk_api_key:}}
-  {{# https://www.civicuk.com/blog-item/simplify-cookie-control-set-google-consent-mode }}
-  {{# https://developers.google.com/tag-platform/devguides/consent#implementation_example }}
-  <script type="text/javascript">
 
+<script type="text/javascript">
   window.dataLayer = window.dataLayer || [];
   function gtag() { dataLayer.push(arguments); }
 
@@ -21,6 +18,12 @@
   gtag('js', new Date());
   gtag('config', '{{=ga_code}}', { 'anonymize_ip': true });
 
+</script>
+
+{{if ga_code and civicuk_api_key:}}
+  {{# https://www.civicuk.com/blog-item/simplify-cookie-control-set-google-consent-mode }}
+  {{# https://developers.google.com/tag-platform/devguides/consent#implementation_example }}
+  <script type="text/javascript">
   var cc_config={
     apiKey: '{{=civicuk_api_key}}',
     product: "COMMUNITY",
@@ -46,4 +49,12 @@
   <script src="https://cc.cdn.civiccomputing.com/9/cookieControl-9.x.min.js" type="text/javascript"></script>
   <script type="text/javascript">CookieControl.load(cc_config);</script>
   <style>body #ccc #ccc-icon:first-child { display: none }</style>
+{{else:}}
+  <script type="text/javascript">
+  // Dummy gtag logging events to webdeveloper console
+  function gtag() {
+    console.debug("gtag", JSON.stringify(Array.from(arguments)));
+  }
+  for (a of window.dataLayer) gtag.apply(null, a);
+  </script>
 {{pass}}

--- a/views/analytics.html
+++ b/views/analytics.html
@@ -1,5 +1,6 @@
 {{# Google analytics tracking code Copyright Google }}
 {{ga_code = myconf.get('analytics.ga_code', default='')}}
+{{ga_debugview = myconf.get('analytics.ga_debugview', default=False)}}
 {{civicuk_api_key = myconf.get('analytics.civicuk_api_key', default='')}}
 
 
@@ -16,8 +17,12 @@
   });
 
   gtag('js', new Date());
-  gtag('config', '{{=ga_code}}', { 'anonymize_ip': true });
+  gtag('config', '{{=ga_code}}', {
+      'anonymize_ip': true,
 
+      // Enable debug mode: Change appconfig.ini, Go to Admin (bottom-left) -> Data Display -> DebugView
+      {{if ga_debugview:}}'debug_mode': true,{{pass}}
+  });
 </script>
 
 {{if ga_code and civicuk_api_key:}}

--- a/views/treeviewer/UI_layer.load
+++ b/views/treeviewer/UI_layer.load
@@ -27,7 +27,9 @@
         <li><a href="#colkey-modal" uk-toggle><span uk-icon="icon: expand"></span>{{=T('Colour key')}}</a></li>
         <li><a href="#about-modal" uk-toggle><span uk-icon="icon: expand"></span>{{=T('About OneZoom')}}</a></li>
         <li><a href="#datasources-modal" uk-toggle><span uk-icon="icon: expand"></span>{{=T('Data sources')}}</a></li>
-        <li><a href="#terms-modal" uk-toggle><span uk-icon="icon: expand"></span>{{=T('Terms of use')}}</a></li>
+        {{if myconf.get('analytics.civicuk_api_key', default=''):}}
+        <li><a href="#" onclick="CookieControl.open(); return (false);"><span uk-icon="icon: expand"></span>{{=T('Cookie consent')}}</a></li>
+        {{pass}}
 
         <li class="uk-nav-header">{{=T('Image sources')}}</li>
         <li><label uk-tooltip="pos: right" title="{{=T('Show best image from any source: the image may not have been verified by a taxonomist. For any image, click or zoom on the © symbol for details.')}}">

--- a/views/treeviewer/layout.html
+++ b/views/treeviewer/layout.html
@@ -114,6 +114,7 @@ request.vars.links = setup_params['UI_layer']['vars'].get('links')
       var select_tab_index=null;
       var url_dict = responseJSON.data;
       var n_tabs = 0;
+      var pinpoint = responseJSON.ott ? '@=' + responseJSON.ott : "";
       // make sure the id names correspond to the names returned by the api
       $("#external-modal .external-tabs li").each(function(index) {
         var tab = $(this);
@@ -128,6 +129,8 @@ request.vars.links = setup_params['UI_layer']['vars'].get('links')
             var specific_popup = $("#external-modal .popup-container ." + linkout_name);
             //set the data-src attribute to the url. When the tab is shown, it will get src from there
             specific_popup.attr("data-src", url_arr[0]);
+            // Add pinpoint, so it can be used in Google Analytics reporting
+            specific_popup.attr("data-pinpoint", pinpoint);
             {{if is_testing:}}console.log("set data-src for '" + linkout_name + "' to " + url_arr[0]);{{pass}}
             //define the linkout (some hackery here to allow the same element to act as a plain link or a 'post' submission)
             $(".expand-tab form input[type=hidden]", specific_popup).remove()
@@ -243,6 +246,12 @@ function closeAndLeap(event, href, original_searchbox, input_type) {
 function load_tab(tab_content) {
   var ifrm;
 
+  // Report all tab loads & changes to GA
+  // parameters from select_content https://developers.google.com/analytics/devguides/collection/ga4/reference/events?client_type=gtag#select_content
+  if (window.gtag) window.gtag("event", "popup_open", {
+      content_type: tab_content.attr("data-name"),
+      content_id: tab_content.attr("data-pinpoint") || undefined,
+  });
   if (tab_content.children().last().hasClass('popup-content')) {
       ifrm = tab_content.children().last().children('iframe')[0];
   } else {
@@ -253,8 +262,20 @@ function load_tab(tab_content) {
       ifrm.addEventListener('load', function() {
         {{if is_testing:}}console.log("Hiding iframe loading info");{{pass}}
         $(".iframe-loading-info", $(this).parent().parent()).hide()
-        }, false);
+        if (window.gtag) ifrm.contentDocument.addEventListener("scroll", function () {
+            // Only set a scroll timeout once
+            if (ifrm._oz_scrollTimeout) return;
+            // Report pop-up scrolling to GA
+            ifrm._oz_scrollTimeout = setTimeout(function () {
+                if (ifrm.checkVisibility()) window.gtag("event", "popup_scroll", {
+                    content_type: tab_content.attr("data-name"),
+                    content_id: tab_content.attr("data-pinpoint") || undefined,
+                });
+            }, 5000);
+        });
+      }, false);
       ifrm.setAttribute("sandbox", "allow-same-origin allow-scripts allow-forms allow-popups");
+      ifrm.addEventListener("scroll", function (event) { console.log("woo") });
       //add iframe inside a div wrapper
       tab_content.append($('<div>', {'class':'popup-content iframe-container'}).append(ifrm));
   }
@@ -935,6 +956,13 @@ function setupUI() {
       .on('hidden', function() {
         {{if is_testing:}}console.log("Removing content, data-src values, and hidden vars from each tab");{{pass}}
         $('#external-modal .popup-container li').each(function() {
+            if ($(this).hasClass("uk-active") && this.checkVisibility()) {
+                // Report tab closure to GA
+                if (window.gtag) window.gtag("event", "popup_close", {
+                    content_type: $(this).attr("data-name"),
+                    content_id: $(this).attr("data-pinpoint") || undefined,
+                });
+            }
             $(this)
                 .attr("data-src","")
                 .children('.popup-content').remove()

--- a/views/treeviewer/layout.html
+++ b/views/treeviewer/layout.html
@@ -214,8 +214,6 @@ var locations_json = '{{=XML(setup_params.get("locations_json") or "[]")}}';
 
 
 function closeAndLeap(event, href, original_searchbox, input_type) {
-    //TODO: add hit in search count.
-    // add_hit_in_search_count(OZIDin);
     var dropdown = $(".search_dropdown", original_searchbox)
     if (dropdown.length) {
         if ((dropdown.first().outerWidth()*2) > document.getElementById("OneZoomCanvasID").width) {
@@ -225,8 +223,19 @@ function closeAndLeap(event, href, original_searchbox, input_type) {
     if (input_type === 'ancestor') {
         onezoom.controller.default_move_to(href, 'ancestor');
     } else {
+        // Strip /life/ from href
+        href = href.replace(/^\/[A-Z_\-/.]+/i, '');
+
+        // Report search hit to GA
+        if (window.gtag) window.gtag("event", "select_item", {
+            item_list_id: event.target.closest("dl").className || "search_results",
+            items: [{
+                item_id: href.replace(/\?.*/, ''),
+            }],
+        });
+
         // Strip /life/ from any URL, update tree state
-        onezoom.controller.set_treestate(href.replace(/^\/[A-Z_\-/.]+/i, ''));
+        onezoom.controller.set_treestate(href);
     }
 }
 

--- a/views/treeviewer/layout.html
+++ b/views/treeviewer/layout.html
@@ -158,7 +158,6 @@ request.vars.links = setup_params['UI_layer']['vars'].get('links')
         $('#external-modal .no-tab-data').show()
       }
       UIkit.tab('#external-modal .external-tabs').show(select_tab_index);
-      load_tab($("#external-modal .popup-container li").eq(select_tab_index));
       $('#external-modal .tab-loading-info').hide();
       $('#external-modal .external-content').show();
       if (searchResultToPush) {


### PR DESCRIPTION
This tidies up the google analytics interfacing code, and fires a bunch of events at GA for various conditions.

A test mode is also added, if you do not have GA enabled in your local instance then the gtag calls will be echoed to the webdeveloper console (you may need to activate the "verbose" level and/or filter the console for "gtag").