### PR TITLE
Client-side DataStore abstract array handling

### DIFF
--- a/OZprivate/rawJS/OZTreeModule/src/api/api_manager.js
+++ b/OZprivate/rawJS/OZTreeModule/src/api/api_manager.js
@@ -61,6 +61,21 @@ class APIManager {
   }
 
   /**
+   * Fetch static tree data
+   * (file name will be automatically decorated with path/tree_version)
+   *
+   * Returns a window.fetch response promise
+   */
+  static_tree_data(data_file) {
+    const abortController = new AbortController();
+    setTimeout(() => { abortController.abort()}, config.api.abort_request_threshold);
+
+    return window.fetch(config.api.static_data_url_func(data_file), {
+      signal: abortController.signal
+    });
+  }
+
+  /**
    * Call the /API/pinpoints endpoint
    * @param pps Array of pinpoints to lookup
    * @param options /API/pinpoints querystring options

--- a/OZprivate/rawJS/OZTreeModule/src/controller/controller_navigation.js
+++ b/OZprivate/rawJS/OZTreeModule/src/controller/controller_navigation.js
@@ -3,6 +3,7 @@
  */
 import config from '../global_config';
 import data_repo from '../factory/data_repo';
+import data_store_api from '../data_store/api';
 import { record_url } from '../navigation/record';
 import { parse_state } from '../navigation/state';
 import { get_largest_visible_node } from '../navigation/utils';
