### PR TITLE
Be more picky about anchor nodes

### DIFF
--- a/OZprivate/rawJS/OZTreeModule/src/position_helper.js
+++ b/OZprivate/rawJS/OZTreeModule/src/position_helper.js
@@ -394,8 +394,11 @@ function reanchor_at_node(node, root_node) {
 }
 
 /**
- * Walk tree, anchoring to the first node on-screen that has 2.2 < node.rvar < 22000
+ * Walk tree, anchoring to the first node that is both on screen and of a reasonable size
  * (i.e. set graphref on this node and it's ancestors)
+ *
+ * Reasonable size here means we should ignore high-up nodes whose bounding boxes encompass half of
+ * insects in a balanced tree (e.g.)
  *
  * For debugging, you can draw the current anchor node with:
  *   onezoom.config.debug_bounding_box = (node => node === onezoom.tree_state.anchor_node ? 0x03 : 0)
@@ -407,7 +410,7 @@ function reanchor(node) {
   if (!node.dvar) return;
 
   node.graphref = true;
-  if (node.gvar || !node.has_child || (node.rvar > 2.2 && node.rvar < 22000)) {
+  if (!node.has_child || node.gvar && (node.rvar > 1 && node.rvar < 2200)) {
     // Anchor to this node
     tree_state.anchor_node = node;  // NB: Only saved for debugging purposes
     tree_state.xp = node.xvar;

--- a/OZprivate/rawJS/OZTreeModule/src/position_helper.js
+++ b/OZprivate/rawJS/OZTreeModule/src/position_helper.js
@@ -381,6 +381,9 @@ function reanchor_at_node(node, root_node) {
   // Set graphref false everywhere
   deanchor(root_node);
 
+  // Anchor to this node
+  tree_state.anchor_node = node;  // NB: Only saved for debugging purposes
+
   // Walk up tree from (node), setting graphref
   while (node.upnode) {
     node.graphref = true;
@@ -393,6 +396,11 @@ function reanchor_at_node(node, root_node) {
 /**
  * Walk tree, anchoring to the first node on-screen that has 2.2 < node.rvar < 22000
  * (i.e. set graphref on this node and it's ancestors)
+ *
+ * For debugging, you can draw the current anchor node with:
+ *   onezoom.config.debug_bounding_box = (node => node === onezoom.tree_state.anchor_node ? 0x03 : 0)
+ * ...or add a browser watch condition of:
+ *   onezoom.tree_state.anchored_node + ' ' + onezoom.tree_state.anchored_node.rvar
  */
 function reanchor(node) {
   // If this node (or it's desendents) aren't visible, don't bother
@@ -401,6 +409,7 @@ function reanchor(node) {
   node.graphref = true;
   if (node.gvar || !node.has_child || (node.rvar > 2.2 && node.rvar < 22000)) {
     // Anchor to this node
+    tree_state.anchor_node = node;  // NB: Only saved for debugging purposes
     tree_state.xp = node.xvar;
     tree_state.yp = node.yvar;
     tree_state.ws = node.rvar / 220;


### PR DESCRIPTION
The problem in #972 is that we choose the anchor node primarily on a node's bounding box. In a "balanced" tree, the bounding box for one below "Animals" covers most of the insect kingdom, so we don't bother considering any nodes below as an anchor node. Eventually this is too far away and everything goes wrong:

https://github.com/OneZoom/OZtree/blob/42ffe51f8ab5956de5ffc822e8bbf00fda369c7d/OZprivate/rawJS/OZTreeModule/src/position_helper.js#L385

As well as a traditional heap of tidy-up (EDIT: Merged in https://github.com/OneZoom/OZtree/pull/982), https://github.com/OneZoom/OZtree/commit/a4be6ed2e496d3343056b91740fc6864aab24701 fixes this by insisting on gvar (bounding box on screen) *and* a tighter range of rvar (node zoom). This fixes the initial issue, as the bounding box now follows you down, but the flight back from "Elephant Hawk-Moth" to "Elephant Seal" is very broken. I suspect this is an unrelated issue, and flight code that hasn't been used before not doing the right thing.

If you want to play with the cut-off @jrosindell / @jaredkhan, https://github.com/OneZoom/OZtree/commit/9ec50a4707f407a2c28d8593b12268a75e930963 stashes the anchor node away so you can do things like this in the JS console:

```javascript
onezoom.config.debug_bounding_box = (node => node === onezoom.tree_state.anchor_node ? 0x03 : 0)
```

... and watch the anchor node move about as you go.

If I get a chance tomorrow I'll see if I can figure out what's up with the flight.