### PR TITLE
Remove dates js / fake_migrate config option

### DIFF
--- a/OZprivate/rawJS/OZTreeModule/src/api/api_manager.js
+++ b/OZprivate/rawJS/OZTreeModule/src/api/api_manager.js
@@ -35,11 +35,11 @@ class APIManager {
   /**
    * Fetch all required data to call data_repo.setup()
    *
-   * (i.e raw_data, cut_map, poly_cut_map, cut_threshold, tree_date)
+   * (i.e raw_data, cut_map, poly_cut_map, cut_threshold)
    */
   fetch_tree_data() {
     // NB: rely on static_data_url_func() to add any tree version string
-    return Promise.all(['completetree.js', 'cut_position_map.js', 'dates.js'].map((data_file) => {
+    return Promise.all(['completetree.js', 'cut_position_map.js'].map((data_file) => {
       return new Promise((resolve, reject) => {
         // Assume all data_files are JavaScript that needs adding to page
         // https://developer.mozilla.org/en-US/docs/Web/API/HTMLScriptElement#dynamically_importing_scripts
@@ -56,7 +56,6 @@ class APIManager {
         cut_map: JSON.parse(window.cut_position_map_json_str || "{}"),
         poly_cut_map: JSON.parse(window.polytomy_cut_position_map_json_str || "{}"),
         cut_threshold: window.cut_threshold || 10000,
-        tree_date: window.tree_date || {},
       };
     });
   }

--- a/OZprivate/rawJS/OZTreeModule/src/factory/midnode.js
+++ b/OZprivate/rawJS/OZTreeModule/src/factory/midnode.js
@@ -540,13 +540,6 @@ class Midnode {
   get has_child() {
     return this.children.length > 0;
   }
-  get date() {
-    if (this.is_interior_node) {
-      return data_repo.tree_date.nodes[this.metacode];
-    } else {
-      return data_repo.tree_date.leaves[this.metacode];
-    }    
-  }
 }
 
 function calc_richness_of_node(node) {

--- a/OZprivate/rawJS/OZTreeModule/tests/test_factory_data_repo.js
+++ b/OZprivate/rawJS/OZTreeModule/tests/test_factory_data_repo.js
@@ -53,7 +53,7 @@ test('DataRepo:update_metadata', function (t) {
         }).filter(function (x) { return x.ozid !== '0' && x.ozid !== 'temp' });
     }
 
-    data_repo.setup({raw_data: rawdata, cut_map: {}, poly_cut_map: {}, cut_threshold: 10000, tree_date: "{}"});
+    data_repo.setup({raw_data: rawdata, cut_map: {}, poly_cut_map: {}, cut_threshold: 10000});
     t.deepEqual(pic_metadata(["OTTid", "picID", "picID_src", "picID_rating", "picID_credit"]), [], "No leaves at start");
 
     // Add some leaves without images

--- a/OZprivate/rawJS/OZTreeModule/tests/util_data_repo.js
+++ b/OZprivate/rawJS/OZTreeModule/tests/util_data_repo.js
@@ -17,8 +17,6 @@ export function populate_data_repo(tree_serial = '25589581') {
        <script src="completetree_${tree_serial}.js" type="text/javascript"></script>
        <!-- cut_position_map_json_str, polytomy_cut_position_map_json_str, cut_thresholdcut_threshold -->
        <script src="cut_position_map_${tree_serial}.js" type="text/javascript"></script>
-       <!-- tree_date -->
-       <script src="dates_${tree_serial}.js" type="text/javascript"></script>
     </body>`, {
       resources: 'usable',
       runScripts: 'dangerously',
@@ -32,7 +30,6 @@ export function populate_data_repo(tree_serial = '25589581') {
         cut_map: JSON.parse(this.cut_position_map_json_str),
         poly_cut_map: JSON.parse(this.polytomy_cut_position_map_json_str),
         cut_threshold: this.cut_threshold,
-        tree_date: this.tree_date,
       });
 
       // Add some dummy data so we can look up some IDs / OTTs, captured output from node_details

--- a/README.markdown
+++ b/README.markdown
@@ -154,6 +154,22 @@ USE OneZoom
 SOURCE ${WEB2PY_PATH}/applications/OZtree/OZprivate/ServerScripts/SQL/create_db_indexes.sql
 ```
 
+### Migrate / clone DB
+
+Clone the database by duming & restoring:
+
+```
+mysqldump -p --routines --triggers OneZoom | mysql -p OneZoom_Other
+```
+
+Edit the DB connection string in ``private/appconfig.ini``.
+
+Run a fake migration, as all tables will exist, but web2py won't be aware of it.
+
+* Edit private/appconfig.ini, setting ``migrate=fake``
+* ``./web2py-run tests/unit/test_modules_embed.py``, on startup this will create tables as necessary
+* Edit private/appconfig.ini, migrate=0
+
 ## Production installation
 
 For a production installation of OneZoom, you also need nginx & supervisor:

--- a/models/db.py
+++ b/models/db.py
@@ -72,14 +72,15 @@ name_rank_chars = 30 ##max length for a taxonomic rank, e.g. species, genus, ...
 
 ## if NOT running on Google App Engine use SQLite or other DB
 DALstring = myconf.take('db.uri')
-doMigration = myconf.take('db.migrate') in ['true', '1', 't', 'y', 'yes', 'True']
+doMigration = myconf.take('db.migrate') in ['true', '1', 't', 'y', 'yes', 'True', "fake"]
+doFakeMigrate = myconf.take('db.migrate') == "fake"
 if DALstring.startswith('mysql://'):
     db = DAL(DALstring, 
         driver_args={'read_default_file':os.path.join(request.folder, 'private','my.cnf')}, 
         pool_size=myconf.take('db.pool_size', cast=int), 
         check_reserved=['all'], 
         migrate=doMigration,
-        #fake_migrate_all=True, # uncomment to fix migration issues assuming correct DB fields exist
+        fake_migrate_all=doFakeMigrate,
         lazy_tables= not is_testing)
     ## allow mysql tinyint
     from gluon.dal import SQLCustomType

--- a/private/appconfig.ini.example
+++ b/private/appconfig.ini.example
@@ -5,6 +5,10 @@
 ;  characters etc into the database (e.g. for vernacular names)
 [db]
 uri       = mysql://oz:passwd@127.0.0.1/OneZoom?set_encoding=utf8mb4
+; migrate = 1 / 0 / fake
+; *    1 = Try to migrate tables that don't match web2py's stored CREATE TABLE hash on the filesystem
+; *    0 = Only try to recreate tables that don't have a stored CREATE TABLE hash on the filesystem
+; * fake = Pretend to migrate, assume DB is fine, only update web2py's stored CREATE TABLE hash
 migrate   = 1
 pool_size = 1
 


### PR DESCRIPTION
The dates.js file is only ever referenced by the node date property, which is never actually used.

When rendering dates in nodes, we actually use "lengthbr", populated from ``node_details.node_cols["age"]``.

Also, add an easier-to-get-to config option for when you need to use fake-migrate, and document doing so.