@@ -91,6 +92,9 @@ export default function (Controller) {
     if (init) {
         return tree_settings.rebuild_tree(vis, prev, this);
     }
+
+    // Get any data stores to clear their state in case they're no longer needed
+    data_store_api.clear();
 
     // Get pre-rebuild state, so we can restore the rough position by ID
     // Get largest node, use this to restore position

--- a/OZprivate/rawJS/OZTreeModule/src/data_store/api.js
+++ b/OZprivate/rawJS/OZTreeModule/src/data_store/api.js
@@ -1,7 +1,23 @@
 import api_manager from '../api/api_manager';
 
 /**
- * Background fetcher for data store slices
+ * Abstract interface a set of raw array data files
+ *
+ * The DataStore singleton mediates access to a number of per-node/per-leaf
+ * data structures, downloading binary arrays as needed.
+ *
+ * To use a data store, access it via. the singleton, e.g:
+ *
+ *     import data_store_api from 'data_store/api';
+ *     console.log(data_store_api.geological.get(node));
+ *
+ * ...if the backing array hasn't yet been retrieved, then this will fetch in the background.
+ *
+ * To implement a data store, create a subclass of DataStore (see src/data_store/data_store.js)
+ * and inject it at the end of this file:
+ *
+ *     ds_api.inject(DataStoreIUCN);
+ *
  */
 class DataStoreAPI {
   constructor() {

--- a/OZprivate/rawJS/OZTreeModule/src/data_store/api.js
+++ b/OZprivate/rawJS/OZTreeModule/src/data_store/api.js
@@ -1,0 +1,93 @@
+import api_manager from '../api/api_manager';
+
+/**
+ * Background fetcher for data store slices
+ */
+class DataStoreAPI {
+  constructor() {
+    this._dsNames = [];
+    this._queue = {};
+    this._notifyTimeoutMs = 100;  // How long before triggers, in ms
+    this._subsequentTimeoutMs = 100;  // If there's still more to do, how long before we trigger, in ms
+    this._fails = {};
+    this._batchSize = 5;  // How many we fetch in one go
+    this._maxFails = 5;  // How many times we retry before start unleashing the error upstream
+  }
+
+  /**
+   * Create a DataStore instance from DsClass, add it to the API
+   */
+  inject(DsClass) {
+    const ds = new DsClass(this);
+    this._dsNames.push(ds.name);
+    this[ds.name] = ds;
+  }
+
+  /**
+   * Clear all data stores, e.g. on visualisation change
+   */
+  clear() {
+    Object.keys(this._dsNames).forEach((dsName) => {
+      this[dsName].clear();
+    });
+  }
+
+  /**
+   * Notify DataStoreAPI there's a missing slice to fetch
+   * - sliceName: The data slice to fetch
+   * - dataStore: The DataStore object to eventually be notified with dataStore.incoming(sliceName, resp);
+   */
+  notify(sliceName, dataStore) {
+    // Add slice to overall queue
+    if (this._queue[sliceName] && this._queue[sliceName] !== dataStore) {
+      throw new Error("Data stores sharing slices not supported");
+    }
+    if ((this._fails[sliceName] || 0) > this._maxFails) {
+      // Keeps failing, send error upwards
+      throw new Error("Cannot fetch " + sliceName);
+    }
+    this._queue[sliceName] = dataStore;
+
+    this._startTimer(this._notifyTimeoutMs);
+  }
+
+  // Start a timer if there isn't already one going
+  _startTimer(timeout) {
+    // Already waiting, don't bother
+    if (this._timer) return;
+
+    // Otherwise, start a new timer
+    this._timer = window.setTimeout(() => {
+      const sliceNames = Object.keys(this._queue);
+
+      // If more to fetch, limit to the batch size
+      if (sliceNames.length > this._batchSize) {
+        sliceNames.splice(this._batchSize, sliceNames.length - this._batchSize);
+      }
+
+      // Fetch everything in the current batch
+      return Promise.all(sliceNames.map((sliceName) => {
+        return api_manager.static_tree_data(sliceName).then((response) => {
+          if (!response.ok) throw new Error(`Data store fetch ${sliceName} failed ${response.status}:${response.statusText}`);
+          return this._queue[sliceName].incoming(sliceName, response);
+        }).then(() => {
+          delete this._queue[sliceName];
+        }).catch((error) => {
+          // Note the failure & carry on
+          console.error("Data store slice fetch error", error);
+          this._fails[sliceName] = (this._fails[sliceName] || 0) + 1;
+          delete this._queue[sliceName];
+        });
+      })).finally(() => {
+        // Now we're done, let another timer start
+        this._timer = undefined;
+        // If there's more waiting (either added since we started, or over batchSize), go again
+        if (Object.keys(this._queue).length > 0) this._startTimer(this._subsequentTimeoutMs);
+      });
+    }, timeout);
+  }
+}
+
+// Return singleton instance with all DataStores added
+const ds_api = new DataStoreAPI();
+export default ds_api;

--- a/OZprivate/rawJS/OZTreeModule/src/data_store/data_store.js
+++ b/OZprivate/rawJS/OZTreeModule/src/data_store/data_store.js
@@ -1,0 +1,94 @@
+/**
+ * DataStore: Data manager for (mostly binary array) data
+ */
+export default class DataStore {
+  name = "changeme";  /** The name this DataStore will be added to DataStoreAPI as */
+
+  /**
+   * Convert a node to a DataStore id (read: array offset)
+   * By default use the metacode
+   */
+  nodeToId(node) {
+    return node.metacode;
+  }
+
+  /**
+   * Convert a node into an array slice name
+   * (i.e. the data array that this node will be found in)
+   *
+   * If null is returned, then it's assumed that there is no data for the node
+   */
+  sliceNameFor(node) {
+    return this.is_leaf ? "data_leaf.dat" : "data_node.dat";
+  }
+
+  /**
+   * Convert a window.fetch Response into a data view
+   * By default, convert into Uint8Array of bytes
+   *
+   * See: https://developer.mozilla.org/en-US/docs/Web/API/Response
+   */
+  dataView(response) {
+    // Read as Uint8Array by default
+    return response.bytes();
+  }
+
+  constructor(dataStoreApi) {
+    this.clear();  // Init internal structures
+    this.dataStoreApi = dataStoreApi;
+  }
+
+  /**
+   * Get value from DataStore for given node
+   * - missingValue: Value to return when node has no value in slice
+   * - missingSlice: Value to return when node has no slice assigned
+   *
+   * If slice is missing, queue up request to fetch it & return undefined
+   * Otherwise return value/missingValue/missingSlice (default null)
+   */
+  get(node, missingValue = null, missingSlice = missingValue) {
+    const sliceName = this.sliceNameFor(node);
+    if (sliceName === null) return missingSlice;
+    const view = this._slices[sliceName];
+
+    if (!view) {
+      this.dataStoreApi.notify(sliceName, this);
+      return undefined;
+    }
+    const out = view[this.nodeToId(node)];
+    return out === undefined ? missingValue : out;
+  }
+
+  /**
+   * A requested slice has come in, process & save it
+   * This will be called by DataStoreAPI
+   */
+  incoming(sliceName, response) {
+    return this.dataView(response).then((view) => {
+      this._slices[sliceName] = view;
+    });
+  }
+
+  /**
+   * Clear all existing slices from memory
+   */
+  clear() {
+    this._slices = {};
+  }
+
+  /**
+   * Helper to test platform endian-ness
+   *
+   * Uint16Array() buffers are CPU endian-ness, so we should fetch data with the correct endian-ness.
+   * Use this to decide what to fetch.
+   *
+   * However, everything is little-endian nowadays, so we can just treat big-endian as an error
+   * (sorry, IBM mainframe users).
+   */
+  isLittleEndian() {
+    if (globalThis._platLittleEndian === undefined) {
+      globalThis._platLittleEndian = new Uint8Array(new Uint16Array([1]).buffer)[0] === 1;
+    }
+    return globalThis._platLittleEndian;
+  }
+}

--- a/OZprivate/rawJS/OZTreeModule/src/data_store/data_store.js
+++ b/OZprivate/rawJS/OZTreeModule/src/data_store/data_store.js
@@ -1,5 +1,67 @@
 /**
- * DataStore: Data manager for (mostly binary array) data
+ * DataStore: Abstract data manager class for (mostly binary array) data
+ *
+ * A DataStore maps requests for data for a node back to binary array files.
+ * Before using, an implementation must be injected into the DataStoreAPI (see src/data_store/api.js).
+ *
+ * An implementation for IUCN using DataStore could look like:
+ *
+ *     import DataStore from './data_store';
+ *
+ *     export default class DataStoreIUCN extends DataStore {
+ *       name = "iucn";  // The name that this will be availble from DataStoreApi under
+ *
+ *       constructor(dataStoreApi) {
+ *         super(dataStoreApi);
+ *
+ *         if (!this.isLittleEndian()) {
+ *           throw new Error("Onezoom doesn't support big-endian CPUs");
+ *         }
+ *       }
+ *
+ *       // IUCN data indexed by ott
+ *       nodeToId(node) {
+ *         return node.ott;
+ *       }
+ *
+ *       // Only one array for all IUCN data
+ *       sliceNameFor(node) {
+ *         // NB: There is no data for nodes in IUCN, so we only have a slice for leaves
+ *         return node.is_leaf ? "iucn_le.dat" : null;
+ *       }
+ *
+ *       // We read iucn.dat as a Uint16Array() (CPU-endianness)
+ *       dataView(resp) {
+ *         return resp.arrayBuffer().then((ab) => new Uint16Array(ab));
+ *       }
+ *     }
+ *
+ * We can use DataStore for non-binary-array data too, e.g. a cutmap implementation:
+ *
+ *     import DataStore from './data_store';
+ *
+ *     export default class DataStoreCutMap extends DataStore {
+ *       name = "cutmap";  // The name that this will be availble from DataStoreApi under
+ *
+ *       setCutMapType(type) {
+ *         // NB: This will auto-trigger the new slice to be fetched, as the name to look-up will change
+ *         self._sliceName = type === "polytomy" ? "poly_cut_position_map.json" : "cut_position_map.json";
+ *       }
+ *
+ *       nodeToId(node) {
+ *         return node.end;
+ *       }
+ *
+ *       // Fetch JSON file to populate cut-position map
+ *       sliceNameFor(node) {
+ *         return self._sliceName || 'cut_position_map.json';
+ *       }
+ *
+ *       // Our "data array" is a JSON object
+ *       dataView(resp) {
+ *         return resp.json();
+ *       }
+ *     }
  */
 export default class DataStore {
   name = "changeme";  /** The name this DataStore will be added to DataStoreAPI as */

--- a/OZprivate/rawJS/OZTreeModule/src/factory/data_repo.js
+++ b/OZprivate/rawJS/OZTreeModule/src/factory/data_repo.js
@@ -297,6 +297,7 @@ function parse_ordered_nodes(data_repo, nodes, node_details) {
     m.entry[m.idx["sp7"]] = nodes[i][node_details.node_cols["{pic}7"]];
     m.entry[m.idx["sp8"]] = nodes[i][node_details.node_cols["{pic}8"]];
     
+    // The numbers of DD/NE/LC... leaves below this node (as opposed to parse_iucn, which is OTT/"LC" pairs)
     m.entry[m.idx["iucnDD"]] = nodes[i][node_details.node_cols["iucnDD"]];
     m.entry[m.idx["iucnNE"]] = nodes[i][node_details.node_cols["iucnNE"]];
     m.entry[m.idx["iucnLC"]] = nodes[i][node_details.node_cols["iucnLC"]];

--- a/OZprivate/rawJS/OZTreeModule/src/global_config.js
+++ b/OZprivate/rawJS/OZTreeModule/src/global_config.js
@@ -68,7 +68,10 @@ config.api = {
   tour_search_api: null,
 
   // Function to convert "completetree.js" -> "/OZtree/static/FinalOutputs/data/completetree_27400288.js", e.g.
-  static_data_url_func: function (data_name) { return data_name; },
+  static_data_url_func: function (data_name) {
+      const parts = data_name.split(".", 2);
+      return `/static/${parts[0]}_12345.${parts[1]}`;
+  },
 
   //The following are functions which take an OTT or a OneZoom id
   OZ_leaf_json_url_func: null,

--- a/OZprivate/rawJS/OZTreeModule/tests/test_data_store.js
+++ b/OZprivate/rawJS/OZTreeModule/tests/test_data_store.js
@@ -1,0 +1,149 @@
+/**
+  * Usage: npx babel-tape-runner OZprivate/rawJS/OZTreeModule/tests/test_data_store.js
+  */
+import test from 'tape';
+var jsdom = require('jsdom');
+import DataStore from '../src/data_store/data_store';
+import { getDataStoreAPI } from './util_data_store';
+
+test('data_store:null', function (test) {
+  class DataStoreUt extends DataStore {
+    name = "ut";
+
+    nodeToId(node) { return node.metacode; }
+    sliceNameFor(node) { return null; }
+    dataView(response) { return response.bytes(); }
+  };
+  const ds = getDataStoreAPI(test, [DataStoreUt]).ut;
+
+  return Promise.resolve().then(() => {
+    test.deepEqual(ds.get({ metacode: 0 }), null, "No slices --> any metacode returns null");
+    test.deepEqual(ds.get({ metacode: 4 }), null, "No slices --> any metacode returns null");
+    test.deepEqual(ds.get({ metacode: 4 }, 88, 99), 99, "No slices --> return missingSlice");
+    test.deepEqual(ds.get({ metacode: 4 }, 44), 44, "No slices --> fallback to missingValue");
+  }).then(() => {
+    return global.window.fetch.waitingWithTimeout().then((w) => test.deepEqual(w, {}, "No requests left in queue"));
+  });
+});
+
+test('data_store:json', function (test) {
+  class DataStoreUt extends DataStore {
+    name = "ut";
+
+    nodeToId(node) { return node.id; }
+    sliceNameFor(node) { return `slice_${node.slice}.json`; }
+    dataView(response) { return response.json(); }
+  };
+  const ds = getDataStoreAPI(test, [DataStoreUt]).ut;
+
+  return Promise.resolve().then(() => {
+    test.deepEqual(ds.get({ slice: 'apple_pie', id:0 }), undefined, "Slice not available, retuns undefined");
+
+    return global.window.fetch.waitFor("/static/slice_apple_pie_12345.json").then((reqId) => {
+      window.fetch.resolve_json(reqId, ["a", "b", "c", "d"]);
+      return new Promise((resolve) => setTimeout(resolve, 10));  // NB: Let fetch promises settle
+    });
+  }).then(() => {
+    test.deepEqual(ds.get({ slice: 'apple_pie', id:0 }), "a", "Slice now available (0)");
+    test.deepEqual(ds.get({ slice: 'apple_pie', id:1 }), "b", "Slice now available (1)");
+    test.deepEqual(ds.get({ slice: 'apple_pie', id:5 }), null, "Slice now available, but no value in it (5)");
+    test.deepEqual(ds.get({ slice: 'apple_pie', id:5 }, 99), 99, "Can customise the missing value");
+    test.deepEqual(ds.get({ slice: 'apple_pie', id:5 }, 88, 99), 88, "Can customise the missing value");
+
+    test.deepEqual(ds.get({ slice: 'pizza', id:0 }), undefined, "Slice not available, retuns undefined");
+    test.deepEqual(ds.get({ slice: 'pizza', id:1 }), undefined, "Slice still not available");
+    test.deepEqual(ds.get({ slice: 'cake', id:"c" }), undefined, "Slice not available, retuns undefined");
+
+    return Promise.all([
+      // NB: Only requesting it once
+      global.window.fetch.waitFor("/static/slice_pizza_12345.json"),
+      global.window.fetch.waitFor("/static/slice_cake_12345.json"),
+    ]).then((reqIds) => {
+      window.fetch.resolve_json(reqIds[0], ["pepperoni", "hawiian"]);
+      window.fetch.resolve_json(reqIds[1], {"v": "victoria sponge", "c": "chocolate"});
+      return new Promise((resolve) => setTimeout(resolve, 10));  // NB: Let fetch promises settle
+    })
+  }).then(() => {
+    test.deepEqual(ds.get({ slice: 'pizza', id:0 }), "pepperoni", "Pizza now available");
+    test.deepEqual(ds.get({ slice: 'cake', id:"c" }), "chocolate", "Cake now available");
+    test.deepEqual(ds.get({ slice: 'apple_pie', id:0 }), "a", "Apple pie still available");
+  }).then(() => {
+    ds.clear();
+    test.deepEqual(ds.get({ slice: 'apple_pie', id:0 }), undefined, "Apple pie no longer available after clear");
+    test.deepEqual(ds.get({ slice: 'pizza', id:1 }), undefined, "Pizza no longer available after clear");
+
+  }).then(() => {
+    return global.window.fetch.waitingWithTimeout().then((w) => test.deepEqual(Object.keys(w).sort(), [
+      "/static/slice_apple_pie_12345.json",
+      "/static/slice_pizza_12345.json",
+    ], "pizza/apple pie requests left hanging"));
+  }).then(() => {
+    return Promise.all([
+      // NB: Only requesting it once
+      global.window.fetch.waitFor("/static/slice_pizza_12345.json"),
+      global.window.fetch.waitFor("/static/slice_apple_pie_12345.json"),
+    ]).then((reqIds) => {
+      window.fetch.resolve_json(reqIds[0], ["pepperoni", "hawiian"]);
+      window.fetch.resolve_json(reqIds[1], {"v": "victoria sponge", "c": "chocolate"});
+      return new Promise((resolve) => setTimeout(resolve, 10));  // NB: Let fetch promises settle
+    });
+  });
+});
+
+test('data_store:bytes', function (test) {
+  class DataStoreUt extends DataStore {
+    name = "ut_bytes";
+
+    nodeToId(node) { return node.id; }
+    sliceNameFor(node) { return `slice_${node.slice}.dat`; }
+    dataView(response) { return response.bytes(); }
+  };
+  const ds = getDataStoreAPI(test, [DataStoreUt]).ut_bytes;
+
+  return Promise.resolve().then(() => {
+    test.deepEqual(ds.get({ slice: 'apple_pie', id:0 }), undefined, "Slice not available, retuns undefined");
+
+    return global.window.fetch.waitFor("/static/slice_apple_pie_12345.dat").then((reqId) => {
+      window.fetch.resolve_bytes(reqId, "\x01\xAA\x03");
+      return new Promise((resolve) => setTimeout(resolve, 10));  // NB: Let fetch promises settle
+    });
+  }).then(() => {
+    test.deepEqual(ds.get({ slice: 'apple_pie', id:0 }), 0x01, "Slice now available (0)");
+    test.deepEqual(ds.get({ slice: 'apple_pie', id:1 }), 0xAA, "Slice now available (1)");
+  }).then(() => {
+    return global.window.fetch.waitingWithTimeout().then((w) => test.deepEqual(w, {}, "No requests left in queue"));
+  });
+});
+
+test('data_store:uint16', function (test) {
+  class DataStoreUt extends DataStore {
+    name = "ut_bytes";
+
+    nodeToId(node) { return node.id; }
+    sliceNameFor(node) { return `slice_${node.slice}_le.dat`; }
+    dataView(response) { return response.arrayBuffer().then((ab) => new Uint16Array(ab)); }
+  };
+  const ds = getDataStoreAPI(test, [DataStoreUt]).ut_bytes;
+
+  return Promise.resolve().then(() => {
+    test.deepEqual(ds.isLittleEndian(), true, "Running on a little-endian CPU")
+  
+    test.deepEqual(ds.get({ slice: 'apple_pie', id:0 }), undefined, "Slice not available, retuns undefined");
+
+    return global.window.fetch.waitFor("/static/slice_apple_pie_le_12345.dat").then((reqId) => {
+      window.fetch.resolve_buffer(reqId, new Uint16Array([0xBEEF, 0xCAFE]));
+      return new Promise((resolve) => setTimeout(resolve, 10));  // NB: Let fetch promises settle
+    });
+  }).then(() => {
+    test.deepEqual(ds.get({ slice: 'apple_pie', id:0 }), 0xBEEF, "Slice now available (0)");
+    test.deepEqual(ds.get({ slice: 'apple_pie', id:1 }), 0xCAFE, "Slice now available (1)");
+  }).then(() => {
+    return global.window.fetch.waitingWithTimeout().then((w) => test.deepEqual(w, {}, "No requests left in queue"));
+  });
+});
+
+test.onFinish(function() {
+  // NB: Something data_repo includes in is holding node open.
+  //     Can't find it so force our tests to end.
+  process.exit(0)
+});

--- a/OZprivate/rawJS/OZTreeModule/tests/util_data_store.js
+++ b/OZprivate/rawJS/OZTreeModule/tests/util_data_store.js
@@ -1,0 +1,16 @@
+import fakeFetch from './util_fake_fetch';
+import dataStoreAPI from '../src/data_store/api.js';
+
+/**
+ * Return the DataStoreAPI, ensuring environment can do fake fetches
+ */
+export function getDataStoreAPI(test, injectClasses = []) {
+  if (!global.window) global.window = { setTimeout: setTimeout };
+  if (!global.window.fetch) window.fetch = fakeFetch();
+
+  injectClasses.forEach((cls) => {
+    dataStoreAPI.inject(cls);
+  });
+
+  return dataStoreAPI;
+};

--- a/OZprivate/rawJS/OZTreeModule/tests/util_fake_fetch.js
+++ b/OZprivate/rawJS/OZTreeModule/tests/util_fake_fetch.js
@@ -1,0 +1,100 @@
+/**
+ * Fake window.fetch with a version that does no network access
+ *
+ * if (!global.window) global.window = { setTimeout: setTimeout };
+ * if (!global.window.fetch) window.fetch = fakeFetch();
+ */
+export default function fakeFetch() {
+  const f = function (url, opts) {
+    let reqId = url + '  ';
+    if (!f.requests) f.requests = {};
+    while (f.requests[reqId]) reqId += "a";
+    f.requests[reqId] = {url: url, opts: opts};
+
+    console.log(`==== New request ${reqId}`);
+
+    return new Promise((resolve, reject) => {
+      f.requests[reqId].resolve = resolve;
+      f.requests[reqId].reject = reject;
+
+      // If something was waiting for this request, give it a poke
+      if ((f.waitingFor || {})[url]) {
+        f.waitingFor[url](reqId);
+        delete f.waitingFor[url];
+      }
+    }).finally(() => {
+      delete f.requests[reqId];
+    });
+  }
+
+  // List all waiting fetch requests and their IDs
+  f.waiting = function (abortOld) {
+    const out = {};
+    Object.keys(f.requests || {}).forEach((reqId) => {
+      if (f.requests[reqId].resolve) {
+        const url = f.requests[reqId].url;
+        if (!out[url]) out[url] = [];
+        out[url].push(reqId);
+        if (abortOld) {
+          f.requests[reqId].reject(new Error("abort"));
+        }
+      }
+    });
+    return out;
+  };
+
+  // Let fetch promises settle, then return list of waiting items
+  f.waitingWithTimeout = function (abortOld) {
+    return new Promise((resolve) => setTimeout(() => {
+      resolve(f.waiting(abortOld))
+    }, 100));
+  };
+
+  // Wait for a request for the given URL, return the request ID
+  f.waitFor = function (url) {
+    // Is there a request already waiting?
+    for (let reqId of Object.keys(f.requests || {})) {
+      if (f.requests[reqId].url === url) {
+        return Promise.resolve(reqId);
+      }
+    }
+
+    // Log that we want to know about the next request
+    if (!f.waitingFor) f.waitingFor = {};
+    return new Promise((resolve) => {
+      f.waitingFor[url] = resolve;
+    });
+  };
+
+  // Reject as network error
+  f.resolve_neterr = function (reqId) {
+    f.requests[reqId].reject(new Error("Your network cable is unplugged or summat"));
+  }
+
+  // Resolve request as a server failure
+  f.resolve_servfail = function (reqId) {
+    f.requests[reqId].resolve({ ok: false, status: 500, statusText: "Oh noes" });
+  };
+
+  // Resolve request as a server failure
+  f.resolve_servfail = function (reqId) {
+    f.requests[reqId].resolve({ ok: false, status: 500, statusText: "Oh noes" });
+  };
+
+  // Resolve with a JSON promise
+  f.resolve_json = function (reqId, data) {
+    f.requests[reqId].resolve({ ok: true, status: 200, statusText: "OK", json: () => Promise.resolve(data) });
+  };
+
+  // Resolve with a bytes promise
+  f.resolve_bytes = function (reqId, dataString) {
+    f.requests[reqId].resolve({ ok: true, status: 200, statusText: "OK", bytes: () => Promise.resolve(Uint8Array.from(dataString.split("").map(x => x.charCodeAt()))) });
+  };
+
+  // Resolve with an arrayBuffer promise
+  f.resolve_buffer = function (reqId, intArray) {
+    f.requests[reqId].resolve({ ok: true, status: 200, statusText: "OK", arrayBuffer: () => Promise.resolve(intArray.buffer) });
+  };
+
+  return f;
+}


### PR DESCRIPTION
Add an DataStore class to manage raw binary arrays, containing values per-node or per-leaf. Automatically fetch data as required so downstream users can just ask for a data point and expect it to be there next time around.

In itself this doesn't do anything, as no data stores have been implemented or are used elsewhere. But it's a start :)

Fixes #978 