### PR TITLE
private/show_errors: Console error viewer

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -76,6 +76,15 @@ module.exports = function (grunt) {
         cwd: "../../",
         command: exec_web2py_script("private/background_tasks.py"),
       },
+      show_errors: {
+        cwd: "../../",
+        command: function () {
+          return [].concat(
+            [venv_python, "applications/OZtree/private/show_errors.py"],
+            Array.from(arguments),
+          ).join(" ");
+        }
+      },
       db_fixtures: {
         command: function () {
             // Either accept a list of test filenames, or work it out ourselves and run all tests

--- a/README.markdown
+++ b/README.markdown
@@ -345,6 +345,22 @@ If you wish to use your editor's debugger to debug the JavaScript code, you will
 1. Run `grunt dev` to perform the initial dev compilation.
 1. Run `npm run compile_js_dev:watch` to compile source maps and automatically recompile if files are changed. Note: this command will continue to run until it is killed.
 
+### Server side errors
+
+Server-side errors may be reported as:
+
+> Internal error
+> Ticket issued: OZtree/...
+
+The ticket links to the web2py management portal, which you could grant yourself access to, but when running locally you can inspect the error logs directly with:
+
+```
+./node_modules/.bin/grunt exec:show_errors
+```
+
+You can also use ``./node_modules/.bin/grunt exec:show_errors:clear``, which will automatically delete errors after displaying them.
+Thus you will only see errors since the previous run.
+
 # Documentation
 
 Documentation is partially compiled from the source code using Grunt, and lives in `OZprivate/rawJS/OZTreeModule/docs`. Once compiled, it can be viewed online using your web2py server. For example, if you are running web2py on http://127.0.0.1:8000, you should be able to visit [http://127.0.0.1:8000/OZtree/dev/DOCS](http://127.0.0.1:8000/OZtree/dev/DOCS), or (if you have manager access to the OneZoom site) at [http://onezoom.org/dev/DOCS](http://onezoom.org/dev/DOCS).

--- a/private/show_errors.py
+++ b/private/show_errors.py
@@ -1,0 +1,42 @@
+"""
+Print any web2py application errors to the console
+==================================================
+
+Read web2py error files & print them to the console in a human-readable fashion.
+
+Usage::
+
+    grunt exec:show_errors[:clear]
+
+* ``clear`` will delete errors after outputting errors, so subsequent calls only show new errors
+
+"""
+import glob
+import os
+import os.path
+import pickle
+import sys
+
+run_clear = 'clear' in sys.argv
+
+application_path = os.path.realpath(os.path.join(os.path.dirname(__file__), '..'))
+
+# Manually append web2py to module search path, so we don't have to run underneath it
+try:
+    import gluon
+except ImportError:
+    sys.path.append(os.path.realpath(os.path.join(application_path, "..", "..")))
+
+for err_path in sorted(glob.glob(os.path.join(application_path, "errors", "*.*.*.*.*-*-*.*"))):
+    err_name = os.path.basename(err_path)
+    with open(err_path, 'rb') as f:
+        err = pickle.load(f)
+
+    print(err_name)
+    print("=" * len(err_name))
+    print(err['layer'])
+    print(err['output'])
+    print(err['traceback'])
+
+    if run_clear:
+        os.unlink(err_path)


### PR DESCRIPTION
I finally got fed up with half-written bash scripts to look at the web2py error logs and wrote a python script to do the work.

Calling ``./node_modules/.bin/grunt exec:show_errors:clear`` will show all errors & delete them in a ~human-readable form. It will also (optionally) delete them, so errors don't build up.