### PR TITLE
Fix embed_edit by copying over it's missing import

### DIFF
--- a/controllers/default.py
+++ b/controllers/default.py
@@ -13,7 +13,6 @@ from collections import OrderedDict
 
 import ozmail
 import tour
-from embed import embedize_url
 from sponsorship import (
     sponsorship_enabled, reservation_total_counts, clear_reservation, get_reservation,
     reservation_validate_basket_fields,

--- a/controllers/developer.py
+++ b/controllers/developer.py
@@ -1,4 +1,5 @@
 import ozmail
+from embed import embedize_url
 
 from OZfunc import (
     __release_info,

--- a/tests/unit/test_controllers_developer.py
+++ b/tests/unit/test_controllers_developer.py
@@ -1,0 +1,51 @@
+"""
+Run with::
+
+    grunt exec:test_server:test_controllers_developer.py
+"""
+import unittest
+
+import applications.OZtree.controllers.developer as Developer
+from applications.OZtree.tests.unit import util
+
+
+class TestControllersDeveloper(unittest.TestCase):
+    maxDiff = None
+
+    def tearDown(self):
+        db.rollback()
+
+    def test_embed_edit(self):
+        def embed_edit(**kwargs):
+            form = util.call_controller(Developer, 'embed_edit', vars=kwargs, method='POST' if len(kwargs) > 0 else 'GET')['form']
+            return dict(
+                flash=Developer.response.flash,
+            )
+
+        # Nothing happens with an empty form
+        self.assertEqual(embed_edit(), dict(flash=""))
+
+        # Can't send without configuration
+        util.set_smtp(sender=None)
+        self.assertEqual(embed_edit(email="ut1@example.com", url="http://ut/life/", _formname="default"), dict(
+            flash="No e-mail configuration in appconfig.ini, so cannot send email",
+        ))
+
+        # Try sending for real
+        util.set_smtp(sender="admin@example.com")
+        # NB: Not actually testing the e-mail contents, util.set_smtp should be setting up a fake mailer to do that
+        self.assertEqual(embed_edit(email="ut1@example.com", url="http://ut/life/", _formname="default"), dict(
+            flash="E-mail with embed code sent",
+        ))
+
+
+if __name__ == '__main__':
+    import sys
+
+    if current.globalenv['is_testing'] != True:
+        raise RuntimeError("Do not run tests in production environments, ensure is_testing = True")
+    suite = unittest.TestSuite()
+    suite.addTest(unittest.makeSuite(TestControllersDeveloper))
+    result = unittest.TextTestRunner(verbosity=2).run(suite)
+    if not result.wasSuccessful():
+        sys.exit(1)

--- a/tests/unit/util.py
+++ b/tests/unit/util.py
@@ -32,13 +32,11 @@ def call_controller(module, endpoint, vars={}, args=[], method=None, username=No
     current.request.args = args
     if method:
         current.request.env.request_method = method
+    current.request.application = 'OZtree'
+    current.request.folder = os.path.abspath('applications/OZtree')
 
-    class FakeAuth():
-        """Fake enough of of the auth API"""
-        def basic(self):
-            # NB: Do this in the basic call to ensure it happens
-            self.user = username
-    current.globalenv['auth'] = FakeAuth()
+    # Force any provided username into auth setup
+    current.globalenv['auth'].user = username
 
     # Poke session / DB / request into module's namespace
     module.session = current.session
@@ -47,6 +45,12 @@ def call_controller(module, endpoint, vars={}, args=[], method=None, username=No
     module.response = current.response
     module.auth = current.globalenv['auth']
     module.HTTP = current.globalenv['HTTP']
+    module.FORM = current.globalenv['FORM']
+    module.LABEL = current.globalenv['LABEL']
+    module.INPUT = current.globalenv['INPUT']
+    module.IS_NOT_EMPTY = current.globalenv['IS_NOT_EMPTY']
+    module.IS_EMAIL = current.globalenv['IS_EMAIL']
+    module.URL = current.globalenv['URL']
 
     return getattr(module, endpoint)()
 


### PR DESCRIPTION
It moved to ``developer.py`` at some point, but it's required imports didn't.

To avoid it happening again, add some unit testing to ``embed_edit``.