### PR TITLE
Issue 1013 prerequisite fixes

### DIFF
--- a/OZprivate/rawJS/OZTreeModule/src/api/api_manager.js
+++ b/OZprivate/rawJS/OZTreeModule/src/api/api_manager.js
@@ -68,10 +68,13 @@ class APIManager {
    */
   static_tree_data(data_file) {
     const abortController = new AbortController();
-    setTimeout(() => { abortController.abort()}, config.api.abort_request_threshold);
+    const abort_timer = setTimeout(() => { abortController.abort()}, config.api.abort_request_threshold);
 
     return window.fetch(config.api.static_data_url_func(data_file), {
       signal: abortController.signal
+    }).finally(() => {
+      // Request is done with, no point still holding onto a timer to abort it
+      clearTimeout(abort_timer);
     });
   }
 

--- a/OZprivate/rawJS/OZTreeModule/src/data_store/api.js
+++ b/OZprivate/rawJS/OZTreeModule/src/data_store/api.js
@@ -43,7 +43,7 @@ class DataStoreAPI {
    * Clear all data stores, e.g. on visualisation change
    */
   clear() {
-    Object.keys(this._dsNames).forEach((dsName) => {
+    this._dsNames.forEach((dsName) => {
       this[dsName].clear();
     });
   }

--- a/OZprivate/rawJS/OZTreeModule/src/factory/at_midnode.js
+++ b/OZprivate/rawJS/OZTreeModule/src/factory/at_midnode.js
@@ -1,5 +1,4 @@
 import Midnode from './midnode';
-import {ObjectPool} from '../util/index';
 
 class ATMidnode extends Midnode {
   constructor() {
@@ -82,7 +81,5 @@ let mapping = {
   "AllArchaeaAndEukaryotes_":"39d"
   
 };
-
-ATMidnode.obj_pool = new ObjectPool(ATMidnode, 25000);
 
 export default ATMidnode;

--- a/OZprivate/rawJS/OZTreeModule/src/factory/factory.js
+++ b/OZprivate/rawJS/OZTreeModule/src/factory/factory.js
@@ -15,7 +15,7 @@ class Factory {
    * Builds the root node, called by controller.rebuild_tree()
    */
   build_tree() {
-    this.root = Midnode.create();
+    this.root = new Midnode();
     this.root.init(0, data_repo.raw_data.length-1, 1, 1, null, 0);
   }
   

--- a/OZprivate/rawJS/OZTreeModule/src/factory/garbage_collection.js
+++ b/OZprivate/rawJS/OZTreeModule/src/factory/garbage_collection.js
@@ -36,37 +36,15 @@ function find_unused_node_and_clear(node, last_dvar_height, last_target_height) 
 
 function find_unused_node_and_clear2(node, last_dvar_height, last_target_height) {
   if (last_dvar_height >= config.gc.detach_level && last_target_height >= config.generation_on_subbranch_during_fly) {
-    free_space_from_node(node);
+    // NB: We can't undevelop a single node, as there's no convention for a node with half-developed children
+    //     Instead, undevelop below this node
+    node.children = [];
   } else {
     let length = node.children.length;
     for (let i=0; i<length; i++) {
       find_unused_node_and_clear2(node.children[i], last_dvar_height+1, last_target_height+1);
     }
   }
-}
-
-/*
-* Destroy all descendants of node and clear its reference to its children.
-* node would remain on the tree after calling this function but all its descendants would gone.
-* Its descendants would be recovered automatically if node is insight.
-*/
-function free_space_from_node(node) {
-  let length = node.children.length;
-  for (let i=0; i<length; i++) {
-    free_space_from_node2(node.children[i]);
-  }
-  node.children = [];
-}
-
-/*
-* Destroy all descendants of node and destroy node itself
-*/
-function free_space_from_node2(node) {
-  let length = node.children.length;
-  for (let i=0; i<length; i++) {
-    free_space_from_node2(node.children[i]);
-  }
-  node.free();
 }
 
 /*

--- a/OZprivate/rawJS/OZTreeModule/src/factory/garbage_collection.js
+++ b/OZprivate/rawJS/OZTreeModule/src/factory/garbage_collection.js
@@ -22,15 +22,29 @@ function clear_garbage() {
 
 /*
 * Destroy all nodes which are above certain distance(detach_level) from the visible main branch(where dvar=true).
+* (last_dvar_height) / (last_target_height) are (node)'s own distance from the closest
+* dvar / targeted node at or above it, i.e. 0 if (node) is dvar / targeted itself.
 */
 function find_unused_node_and_clear(node, last_dvar_height, last_target_height) {
-  if (node.has_child) {
-    if (node.dvar || node.targeted) {
-      last_dvar_height = node.dvar ? 0 : (last_dvar_height+1);
-      last_target_height = node.targeted ? 0 : (last_target_height+1);
-    } else {
-      find_unused_node_and_clear2(node, last_dvar_height, last_target_height);
-    }
+  if (!node.has_child) return;
+
+  if (!node.dvar && !node.targeted) {
+    // Out of reach of both the visible branch and the flight path. Both propagate up
+    // towards the root---re_calc() ORs dvar from a node's children, target_by_code()
+    // marks the whole root-to-target path---so we don't have to look below for more.
+    // (re_calc() can leave a stale dvar on a subtree it didn't visit this frame, but
+    // that subtree is offscreen, so collecting it is what we want anyway)
+    return find_unused_node_and_clear2(node, last_dvar_height, last_target_height);
+  }
+
+  // Still on the visible branch / flight path, so nothing to collect here. Look below
+  // for nodes that aren't, restarting the count for whichever of the 2 a child renews
+  for (let i=0; i<node.children.length; i++) {
+    find_unused_node_and_clear(
+      node.children[i],
+      node.children[i].dvar ? 0 : (last_dvar_height+1),
+      node.children[i].targeted ? 0 : (last_target_height+1),
+    );
   }
 }
 

--- a/OZprivate/rawJS/OZTreeModule/src/factory/life_midnode.js
+++ b/OZprivate/rawJS/OZTreeModule/src/factory/life_midnode.js
@@ -1,5 +1,4 @@
 import Midnode from './midnode';
-import {ObjectPool} from '../util/index';
 
 class LifeMidnode extends Midnode {
   constructor() {
@@ -15,7 +14,5 @@ class LifeMidnode extends Midnode {
     this.bezr = undefined;
   }
 }
-
-LifeMidnode.obj_pool = new ObjectPool(LifeMidnode, 25000);
 
 export default LifeMidnode;

--- a/OZprivate/rawJS/OZTreeModule/src/factory/midnode.js
+++ b/OZprivate/rawJS/OZTreeModule/src/factory/midnode.js
@@ -72,35 +72,6 @@ class Midnode {
     
     this.full_children_length = 0;
   }
-  static create(obj) {
-    return this.obj_pool.get();
-  }
-  free() {
-    this.constructor.obj_pool.release(this);
-  }
-  release() {
-    this.children = [];
-    this._meta = undefined;
-    this._detail_fetched = false;
-    this._cname = null;
-    this._latin_name = null;
-    this._age = null;
-    this._spec_num_full = null;
-    this._picset_len = null;
-    this._picset_codes = null;
-    this._signpost_common = false;
-    this._threatened_branch = null;
-    this._redlist = null;
-    this._pic_filename = null;
-    this._picID_credit = null;
-    this._picID_src = null;
-    this._ott = null;
-    this._region = null;
-    this._date = null;
-    this._popularity = null;
-    this._is_polytomy = null;
-    delete this.highlight_status;
-  }
     
   // called initially with
   // this.root.init(0, data_repo.raw_data.length-1, 1, 1, null, 20);
@@ -144,7 +115,7 @@ class Midnode {
           this.children[i].develop_children(default_depth - 1);
         }
       } else {
-        this.children[i] = this.constructor.create();
+        this.children[i] = new this.constructor();
         this.children[i].init(this.child_start_pos[i], this.child_end_pos[i], this.child_node_meta_start[i], this.child_leaf_meta_start[i], this, depth);
       }
     }

--- a/OZprivate/rawJS/OZTreeModule/src/factory/polytomy_midnode.js
+++ b/OZprivate/rawJS/OZTreeModule/src/factory/polytomy_midnode.js
@@ -1,5 +1,4 @@
 import Midnode from './midnode';
-import {ObjectPool} from '../util/index';
 import data_repo from './data_repo';
 
 class PolytomyMidnode extends Midnode {
@@ -82,7 +81,5 @@ function split_string_and_record_in_cuts(start, end, cuts, first_cut=true) {
     }
   }
 }
-
-PolytomyMidnode.obj_pool = new ObjectPool(PolytomyMidnode, 100000);
 
 export default PolytomyMidnode;

--- a/OZprivate/rawJS/OZTreeModule/src/image_cache.js
+++ b/OZprivate/rawJS/OZTreeModule/src/image_cache.js
@@ -2,11 +2,17 @@ import config from './global_config';
 
 let pic_map = {};
 let count = 0;
+let clear_timer = null;
 
 export function get_image(src, filename, preferred_px=null) {
   if (filename && src) {
     let url = config.pic.data_path_pics(src, filename, preferred_px); //use url as key into the cache array
     if (!pic_map[url]) {
+      // Only start emptying the cache once there's something in it to empty, so
+      // merely importing this module doesn't leave a timer keeping node alive
+      if (clear_timer === null) {
+        clear_timer = setInterval(clear_least_used_image, config.pic.clear_image_cache_interval);
+      }
       pic_map[url] = {};
       pic_map[url].image = new Image();
       pic_map[url].image.src = url;
@@ -21,9 +27,6 @@ export function get_image(src, filename, preferred_px=null) {
 export function image_ready(image) {
   return image && image.complete && !isNaN(image.naturalWidth) && image.naturalWidth > 0;
 }
-
-
-setInterval(clear_least_used_image, config.pic.clear_image_cache_interval);
 
 //sort images by its last used time. Delete least used images so that the pic_map size won't exceed the max allowed pic_map size.
 function clear_least_used_image() {

--- a/OZprivate/rawJS/OZTreeModule/src/projection/layout/branch_layout_base.js
+++ b/OZprivate/rawJS/OZTreeModule/src/projection/layout/branch_layout_base.js
@@ -38,27 +38,25 @@ class BranchLayoutBase {
       }));
   }
 
-  set_bezier_shape(shape, node, markings_list) {
-    shape.sx = node.bezsx * node.rvar + node.xvar;
-    shape.sy = node.bezsy * node.rvar + node.yvar;
-    shape.c1x = node.bezc1x * node.rvar + node.xvar;
-    shape.c1y = node.bezc1y * node.rvar + node.yvar;
-    shape.c2x = node.bezc2x * node.rvar + node.xvar;
-    shape.c2y = node.bezc2y * node.rvar + node.yvar;
-    shape.ex = node.bezex * node.rvar + node.xvar;
-    shape.ey = node.bezey * node.rvar + node.yvar;
-    shape.stroke.line_cap = 'round';
-    shape.height = 1;
-    shape.markings_list = markings_list || [];
-  }
-
   node_line_width(node) {
     return node.bezr * node.rvar;
   }
 
   get_bezier_shapes(node, shapes, markings_list) {
     let bezier_shape = BezierShape.create();
-    this.set_bezier_shape(bezier_shape, node, markings_list);
+
+    bezier_shape.sx = node.bezsx * node.rvar + node.xvar;
+    bezier_shape.sy = node.bezsy * node.rvar + node.yvar;
+    bezier_shape.c1x = node.bezc1x * node.rvar + node.xvar;
+    bezier_shape.c1y = node.bezc1y * node.rvar + node.yvar;
+    bezier_shape.c2x = node.bezc2x * node.rvar + node.xvar;
+    bezier_shape.c2y = node.bezc2y * node.rvar + node.yvar;
+    bezier_shape.ex = node.bezex * node.rvar + node.xvar;
+    bezier_shape.ey = node.bezey * node.rvar + node.yvar;
+    bezier_shape.stroke.line_cap = 'round';
+    bezier_shape.height = 1;
+    bezier_shape.markings_list = markings_list || [];
+
     bezier_shape.do_stroke = true;
     bezier_shape.stroke.line_width = this.node_line_width(node, markings_list);
     bezier_shape.height = 0;

--- a/OZprivate/rawJS/OZTreeModule/src/projection/layout/node_layout_base.js
+++ b/OZprivate/rawJS/OZTreeModule/src/projection/layout/node_layout_base.js
@@ -34,14 +34,34 @@ class NodeLayoutBase {
     this.hovering = false;
   }
   
+  /**
+   * node.rvar, corrected for how big a circle this view draws at the end of a branch.
+   */
+  detail_rvar(node) {
+    /**
+     * The interior-node circle the sizes in this file were originally measured against: the
+     * joint at the end of a branch in the spiral / natural / fern / balanced views, which is
+     * bezr/2 with bezr the fixed partl1 of 0.55.
+     *
+     * Those views all draw the same size of circle for a given rvar, so sizing a node's
+     * contents and gating its detail on rvar alone worked. A view free to stroke its branches
+     * thinner (propspiral) draws a smaller circle for the same rvar, so we divide this out and
+     * work from the circle actually in front of us.
+     */
+    const reference_arcr = 0.55 / 2;
+
+    return node.rvar * node.arcr / reference_arcr;
+  }
+
   calc_twh(node) {
-    this.twidth = config.projection.Twidth * (config.projection.partc - config.projection.partl2) * node.rvar;  
-    this.theight = config.projection.Tsize  * (config.projection.partc - config.projection.partl2) / 2.0 * node.rvar;
-    this.theight2 = config.projection.Tsize  * (config.projection.partc - config.projection.partl2) / 3.0 * node.rvar;
+    let rvar = this.detail_rvar(node);
+    this.twidth = config.projection.Twidth * (config.projection.partc - config.projection.partl2) * rvar;
+    this.theight = config.projection.Tsize  * (config.projection.partc - config.projection.partl2) / 2.0 * rvar;
+    this.theight2 = config.projection.Tsize  * (config.projection.partc - config.projection.partl2) / 3.0 * rvar;
   }
   
   high_res_shapes(node, shapes) {
-    if ((config.projection.draw_all_details && node.rvar >= config.projection.node_high_res_thres)) {
+    if ((config.projection.draw_all_details && this.detail_rvar(node) >= config.projection.node_high_res_thres)) {
       this.high_res_sponsor_shapes(node, shapes);
       this.high_res_image_shapes(node, shapes);
       this.high_res_text_shapes(node, shapes);
@@ -483,8 +503,9 @@ class NodeLayoutBase {
   }
 
   low_res_shapes(node, shapes) {
-    let condition = config.projection.draw_all_details 
-      && node.rvar > config.projection.node_low_res_thres && node.rvar < config.projection.node_high_res_thres;
+    let rvar = this.detail_rvar(node);
+    let condition = config.projection.draw_all_details
+      && rvar > config.projection.node_low_res_thres && rvar < config.projection.node_high_res_thres;
     if (condition) {
       this.low_res_text_shapes(node, shapes);
       this.low_res_date_shapes(node, shapes);
@@ -539,7 +560,7 @@ class NodeLayoutBase {
   }
 
   live_area_interior_circle_test(node) {
-    return node.rvar < config.projection.node_high_res_thres && this.is_mouse_over_node(node);
+    return this.detail_rvar(node) < config.projection.node_high_res_thres && this.is_mouse_over_node(node);
   }
 
   interior_circle_shapes(node, shapes) {
@@ -561,8 +582,8 @@ class NodeLayoutBase {
 
     
   interior_circle_full_shapes(node, shapes) {
-    let condition = node.rvar > config.projection.node_low_res_thres && config.projection.interior_circle_draw;
-      if (condition) {          
+    let condition = this.detail_rvar(node) > config.projection.node_low_res_thres && config.projection.interior_circle_draw;
+      if (condition) {
     let arc_shape = ArcShape.create();
     if (!this.hovered && this.live_area_interior_circle_test(node)) {
       this.hovered = true;
@@ -669,7 +690,7 @@ class NodeLayoutBase {
 
   is_mouse_over_high_res_inner_circle(node) {
     let mouse_over = false;
-    if (node.rvar >= config.projection.node_high_res_thres && tree_state.button_x && tree_state.button_y) {
+    if (this.detail_rvar(node) >= config.projection.node_high_res_thres && tree_state.button_x && tree_state.button_y) {
       let dx_to_node_center = get_abs_x(node, node.arcx) - tree_state.button_x;
       let dy_to_node_center = get_abs_y(node, node.arcy) - tree_state.button_y;
       let button_to_node_center_sqr = dx_to_node_center * dx_to_node_center + dy_to_node_center * dy_to_node_center;

--- a/OZprivate/rawJS/OZTreeModule/src/projection/layout/otop/branch_layout.js
+++ b/OZprivate/rawJS/OZTreeModule/src/projection/layout/otop/branch_layout.js
@@ -18,7 +18,19 @@ class BranchLayout extends BranchLayoutBase {
    */
   get_bezier_shapes(node, shapes, markings_list) {
     let bezier_shape = BezierShape.create();
-    this.set_bezier_shape(bezier_shape, node, markings_list);
+
+    bezier_shape.sx = node.bezsx * node.rvar + node.xvar;
+    bezier_shape.sy = node.bezsy * node.rvar + node.yvar;
+    bezier_shape.c1x = node.bezc1x * node.rvar + node.xvar;
+    bezier_shape.c1y = node.bezc1y * node.rvar + node.yvar;
+    bezier_shape.c2x = node.bezc2x * node.rvar + node.xvar;
+    bezier_shape.c2y = node.bezc2y * node.rvar + node.yvar;
+    bezier_shape.ex = node.bezex * node.rvar + node.xvar;
+    bezier_shape.ey = node.bezey * node.rvar + node.yvar;
+    bezier_shape.stroke.line_cap = 'round';
+    bezier_shape.height = 1;
+    bezier_shape.markings_list = markings_list || [];
+
     bezier_shape.do_stroke = true;
     bezier_shape.stroke.line_width = this.node_line_width(node, markings_list);
     bezier_shape.height = 0;

--- a/OZprivate/rawJS/OZTreeModule/src/projection/layout/polytomy/node_layout.js
+++ b/OZprivate/rawJS/OZTreeModule/src/projection/layout/polytomy/node_layout.js
@@ -20,6 +20,16 @@ class PolytomyNodeLayout extends NodeLayoutBase {
     this.theight = node.rvar * node.arcr * 0.53;
     this.theight2 = node.rvar * node.arcr * 0.37;
   }
+
+  /**
+   * The base class corrects the detail thresholds for how big a circle a view draws, but
+   * polytomy's interior circle is a fixed dot far smaller than the one it works from
+   * (arcr = 0.08 against 0.275), and its sizes above are already measured against it. Keep
+   * the thresholds on plain rvar, which is what they were tuned against here
+   */
+  detail_rvar(node) {
+    return node.rvar;
+  }
     
     interior_circle_shapes(node, shapes) {
         

--- a/OZprivate/rawJS/OZTreeModule/src/projection/pre_calc/balanced_pre_calc.js
+++ b/OZprivate/rawJS/OZTreeModule/src/projection/pre_calc/balanced_pre_calc.js
@@ -45,9 +45,6 @@ function _pre_calc(node) {
   let tempcos90pre = Math.cos(node.arca + Math.PI/2.0);
 
   if (node.has_child) {
-    let atanpre = Math.atan2(node.children[0].richness_val, node.children[1].richness_val);
-    let atanpowpre = Math.atan2(Math.pow(node.children[0].richness_val, 0.5),Math.pow(node.children[1].richness_val, 0.5));
-    
     let tempsin2 = Math.sin(node.arca + Math.PI*thisangleright);
     let tempcos2 = Math.cos(node.arca + Math.PI*thisangleright);
     let tempsin3 = Math.sin(node.arca - Math.PI*thisangleleft);

--- a/OZprivate/rawJS/OZTreeModule/src/projection/pre_calc/spiral_pre_calc.js
+++ b/OZprivate/rawJS/OZTreeModule/src/projection/pre_calc/spiral_pre_calc.js
@@ -59,9 +59,6 @@ function _pre_calc(node) {
 
   if (node.has_child)
   {
-    let atanpre = Math.atan2(node.children[0].richness_val,node.children[1].richness_val);
-    let atanpowpre = Math.atan2(Math.pow(node.children[0].richness_val,0.5),Math.pow(node.children[1].richness_val,0.5));
-
     const [leftChildIndex, rightChildIndex] = (node.children[0].richness_val) >= (node.children[1].richness_val) ? [1, 0] : [0, 1];
     const leftChild = node.children[leftChildIndex];
     const rightChild = node.children[rightChildIndex];

--- a/OZprivate/rawJS/OZTreeModule/src/projection/pre_calc/spiral_pre_calc.js
+++ b/OZprivate/rawJS/OZTreeModule/src/projection/pre_calc/spiral_pre_calc.js
@@ -1,5 +1,20 @@
 import {set_horizon_calculator} from '../horizon_calc/horizon_calc';
 
+/**
+ * Layout pre-calculation for the "spiral" view.
+ *
+ * Each node is drawn as a bezier curve (its branch) with a circle at the end of it,
+ * either a leaf blob, or a joint covering the gap where its children's branches begin.
+ * A node's 2 children are drawn at an angle to their parent: the richer of the 2, the
+ * trunk child, carries on around the spiral, while the poorer, the offshoot, branches
+ * off more sharply.
+ *
+ * Every value below is in the node's own co-ordinate space, i.e. the branch always
+ * runs from (bezsx, bezsy) to (bezex, bezey), whatever the node's size or position on
+ * screen. The layout code converts a point to screen co-ordinates with
+ * (node.xvar + node.rvar * x), and a width or radius with (node.rvar * r), where
+ * xvar/yvar/rvar are maintained by position_helper as the tree is zoomed.
+ */
 class SpiralPreCalc {
   constructor() {
     this._viewtype = "spiral";
@@ -8,19 +23,41 @@ class SpiralPreCalc {
     if (!this._viewtype) throw new Error("viewtype not defined in SpiralPreCalc.");
     else return this._viewtype;
   }
+  /**
+   * Calculate the spiral layout for node and all its descendants, setting on each:
+   *
+   * The branch, a bezier curve drawn by projection/layout/branch_layout_base:
+   * * bezsx, bezsy: Start point of the curve
+   * * bezc1x, bezc1y: First bezier control point
+   * * bezc2x, bezc2y: Second bezier control point
+   * * bezex, bezey: End point of the curve
+   * * bezr: Width the curve is stroked at
+   *
+   * The circle at the end of the branch:
+   * * arcx, arcy: Centre of the circle
+   * * arcr: Radius of the circle. A node with children gets a small joint over the end
+   *   of its branch (bezr/2); a node without gets a leaf blob, much wider than its branch
+   * * arca: Angle in radians the branch points in, used to orient the leaf drawn there
+   *   (see projection/layout/leaf_layout_base) as well as to place the node's children
+   *
+   * How to get from this node's co-ordinate space to each child's, used by
+   * position_helper to position children, and by the horizon calculator to combine
+   * their bounding boxes into this node's:
+   * * nextr[i]: Scale of child i relative to this node
+   * * nextx[i], nexty[i]: Position of child i's origin in this node's co-ordinates
+   *
+   * Note that a node's own branch is decided by its parent, so only nextr/nextx/nexty,
+   * arcx/arcy/arcr are set for node itself here. The exception is the root, which has no
+   * parent to do this for it, and so gets a fixed branch pointing straight up the screen.
+   *
+   * @param {Object} node The (sub)tree root to lay out. If node.is_root, generate the
+   *                      fixed root branch first, otherwise the branch values already on
+   *                      node are kept, and only its descendants' are (re)calculated.
+   */
   pre_calc(node) {
-    let partl1 = 0.55;
     if (node.is_root) {
-      node.bezsx =  0;
-      node.bezsy =  0; // start y position
-      node.bezex =  0; // end x position
-      node.bezey =  -1; // end y position
-      node.bezc1x=  0; // control point 1 x position 
-      node.bezc1y=  -0.05; // control point 2 y position
-      node.bezc2x=  0; // control point 2 x position
-      node.bezc2y=  -0.95; // control point 2 y position
-      node.bezr  =  partl1; // line width
-      node.arca = Math.PI*(3/2);
+      Object.assign(node, root_branch);
+      node.arca = root_arca;
     }
     _pre_calc(node);
   }
@@ -29,77 +66,146 @@ class SpiralPreCalc {
   }
 }
 
+/**
+ * Leaf blob dimensions: a blob of radius (leafmult * partc), sitting posmult beyond the
+ * end of the branch it hangs off. A branch always reaches exactly 1 in its own
+ * co-ordinate space, so these are in effect fractions of a branch's length: a blob comes
+ * out 1.28 in radius, sitting 0.9 past the tip of the branch it caps.
+ */
+const leafmult = 3.2;
+const partc = 0.4;
+const posmult = 0.9;
+
+/**
+ * How thick a branch is drawn, again as a fraction of the 1 it reaches. Every node in the
+ * view is the same partl1 wide (a node is only ever given a width by the fallback in
+ * _pre_calc below), so a branch is a line of constant width rather than a tapering one;
+ * what makes the tree narrow towards the leaves is each child being drawn smaller than its
+ * parent, not the width changing along a branch.
+ */
+const partl1 = 0.55;
+
+/**
+ * How far along its own angle a node places its children's origins. Each child's branch
+ * then starts child_start back along that same angle, i.e. child_origin_dist +
+ * child_start = 1 along it, which is exactly where the node's own branch ends: the child's
+ * curve begins on its parent's tip however the 2 are scaled or angled.
+ */
+const child_origin_dist = 1.3;
+const child_start = -0.3;
+
+/**
+ * How far past the end of its branch a node's joint sits, as a fraction of the branch. Just
+ * beyond it, so the circle covers the gap where the children's branches begin.
+ */
+const joint_overshoot = 1.01;
+
+/**
+ * The 2 kinds of child. The richer of a node's 2 children is the trunk child, carrying on
+ * around the spiral: it turns by the smaller angle, to the right, and is drawn at the
+ * larger scale. The poorer is the offshoot, branching off to the left more sharply and
+ * drawn much smaller. Each kind gives:
+ * * turn: How far the child's angle is turned from its parent's, positive being to the right
+ * * ratio: How much smaller the child is drawn than its parent, i.e. its nextr
+ * * side: Which way the child is pushed off its parent's centre line (see nextx/nexty below)
+ * * control_points: The child's 2 bezier control points, each measured either along its
+ *   parent's angle or along its own (see _pre_calc)
+ */
+const trunk_child = {
+  turn: Math.PI * 0.22,
+  ratio: 1 / 1.3,
+  side: 1,
+  // Both control points lie along the parent's angle, the first sitting exactly on the
+  // start point, so the curve leaves the tip travelling just the way the parent was
+  control_points: (along_parent, along_self) => [along_parent(child_start), along_parent(0.15)],
+};
+const offshoot_child = {
+  turn: Math.PI * -0.46,
+  ratio: 1 / 2.25,
+  side: -1,
+  // Only the first control point follows the parent's angle, and only just: the second sits
+  // back along the child's own angle, pulling the curve straight into its end point, so the
+  // sharper turn is made close to the parent's tip rather than spread over the branch
+  control_points: (along_parent, along_self) => [along_parent(0.1), along_self(0.9)],
+};
+
+/**
+ * The branch the root is drawn with: straight up the screen from the origin to (0, -1),
+ * with the control points spaced along it so the curve comes out as good as straight.
+ *
+ * It doubles as the fallback for any part of a branch a node hasn't been given (see
+ * _pre_calc). A child is given every part of its curve by its parent bar its width, so in
+ * practice bezr is the only one of these an ordinary node takes.
+ */
+const root_arca = Math.PI * (3 / 2); // Straight up the screen
+const root_branch = {
+  bezsx: 0, bezsy: 0, // start position
+  bezc1x: 0, bezc1y: -0.05, // control point 1 position
+  bezc2x: 0, bezc2y: -0.95, // control point 2 position
+  bezex: 0, bezey: -1, // end position
+  bezr: partl1, // line width
+};
+
+/**
+ * Recursively lay out node and its descendants.
+ * @see SpiralPreCalc.pre_calc for the values this sets on each node
+ */
 function _pre_calc(node) {
-  let leafmult = 3.2;
-  let posmult = 0.9;
-  let partc = 0.4;
-  let thisangleleft = 0.46;
-  let thisangleright = 0.22;
-  let thisratio1 = 1/1.3;
-  let thisratio2 = 1/2.25;
-  let partl1 = 0.55;
-  let tempsinpre = Math.sin(node.arca);
-  let tempcospre = Math.cos(node.arca);
-  let tempsin90pre = Math.sin(node.arca + Math.PI/2.0);
-  let tempcos90pre = Math.cos(node.arca + Math.PI/2.0);
-  let tempsin2 = Math.sin(node.arca + Math.PI*thisangleright);
-  let tempcos2 = Math.cos(node.arca + Math.PI*thisangleright);
-  let tempsin3 = Math.sin(node.arca - Math.PI*thisangleleft);
-  let tempcos3 = Math.cos(node.arca - Math.PI*thisangleleft);
-  
-  node.bezsx = node.bezsx  !== undefined ? node.bezsx : 0;
-  node.bezsy = node.bezsy  !== undefined ? node.bezsy : 0; // start y position
-  node.bezex = node.bezex  !== undefined ? node.bezex : 0; // end x position
-  node.bezey = node.bezey  !== undefined ? node.bezey : -1; // end y position
-  node.bezc1x= node.bezc1x !== undefined ? node.bezc1x: 0; // control point 1 x position 
-  node.bezc1y= node.bezc1y !== undefined ? node.bezc1y: -0.05; // control point 2 y position
-  node.bezc2x= node.bezc2x !== undefined ? node.bezc2x: 0; // control point 2 x position
-  node.bezc2y= node.bezc2y !== undefined ? node.bezc2y: -0.95; // control point 2 y position
-  node.bezr  = node.bezr   !== undefined ? node.bezr  : partl1; // line width
+  // The direction our own branch points in, and the same turned a quarter-turn to the
+  // right, which is the direction our children are pushed apart along
+  const dirx = Math.cos(node.arca), diry = Math.sin(node.arca);
+  const perpx = Math.cos(node.arca + Math.PI / 2.0), perpy = Math.sin(node.arca + Math.PI / 2.0);
+
+  // Keep the branch our parent gave us, filling in anything it left unset from the root
+  // branch: a node's width always comes from there, and a node we have been asked to lay a
+  // subtree out from may have no branch at all yet
+  for (const name in root_branch) {
+    if (node[name] === undefined) node[name] = root_branch[name];
+  }
 
   if (node.has_child)
   {
-    const [leftChildIndex, rightChildIndex] = (node.children[0].richness_val) >= (node.children[1].richness_val) ? [1, 0] : [0, 1];
-    const leftChild = node.children[leftChildIndex];
-    const rightChild = node.children[rightChildIndex];
-    
-    node.nextr[rightChildIndex] = thisratio1; // r (scale) reference for child 1
-    node.nextr[leftChildIndex] = thisratio2; // r (scale) reference for child 2
-    rightChild.bezsx = -(0.3)*(tempcospre)/thisratio1;
-    rightChild.bezsy = -(0.3)*(tempsinpre)/thisratio1;
-    rightChild.bezex = tempcos2;
-    rightChild.bezey = tempsin2;
-    rightChild.bezc1x = -0.3*(tempcospre)/thisratio1;
-    rightChild.bezc1y = -0.3*(tempsinpre)/thisratio1;
-    rightChild.bezc2x = 0.15*(tempcospre)/thisratio1;
-    rightChild.bezc2y = 0.15*(tempsinpre)/thisratio1;
-    rightChild.arca = node.arca + Math.PI*thisangleright;
-    
-    leftChild.bezsx = -(0.3)*(tempcospre)/thisratio2;
-    leftChild.bezsy = -(0.3)*(tempsinpre)/thisratio2;
-    leftChild.bezex = tempcos3;
-    leftChild.bezey = tempsin3;
-    leftChild.bezc1x = 0.1*(tempcospre)/thisratio2;
-    leftChild.bezc1y = 0.1*(tempsinpre)/thisratio2;
-    leftChild.bezc2x = 0.9*tempcos3;
-    leftChild.bezc2y = 0.9*tempsin3;
-    leftChild.arca = node.arca - Math.PI*thisangleleft;
-    
-    node.nextx[rightChildIndex] = (1.3*Math.cos(node.arca))+(((node.bezr)-(partl1*thisratio1))/2.0)*tempcos90pre; // x refernece point for both children
-    node.nexty[rightChildIndex] = (1.3*Math.sin(node.arca))+(((node.bezr)-(partl1*thisratio1))/2.0)*tempsin90pre; // y reference point for both children
-    node.nextx[leftChildIndex] = (1.3*Math.cos(node.arca))-(((node.bezr)-(partl1*thisratio2))/2.0)*tempcos90pre; // x refernece point for both children
-    node.nexty[leftChildIndex] = (1.3*Math.sin(node.arca))-(((node.bezr)-(partl1*thisratio2))/2.0)*tempsin90pre; // y reference point for both children
-    
-    node.arcx = node.bezex*1.01;
-    node.arcy = node.bezey*1.01;
-    node.arcr = node.bezr/2;
-    
+    // The richer child carries on around the spiral as the trunk, the poorer offshoots
+    const [offshootChildIndex, trunkChildIndex] = (node.children[0].richness_val) >= (node.children[1].richness_val) ? [1, 0] : [0, 1];
+
+    for (const [childIndex, kind] of [[trunkChildIndex, trunk_child], [offshootChildIndex, offshoot_child]]) {
+      const child = node.children[childIndex];
+      const child_arca = node.arca + kind.turn;
+      const child_dirx = Math.cos(child_arca), child_diry = Math.sin(child_arca);
+      // The 2 ways a point on the child's branch is measured, both in the child's own
+      // co-ordinate space: a distance along the child's angle, or one back along ours --
+      // which, the child being drawn ratio times smaller than us, is that much longer there
+      const along_self = (dist) => [dist * child_dirx, dist * child_diry];
+      const along_parent = (dist) => [dist * dirx / kind.ratio, dist * diry / kind.ratio];
+      const [c1, c2] = kind.control_points(along_parent, along_self);
+
+      node.nextr[childIndex] = kind.ratio; // r (scale) reference for the child
+      child.arca = child_arca;
+      // The branch runs from our own tip (see child_start) to 1 along the child's angle
+      [child.bezsx, child.bezsy] = along_parent(child_start);
+      [child.bezc1x, child.bezc1y] = c1;
+      [child.bezc2x, child.bezc2y] = c2;
+      [child.bezex, child.bezey] = along_self(1);
+
+      // Both children start child_origin_dist along our own angle, then are pushed apart at
+      // right-angles to it, by half the difference between our branch width and theirs
+      const bias = kind.side * ((node.bezr - (partl1 * kind.ratio)) / 2.0);
+      node.nextx[childIndex] = (child_origin_dist * dirx) + (bias * perpx); // x reference point for the child
+      node.nexty[childIndex] = (child_origin_dist * diry) + (bias * perpy); // y reference point for the child
+    }
+
+    // Joint just beyond the end of our branch, covering the gap where the children start
+    node.arcx = node.bezex * joint_overshoot;
+    node.arcy = node.bezey * joint_overshoot;
+    node.arcr = node.bezr / 2;
+
     _pre_calc(node.children[0]);
     _pre_calc(node.children[1]);
   } else {
-    node.arcx = node.bezex+posmult*(tempcospre);
-    node.arcy = node.bezey+posmult*(tempsinpre);
-    node.arcr = leafmult*partc;
+    // Leaf blob, sitting posmult beyond the end of our branch, in the direction we point
+    node.arcx = node.bezex + (posmult * dirx);
+    node.arcy = node.bezey + (posmult * diry);
+    node.arcr = leafmult * partc;
   }
 }
 

--- a/OZprivate/rawJS/OZTreeModule/src/tree_state.js
+++ b/OZprivate/rawJS/OZTreeModule/src/tree_state.js
@@ -30,11 +30,11 @@ class TreeState {
     this.last_render_at = new Date();
     this.button_x = null;
     this.button_y = null;
-    let self = this;
-    setTimeout(function() {
-      self.url_parsed = true;
-    }, 5000);
     if (global.document) {
+      // NB: Only in a browser, otherwise this timer keeps node alive for no reason
+      setTimeout(() => {
+        this.url_parsed = true;
+      }, 5000);
       document.onmousemove = (ev) => {
         this.last_active_at = new Date()
       }

--- a/OZprivate/rawJS/OZTreeModule/tests/test_data_store.js
+++ b/OZprivate/rawJS/OZTreeModule/tests/test_data_store.js
@@ -141,9 +141,3 @@ test('data_store:uint16', function (test) {
     return global.window.fetch.waitingWithTimeout().then((w) => test.deepEqual(w, {}, "No requests left in queue"));
   });
 });
-
-test.onFinish(function() {
-  // NB: Something data_repo includes in is holding node open.
-  //     Can't find it so force our tests to end.
-  process.exit(0)
-});

--- a/OZprivate/rawJS/OZTreeModule/tests/test_factory_data_repo.js
+++ b/OZprivate/rawJS/OZTreeModule/tests/test_factory_data_repo.js
@@ -115,9 +115,3 @@ test('DataRepo:update_metadata', function (t) {
 
     t.end();
 });
-
-test.onFinish(function() { 
-  // NB: Something data_repo includes in is holding node open.
-  //     Can't find it so force our tests to end.
-  process.exit(0)
-});

--- a/OZprivate/rawJS/OZTreeModule/tests/test_factory_data_repo.js
+++ b/OZprivate/rawJS/OZTreeModule/tests/test_factory_data_repo.js
@@ -53,7 +53,14 @@ test('DataRepo:update_metadata', function (t) {
         }).filter(function (x) { return x.ozid !== '0' && x.ozid !== 'temp' });
     }
 
-    data_repo.setup({raw_data: rawdata, cut_map: {}, poly_cut_map: {}, cut_threshold: 10000});
+    data_repo.setup({
+        raw_data: rawdata, cut_map: {}, poly_cut_map: {}, cut_threshold: 10000,
+        // NB: data_repo is a module-level singleton, so start from a clean slate
+        //     rather than inheriting whatever another test populated
+        metadata: { leaf_meta: [], node_meta: [] },
+        ott_id_map: {},
+        name_id_map: {},
+    });
     t.deepEqual(pic_metadata(["OTTid", "picID", "picID_src", "picID_rating", "picID_credit"]), [], "No leaves at start");
 
     // Add some leaves without images

--- a/OZprivate/rawJS/OZTreeModule/tests/test_factory_factory.js
+++ b/OZprivate/rawJS/OZTreeModule/tests/test_factory_factory.js
@@ -42,9 +42,3 @@ test('dynamic_loading_by_metacode', function (test) {
   })
 });
 
-
-test.onFinish(function() {
-  // NB: Something data_repo includes in is holding node open.
-  //     Can't find it so force our tests to end.
-  process.exit(0)
-});

--- a/OZprivate/rawJS/OZTreeModule/tests/test_factory_garbage_collection.js
+++ b/OZprivate/rawJS/OZTreeModule/tests/test_factory_garbage_collection.js
@@ -1,0 +1,267 @@
+/**
+  * Usage: npx babel-tape-runner OZprivate/rawJS/OZTreeModule/tests/test_factory_garbage_collection.js
+  */
+import test from 'tape';
+
+import config from '../src/global_config';
+import { init as gc_init } from '../src/factory/garbage_collection';
+import { call_hook, remove_hook } from '../src/util/hook';
+import { populate_factory } from './util_factory'
+
+const orig_detach_level = config.gc.detach_level;
+const orig_generations = config.generation_on_subbranch_during_fly;
+
+/**
+  * Set the 2 config options garbage collection considers, restoring the
+  * defaults once (test) has finished
+  */
+function with_gc_config(test, detach_level, generations) {
+  config.gc.detach_level = detach_level;
+  config.generation_on_subbranch_during_fly = generations;
+  test.teardown(() => {
+    config.gc.detach_level = orig_detach_level;
+    config.generation_on_subbranch_during_fly = orig_generations;
+  });
+}
+
+/**
+  * Return a fresh tree with (depth) generations of children developed, and
+  * nothing else (build_tree() develops no children of its own)
+  */
+function fresh_tree(factory, depth) {
+  factory.build_tree();
+  factory.root.develop_children(depth);
+  return factory.root;
+}
+
+/**
+  * Dotted child-index path of every developed node at or below (node), e.g.
+  * ['root', '0', '0.0', '0.1', '1', ...]. Undeveloped children are skipped, so
+  * this is what garbage collection has left behind.
+  */
+function developed_paths(node, prefix = 'root') {
+  let out = [prefix];
+
+  for (let i = 0; i < node.children.length; i++) {
+    if (node.children[i]) {
+      out = out.concat(developed_paths(node.children[i], prefix === 'root' ? String(i) : prefix + '.' + i));
+    }
+  }
+  return out;
+}
+
+/** The deepest generation with any developed node in it, root being 0 */
+function max_depth(node) {
+  return Math.max(...developed_paths(node).map((p) => p === 'root' ? 0 : p.split('.').length));
+}
+
+test('init: Adds an after_draw hook that collects garbage', function (test) {
+  return populate_factory().then((factory) => {
+    with_gc_config(test, 1, 1);
+    test.teardown(() => remove_hook('after_draw'));
+    let root = fresh_tree(factory, 4);
+
+    // Before init() the after_draw hook does nothing
+    call_hook('after_draw');
+    test.deepEqual(max_depth(root), 5, 'Tree untouched without a hook to do it');
+
+    // ...but once registered, drawing collects everything out of reach
+    gc_init();
+    call_hook('after_draw');
+    test.deepEqual(developed_paths(root), ['root', '0', '1'], 'Everything below the 1st generation collected');
+
+  }).then(function () {
+    test.end();
+  }).catch(function (err) {
+    console.log(err.stack);
+    test.fail(err);
+    test.end();
+  })
+});
+
+test('clear_garbage: Collects generations beyond the configured levels', function (test) {
+  return populate_factory().then((factory) => {
+    with_gc_config(test, 2, 2);
+    test.teardown(() => remove_hook('after_draw'));
+    gc_init();
+    let root = fresh_tree(factory, 4);
+
+    test.deepEqual(max_depth(root), 5, 'Started with 5 generations below the root')
+
+    // A node is undeveloped once it is itself detach_level generations out of reach,
+    // so the node at that generation survives---it's everything below that goes
+    call_hook('after_draw');
+    test.deepEqual(developed_paths(root), [
+      'root',
+      '0', '0.0', '0.1',
+      '1', '1.0', '1.1',
+    ], 'Kept 2 generations below the root, collected the rest');
+
+  }).then(function () {
+    test.end();
+  }).catch(function (err) {
+    console.log(err.stack);
+    test.fail(err);
+    test.end();
+  })
+});
+
+test('clear_garbage: Keeps the greater of detach_level / generation_on_subbranch_during_fly', function (test) {
+  return populate_factory().then((factory) => {
+    with_gc_config(test, 1, 3);
+    test.teardown(() => remove_hook('after_draw'));
+    gc_init();
+
+    // Both conditions have to be met to collect, so the larger config option wins
+    let root = fresh_tree(factory, 4);
+    call_hook('after_draw');
+    test.deepEqual(max_depth(root), 3, 'generation_on_subbranch_during_fly = 3 wins over detach_level = 1');
+
+    config.gc.detach_level = 3;
+    config.generation_on_subbranch_during_fly = 1;
+    root = fresh_tree(factory, 4);
+    call_hook('after_draw');
+    test.deepEqual(max_depth(root), 3, 'detach_level = 3 wins over generation_on_subbranch_during_fly = 1');
+
+  }).then(function () {
+    test.end();
+  }).catch(function (err) {
+    console.log(err.stack);
+    test.fail(err);
+    test.end();
+  })
+});
+
+test('clear_garbage: Undevelops the whole node, leaving it for develop_children() to rebuild', function (test) {
+  return populate_factory().then((factory) => {
+    with_gc_config(test, 1, 1);
+    test.teardown(() => remove_hook('after_draw'));
+    gc_init();
+    let root = fresh_tree(factory, 4);
+
+    call_hook('after_draw');
+    test.deepEqual(developed_paths(root), ['root', '0', '1'], 'Everything below the 1st generation collected');
+
+    // A collected node is emptied outright rather than having individual children
+    // removed---the rest of the tree has no convention for a half-developed node
+    let collected = root.children[0];
+    test.deepEqual(collected.children, [], 'Collected node has no children at all');
+    test.deepEqual(collected.has_child, false, 'so it now reports itself childless');
+    test.deepEqual(collected.full_children_length, 2, 'but still knows how many it ought to have');
+
+    // Repeated collection is a no-op, not an error
+    call_hook('after_draw');
+    test.deepEqual(developed_paths(root), ['root', '0', '1'], 'Still collected, without re-collecting anything');
+
+    // The nodes come back when the tree needs them again
+    collected.develop_children(0);
+    test.deepEqual(developed_paths(root), ['root', '0', '0.0', '0.1', '1'], 'Children redeveloped');
+
+  }).then(function () {
+    test.end();
+  }).catch(function (err) {
+    console.log(err.stack);
+    test.fail(err);
+    test.end();
+  })
+});
+
+test('clear_garbage: A dvar or targeted node protects the generation below it', function (test) {
+  return populate_factory().then((factory) => {
+    with_gc_config(test, 1, 1);
+    test.teardown(() => remove_hook('after_draw'));
+    gc_init();
+
+    // Without anything drawn only the 1st generation survives (see above), but being
+    // drawn restarts the count, buying that child's own children a reprieve.
+    // NB: dvar propagates up to the root, so the root is drawn whenever a child is
+    let root = fresh_tree(factory, 4);
+    root.dvar = true;
+    root.children[0].dvar = true;
+    call_hook('after_draw');
+    test.deepEqual(developed_paths(root), [
+      'root',
+      '0', '0.0', '0.1',
+      '1',
+    ], 'dvar: the drawn child kept a generation its sibling did not');
+
+    // Being on the path to the current flight's destination does the same
+    root = fresh_tree(factory, 4);
+    root.targeted = true;
+    root.children[0].targeted = true;
+    call_hook('after_draw');
+    test.deepEqual(developed_paths(root), [
+      'root',
+      '0', '0.0', '0.1',
+      '1',
+    ], 'targeted: the child being flown to kept a generation its sibling did not');
+
+    // A root with nothing developed below it has nothing to collect, and doesn't error
+    factory.build_tree();
+    test.deepEqual(factory.root.has_child, false, 'Undeveloped root reports no children');
+    call_hook('after_draw');
+    test.deepEqual(developed_paths(factory.root), ['root'], 'Undeveloped root left alone');
+
+  }).then(function () {
+    test.end();
+  }).catch(function (err) {
+    console.log(err.stack);
+    test.fail(err);
+    test.end();
+  })
+});
+
+test('clear_garbage: Collects out-of-reach nodes below a dvar node', function (test) {
+  return populate_factory().then((factory) => {
+    with_gc_config(test, 2, 2);
+    test.teardown(() => remove_hook('after_draw'));
+    gc_init();
+    let root = fresh_tree(factory, 4);
+
+    // The root is being drawn, so is 0 generations from the visible branch...
+    root.dvar = true;
+    // ...as is one of its children, but its sibling is out of reach
+    root.children[0].dvar = true;
+
+    call_hook('after_draw');
+    test.deepEqual(developed_paths(root), [
+      'root',
+      '0', '0.0', '0.0.0', '0.0.1', '0.1', '0.1.0', '0.1.1',
+      '1', '1.0', '1.1',
+    ], 'Counting restarted at the drawn child, so it kept a generation its sibling did not');
+
+  }).then(function () {
+    test.end();
+  }).catch(function (err) {
+    console.log(err.stack);
+    test.fail(err);
+    test.end();
+  })
+});
+
+test('clear_garbage: Walks into subtrees collected by a previous pass', function (test) {
+  return populate_factory().then((factory) => {
+    with_gc_config(test, 3, 3);
+    test.teardown(() => remove_hook('after_draw'));
+    gc_init();
+    let root = fresh_tree(factory, 4);
+
+    // Nothing is being drawn, so everything below the 3rd generation is collected
+    call_hook('after_draw');
+    test.deepEqual(max_depth(root), 3, 'Kept 3 generations below the root');
+
+    // Now draw the tree. The count restarts at the drawn child, bringing the nodes we
+    // just emptied back within reach---being childless, there is nothing left to collect
+    root.dvar = true;
+    root.children[0].dvar = true;
+    call_hook('after_draw');
+    test.deepEqual(max_depth(root), 3, 'Still 3 generations, walked back over without error');
+
+  }).then(function () {
+    test.end();
+  }).catch(function (err) {
+    console.log(err.stack);
+    test.fail(err);
+    test.end();
+  })
+});

--- a/OZprivate/rawJS/OZTreeModule/tests/test_factory_midnode.js
+++ b/OZprivate/rawJS/OZTreeModule/tests/test_factory_midnode.js
@@ -47,14 +47,6 @@ test('sponsor_name,sponsor_kind,sponsor_extra', function (test) {
      extra: 'Don\'t panic'
    }, "Updated metadata, got a sponsorship");
 
-   node.release();
-   node.metacode = 5;  // NB: Unless we change metacode, we'd just fetch the same metadata again
-   test.deepEqual(sponsor(node), {
-     name: undefined,
-     kind: undefined,
-     extra: undefined
-   }, "Releasing cleared metadata");
-
   }).then(function () {
     test.end();
   }).catch(function (err) {

--- a/OZprivate/rawJS/OZTreeModule/tests/test_factory_midnode.js
+++ b/OZprivate/rawJS/OZTreeModule/tests/test_factory_midnode.js
@@ -136,9 +136,3 @@ test('picset', function (test) {
 });
 
 
-test.onFinish(function() {
-  // NB: Something data_repo includes in is holding node open.
-  //     Can't find it so force our tests to end.
-  process.exit(0)
-});
-

--- a/OZprivate/rawJS/OZTreeModule/tests/test_navigation_pinpoint.js
+++ b/OZprivate/rawJS/OZTreeModule/tests/test_navigation_pinpoint.js
@@ -253,9 +253,3 @@ test('node_to_pinpoint:ancestor', function (test) {
 
   test.end();
 });
-
-test.onFinish(function() {
-  // NB: Something data_repo includes in is holding node open.
-  //     Can't find it so force our tests to end.
-  process.exit(0)
-});

--- a/OZprivate/rawJS/OZTreeModule/tests/test_navigation_state.js
+++ b/OZprivate/rawJS/OZTreeModule/tests/test_navigation_state.js
@@ -4,6 +4,8 @@
 import { parse_state, deparse_state } from '../src/navigation/state.js';
 import test from 'tape';
 
+import { setup_fake_window } from './util_dom';
+
 test('parse_state', function (t) {
     function pwl(href) {
         return parse_state(new URL(href));
@@ -65,7 +67,7 @@ test('parse_state', function (t) {
     t.deepEqual(parse_state("?"), {
     }, "A single question mark generates a do-nothing state");
 
-    global.window = { location: new URL("http://onezoom.example.com/cake/@pinpoint") };
+    setup_fake_window(t, { location: new URL("http://onezoom.example.com/cake/@pinpoint") });
     t.deepEqual(parse_state("@Myzopoda_aurita?pop=ol_6794"), {
       url_base: 'http://onezoom.example.com/cake/',
       pinpoint: '@Myzopoda_aurita',

--- a/OZprivate/rawJS/OZTreeModule/tests/test_position_helper.js
+++ b/OZprivate/rawJS/OZTreeModule/tests/test_position_helper.js
@@ -4,6 +4,7 @@
 import * as position_helper from '../src/position_helper.js';
 import { resolve_pinpoints } from '../src/navigation/pinpoint.js';
 import { populate_factory } from './util_factory'
+import { setup_dom } from './util_dom';
 import test from 'tape';
 
 import tree_state from '../src/tree_state.js'
@@ -100,6 +101,9 @@ function test_cur_location(test, controller, node_latin_name, exp_xp, exp_yp, ex
 }
 
 test('perform_actual_fly', function (test) {
+  // NB: setup_canvas fires window_size_change hooks, which may read (window)
+  setup_dom(test);
+
   global.requestAnimationFrame = (callback) => setTimeout(callback, 16);
   global.cancelAnimationFrame = clearTimeout;
   var nodes = {};

--- a/OZprivate/rawJS/OZTreeModule/tests/test_position_helper.js
+++ b/OZprivate/rawJS/OZTreeModule/tests/test_position_helper.js
@@ -156,7 +156,4 @@ test.onFinish(function() {
   
   global.requestAnimationFrame = undefined;
   global.cancelAnimationFrame = undefined;
-  // NB: Something data_repo includes in is holding node open.
-  //     Can't find it so force our tests to end.
-  process.exit(0)
 });

--- a/OZprivate/rawJS/OZTreeModule/tests/test_projection_highlight.js
+++ b/OZprivate/rawJS/OZTreeModule/tests/test_projection_highlight.js
@@ -227,9 +227,3 @@ test('highlights_for', function (test) {
   })
 });
 
-
-test.onFinish(function() {
-  // NB: Something data_repo includes in is holding node open.
-  //     Can't find it so force our tests to end.
-  process.exit(0)
-});

--- a/OZprivate/rawJS/OZTreeModule/tests/test_projection_pre_calc_spiral.js
+++ b/OZprivate/rawJS/OZTreeModule/tests/test_projection_pre_calc_spiral.js
@@ -1,0 +1,252 @@
+/**
+  * Usage: npx babel-tape-runner OZprivate/rawJS/OZTreeModule/tests/test_projection_pre_calc_spiral.js
+  */
+import test from 'tape';
+import almostEqual from 'almost-equal';
+
+import spiral_pre_calc from '../src/projection/pre_calc/spiral_pre_calc';
+import {calc_horizon} from '../src/projection/horizon_calc/horizon_calc';
+
+// Constants baked into spiral_pre_calc, repeated here so expectations read as geometry
+const ROOT_ARCA = Math.PI * (3 / 2);  // Root points straight up
+const ANGLE_RIGHT = Math.PI * 0.22;  // The richer child carries on around the spiral...
+const ANGLE_LEFT = Math.PI * 0.46;  // ...the poorer child branches off more sharply
+const RATIO_RIGHT = 1 / 1.3;  // The richer child is also the larger of the two
+const RATIO_LEFT = 1 / 2.25;
+const DEFAULT_BEZR = 0.55;  // partl1, the width of a branch
+const LEAF_ARCR = 3.2 * 0.4;  // leafmult * partc
+
+function close(t, actual, expected, msg) {
+  t.ok(
+    almostEqual(actual, expected, almostEqual.FLT_EPSILON, almostEqual.FLT_EPSILON),
+    msg + ' (' + actual + ' ~= ' + expected + ')',
+  );
+}
+
+function mk_leaf(richness_val) {
+  return { richness_val: richness_val };
+}
+
+function mk_node(richness_val, children) {
+  return {
+    richness_val: richness_val,
+    has_child: true,
+    children: children,
+    nextr: [],
+    nextx: [],
+    nexty: [],
+  };
+}
+
+function mk_root(children) {
+  let node = mk_node(1, children);
+  node.is_root = true;
+  return node;
+}
+
+/**
+ * A child's reference point should sit 1.3 along the parent's angle, then be
+ * shifted perpendicular to that angle by half the difference in branch widths.
+ * (sign is +1 for the richer/right child, -1 for the poorer/left child)
+ */
+function check_next_point(t, node, index, ratio, sign, msg) {
+  let dx = node.nextx[index] - 1.3 * Math.cos(node.arca);
+  let dy = node.nexty[index] - 1.3 * Math.sin(node.arca);
+
+  close(t, dx * Math.cos(node.arca) + dy * Math.sin(node.arca), 0, msg + ': offset is perpendicular to parent angle');
+  close(t,
+    dx * Math.cos(node.arca + Math.PI / 2) + dy * Math.sin(node.arca + Math.PI / 2),
+    sign * (node.bezr - DEFAULT_BEZR * ratio) / 2,
+    msg + ': offset by half the difference in branch widths');
+}
+
+test('spiral_pre_calc:viewtype', function (t) {
+  t.equal(spiral_pre_calc.viewtype, 'spiral');
+
+  t.end();
+});
+
+test('spiral_pre_calc:setup', function (t) {
+  let root = mk_root([mk_leaf(0.3), mk_leaf(0.7)]);
+
+  // setup() selects the bezier horizon calculator, so horizons can be calculated
+  // for the bezier curves pre_calc() generates
+  spiral_pre_calc.setup();
+  spiral_pre_calc.pre_calc(root);
+  calc_horizon(root);
+
+  // Root's own box covers its bezier curve (padded by half its width) and its arc
+  let bez_xmin = Math.min(root.bezsx, root.bezc1x, root.bezc2x, root.bezex) - root.bezr / 2;
+  let bez_xmax = Math.max(root.bezsx, root.bezc1x, root.bezc2x, root.bezex) + root.bezr / 2;
+  close(t, root.gxmin, Math.min(bez_xmin, root.arcx - root.arcr * 1.305), 'gxmin');
+  close(t, root.gxmax, Math.max(bez_xmax, root.arcx + root.arcr * 1.305), 'gxmax');
+  // ...and the horizon grows to contain the children too
+  t.ok(root.hxmin <= root.gxmin, 'hxmin at least as wide as gxmin');
+  t.ok(root.hxmax >= root.gxmax, 'hxmax at least as wide as gxmax');
+
+  t.end();
+});
+
+test('spiral_pre_calc:root', function (t) {
+  // A root with no children at all: gets the fixed root bezier, drawn as a leaf
+  let root = mk_root(undefined);
+  delete root.has_child;
+
+  spiral_pre_calc.pre_calc(root);
+  close(t, root.arca, ROOT_ARCA, 'arca points straight up');
+  t.deepEqual([root.bezsx, root.bezsy], [0, 0], 'Curve starts at the origin');
+  t.deepEqual([root.bezex, root.bezey], [0, -1], 'Curve ends one unit up');
+  t.deepEqual([root.bezc1x, root.bezc1y], [0, -0.05], 'Control point 1');
+  t.deepEqual([root.bezc2x, root.bezc2y], [0, -0.95], 'Control point 2');
+  t.equal(root.bezr, DEFAULT_BEZR, 'Branch width');
+
+  // Leaf circle sits posmult beyond the end of the branch, in the direction of arca
+  close(t, root.arcx, root.bezex + 0.9 * Math.cos(ROOT_ARCA), 'arcx');
+  close(t, root.arcy, root.bezey + 0.9 * Math.sin(ROOT_ARCA), 'arcy');
+  close(t, root.arcr, LEAF_ARCR, 'arcr');
+
+  t.end();
+});
+
+test('spiral_pre_calc:children', function (t) {
+  let root = mk_root([mk_leaf(0.3), mk_leaf(0.7)]);
+  spiral_pre_calc.pre_calc(root);
+
+  // children[1] is richer, so it's the one that carries on around the spiral
+  let rich = root.children[1], poor = root.children[0];
+
+  // An internal node's arc is a joint at the end of its branch, not a leaf circle
+  close(t, root.arcx, root.bezex * 1.01, 'root arcx');
+  close(t, root.arcy, root.bezey * 1.01, 'root arcy');
+  close(t, root.arcr, root.bezr / 2, 'root arcr');
+
+  close(t, rich.arca, ROOT_ARCA + ANGLE_RIGHT, 'Richer child turns right by the smaller angle');
+  close(t, poor.arca, ROOT_ARCA - ANGLE_LEFT, 'Poorer child turns left by the larger angle');
+  t.deepEqual(root.nextr, [RATIO_LEFT, RATIO_RIGHT], 'Richer child drawn at the larger scale');
+
+  check_next_point(t, root, 1, RATIO_RIGHT, 1, 'Richer child');
+  check_next_point(t, root, 0, RATIO_LEFT, -1, 'Poorer child');
+
+  // Both children's curves end one unit along their own angle
+  close(t, rich.bezex, Math.cos(rich.arca), 'Richer child bezex');
+  close(t, rich.bezey, Math.sin(rich.arca), 'Richer child bezey');
+  close(t, poor.bezex, Math.cos(poor.arca), 'Poorer child bezex');
+  close(t, poor.bezey, Math.sin(poor.arca), 'Poorer child bezey');
+
+  // Both start back down the parent's branch, scaled into the child's own co-ordinates
+  close(t, rich.bezsx, -0.3 * Math.cos(ROOT_ARCA) / RATIO_RIGHT, 'Richer child bezsx');
+  close(t, rich.bezsy, -0.3 * Math.sin(ROOT_ARCA) / RATIO_RIGHT, 'Richer child bezsy');
+  close(t, poor.bezsx, -0.3 * Math.cos(ROOT_ARCA) / RATIO_LEFT, 'Poorer child bezsx');
+  close(t, poor.bezsy, -0.3 * Math.sin(ROOT_ARCA) / RATIO_LEFT, 'Poorer child bezsy');
+
+  // The poorer child's second control point pulls its curve straight towards its end point
+  close(t, poor.bezc2x, 0.9 * poor.bezex, 'Poorer child bezc2x');
+  close(t, poor.bezc2y, 0.9 * poor.bezey, 'Poorer child bezc2y');
+
+  // Children aren't given a width, so fall back to the default
+  t.equal(rich.bezr, DEFAULT_BEZR, 'Richer child bezr');
+  t.equal(poor.bezr, DEFAULT_BEZR, 'Poorer child bezr');
+
+  // Both children are leaves
+  close(t, rich.arcr, LEAF_ARCR, 'Richer child arcr');
+  close(t, poor.arcr, LEAF_ARCR, 'Poorer child arcr');
+  close(t, rich.arcx, rich.bezex + 0.9 * Math.cos(rich.arca), 'Richer child arcx');
+  close(t, rich.arcy, rich.bezey + 0.9 * Math.sin(rich.arca), 'Richer child arcy');
+
+  t.end();
+});
+
+test('spiral_pre_calc:children_order', function (t) {
+  // The same 2 children, in either order
+  let root_a = mk_root([mk_leaf(0.3), mk_leaf(0.7)]);
+  let root_b = mk_root([mk_leaf(0.7), mk_leaf(0.3)]);
+
+  spiral_pre_calc.pre_calc(root_a);
+  spiral_pre_calc.pre_calc(root_b);
+
+  // Layout follows richness, not the order the children happen to be in
+  t.deepEqual(root_a.children[0], root_b.children[1], 'Poorer child laid out the same either way');
+  t.deepEqual(root_a.children[1], root_b.children[0], 'Richer child laid out the same either way');
+  t.deepEqual(root_a.nextr, root_b.nextr.slice().reverse(), 'nextr mirrored');
+  t.deepEqual(root_a.nextx, root_b.nextx.slice().reverse(), 'nextx mirrored');
+  t.deepEqual(root_a.nexty, root_b.nexty.slice().reverse(), 'nexty mirrored');
+
+  t.end();
+});
+
+test('spiral_pre_calc:children_equal_richness', function (t) {
+  let root = mk_root([mk_leaf(0.5), mk_leaf(0.5)]);
+  spiral_pre_calc.pre_calc(root);
+
+  // A tie goes to the first child
+  t.deepEqual(root.nextr, [RATIO_RIGHT, RATIO_LEFT], 'First child treated as the richer one');
+  close(t, root.children[0].arca, ROOT_ARCA + ANGLE_RIGHT, 'First child turns right');
+  close(t, root.children[1].arca, ROOT_ARCA - ANGLE_LEFT, 'Second child turns left');
+
+  t.end();
+});
+
+test('spiral_pre_calc:recursion', function (t) {
+  // Poorer child of the root is itself a node with 2 children
+  let branch = mk_node(0.3, [mk_leaf(0.1), mk_leaf(0.2)]);
+  let root = mk_root([branch, mk_leaf(0.7)]);
+  spiral_pre_calc.pre_calc(root);
+
+  // The branch is drawn as a joint, its children as leaves
+  close(t, branch.arcr, branch.bezr / 2, 'branch arcr');
+  close(t, branch.children[0].arcr, LEAF_ARCR, 'grandchild 0 arcr');
+  close(t, branch.children[1].arcr, LEAF_ARCR, 'grandchild 1 arcr');
+
+  // Grandchildren turn relative to the branch's angle, which is itself relative to the root's
+  close(t, branch.arca, ROOT_ARCA - ANGLE_LEFT, 'branch arca');
+  close(t, branch.children[1].arca, ROOT_ARCA - ANGLE_LEFT + ANGLE_RIGHT, 'Richer grandchild turns right');
+  close(t, branch.children[0].arca, ROOT_ARCA - ANGLE_LEFT - ANGLE_LEFT, 'Poorer grandchild turns left');
+
+  t.deepEqual(branch.nextr, [RATIO_LEFT, RATIO_RIGHT], 'branch nextr');
+  check_next_point(t, branch, 1, RATIO_RIGHT, 1, 'Richer grandchild');
+  check_next_point(t, branch, 0, RATIO_LEFT, -1, 'Poorer grandchild');
+
+  t.end();
+});
+
+function child_separation(node) {
+  return Math.sqrt(
+    Math.pow(node.nextx[1] - node.nextx[0], 2) + Math.pow(node.nexty[1] - node.nexty[0], 2),
+  );
+}
+
+test('spiral_pre_calc:existing_values_preserved', function (t) {
+  // A subtree node, already positioned by its parent, with a wider branch than the default
+  let node = mk_node(0.3, [mk_leaf(0.1), mk_leaf(0.2)]);
+  let default_width_node = mk_node(0.3, [mk_leaf(0.1), mk_leaf(0.2)]);
+  node.arca = 0;
+  default_width_node.arca = 0;
+  node.bezsx = 0.1;
+  node.bezsy = 0.2;
+  node.bezex = 0.3;
+  node.bezey = 0.4;
+  node.bezc1x = 0.5;
+  node.bezc1y = 0.6;
+  node.bezc2x = 0.7;
+  node.bezc2y = 0.8;
+  node.bezr = 1;
+
+  spiral_pre_calc.pre_calc(node);
+  spiral_pre_calc.pre_calc(default_width_node);
+
+  t.deepEqual([
+    node.bezsx, node.bezsy, node.bezex, node.bezey,
+    node.bezc1x, node.bezc1y, node.bezc2x, node.bezc2y, node.bezr,
+  ], [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 1], 'Bezier left as-is, not reset to the root defaults');
+  t.equal(default_width_node.bezr, DEFAULT_BEZR, 'Missing values filled in with the defaults');
+
+  // ...and the wider branch feeds through into where the children are placed
+  check_next_point(t, node, 1, RATIO_RIGHT, 1, 'Richer child');
+  check_next_point(t, node, 0, RATIO_LEFT, -1, 'Poorer child');
+  t.ok(
+    child_separation(node) > child_separation(default_width_node),
+    'A wider branch spaces its children further apart',
+  );
+
+  t.end();
+});

--- a/OZprivate/rawJS/OZTreeModule/tests/test_tour_Screensaver.js
+++ b/OZprivate/rawJS/OZTreeModule/tests/test_tour_Screensaver.js
@@ -234,9 +234,3 @@ test('screensaver.loop_back_forth', function (test) {
   })
 });
 
-
-test.onFinish(function() {
-  // NB: Something data_repo includes in is holding node open.
-  //     Can't find it so force our tests to end.
-  process.exit(0)
-});

--- a/OZprivate/rawJS/OZTreeModule/tests/test_tour_Tour.js
+++ b/OZprivate/rawJS/OZTreeModule/tests/test_tour_Tour.js
@@ -568,9 +568,3 @@ test('tour:goto_stop', function (test) {
   })
 });
 
-
-test.onFinish(function() {
-  // NB: Something data_repo includes in is holding node open.
-  //     Can't find it so force our tests to end.
-  process.exit(0)
-});

--- a/OZprivate/rawJS/OZTreeModule/tests/test_tour_handler_QsOpts.js
+++ b/OZprivate/rawJS/OZTreeModule/tests/test_tour_handler_QsOpts.js
@@ -166,9 +166,3 @@ test('handler_qsopts:event_ordering', function (test) {
   })
 });
 
-
-test.onFinish(function() {
-  // NB: Something data_repo includes in is holding node open.
-  //     Can't find it so force our tests to end.
-  process.exit(0)
-});

--- a/OZprivate/rawJS/OZTreeModule/tests/test_tour_handler_QsOpts.js
+++ b/OZprivate/rawJS/OZTreeModule/tests/test_tour_handler_QsOpts.js
@@ -4,6 +4,7 @@
 import handler_qsopts from '../src/tour/handler/QsOpts.js';
 import test from 'tape';
 
+import { setup_fake_window } from './util_dom';
 import { setup_tour } from './util_tourwrapper';
 
 function fake_tour() {
@@ -29,10 +30,11 @@ function fake_tour() {
 }
 
 function set_location_search(qs) {
-  global.window = { location: { search: qs } };
+  global.window.location = { search: qs };
 }
 
 test('handler_qsopts', function (test) {
+  setup_fake_window(test);
   var ft = fake_tour();
   handler_qsopts(ft).then(function () {
     // into_node gets ignored, we don't do anything

--- a/OZprivate/rawJS/OZTreeModule/tests/test_tree_state.js
+++ b/OZprivate/rawJS/OZTreeModule/tests/test_tree_state.js
@@ -68,9 +68,3 @@ test('focal_area', function (test) {
   test.end();
 });
 
-
-test.onFinish(function() {
-  // NB: Something data_repo includes in is holding node open.
-  //     Can't find it so force our tests to end.
-  process.exit(0)
-});

--- a/OZprivate/rawJS/OZTreeModule/tests/test_tree_state.js
+++ b/OZprivate/rawJS/OZTreeModule/tests/test_tree_state.js
@@ -26,6 +26,8 @@ function test_focal_area(test, expected, message) {
 test('focal_area', function (test) {
   // NB: setup_canvas fires window_size_change hooks, which may read (window)
   setup_dom(test);
+  // tree_state is a module-level singleton, so put the constraint back as we found it
+  test.teardown(function () { tree_state.constrain_focal_area(1, 1) });
 
   tree_state.setup_canvas({ width: 2000, height: 1000 }, 2000, 1000);
   test_focal_area(test, {

--- a/OZprivate/rawJS/OZTreeModule/tests/test_tree_state.js
+++ b/OZprivate/rawJS/OZTreeModule/tests/test_tree_state.js
@@ -4,6 +4,7 @@
 import { populate_factory } from './util_factory'
 import test from 'tape';
 
+import { setup_dom } from './util_dom';
 import tree_state from '../src/tree_state.js'
 
 function test_focal_area(test, expected, message) {
@@ -23,6 +24,9 @@ function test_focal_area(test, expected, message) {
 }
 
 test('focal_area', function (test) {
+  // NB: setup_canvas fires window_size_change hooks, which may read (window)
+  setup_dom(test);
+
   tree_state.setup_canvas({ width: 2000, height: 1000 }, 2000, 1000);
   test_focal_area(test, {
     xmin: 2000 * 0.025,

--- a/OZprivate/rawJS/OZTreeModule/tests/test_ui_tours_list.js
+++ b/OZprivate/rawJS/OZTreeModule/tests/test_ui_tours_list.js
@@ -3,15 +3,15 @@
   */
 import test from 'tape';
 
+import { setup_dom } from './util_dom';
 import { teaseTour } from '../src/ui/tours_list.js';
 
 test('teaseTour', function (test) {
-  var out;
-  global.window = { fakeLs: {} };
+  setup_dom(test);
 
   function tt (tourIds, progress) {
     Object.keys(progress || {}).forEach((k) => {
-      global.window.fakeLs['ts-progress-' + k] = progress[k];
+      global.localStorage.setItem('ts-progress-' + k, JSON.stringify(progress[k]));
     });
     const out = teaseTour(tourIds.map((id) => ({ identifier: id })));
     return out ? out['identifier'] : out;

--- a/OZprivate/rawJS/OZTreeModule/tests/util_data_store.js
+++ b/OZprivate/rawJS/OZTreeModule/tests/util_data_store.js
@@ -1,12 +1,12 @@
 import fakeFetch from './util_fake_fetch';
+import { setup_fake_window } from './util_dom';
 import dataStoreAPI from '../src/data_store/api.js';
 
 /**
  * Return the DataStoreAPI, ensuring environment can do fake fetches
  */
 export function getDataStoreAPI(test, injectClasses = []) {
-  if (!global.window) global.window = { setTimeout: setTimeout };
-  if (!global.window.fetch) window.fetch = fakeFetch();
+  setup_fake_window(test, { setTimeout: setTimeout, fetch: fakeFetch() });
 
   injectClasses.forEach((cls) => {
     dataStoreAPI.inject(cls);

--- a/OZprivate/rawJS/OZTreeModule/tests/util_dom.js
+++ b/OZprivate/rawJS/OZTreeModule/tests/util_dom.js
@@ -1,0 +1,43 @@
+var jsdom = require('jsdom');
+const { JSDOM } = jsdom;
+
+/**
+ * Give (test) its own window/document/localStorage globals, torn down at the end
+ * of the test so nothing is inherited by whatever runs next.
+ *
+ * Returns the JSDOM instance, for tests that need e.g. dom.window.MutationObserver.
+ */
+export function setup_dom(test, html = '<html><body></body></html>') {
+  const dom = new JSDOM(html, {
+    // NB: An origin is required for (window.localStorage) to be available
+    url: 'https://www.onezoom.org/',
+  });
+
+  global.window = dom.window;
+  global.document = dom.window.document;
+  global.localStorage = dom.window.localStorage;
+
+  test.teardown(function () {
+    dom.window.close();
+    // NB: A closed window throws on access, so don't leave it lying around
+    delete global.window;
+    delete global.document;
+    delete global.localStorage;
+  });
+
+  return dom;
+}
+
+/**
+ * Give (test) a bare (window) global with (props), for tests that want to fake
+ * parts of the window without needing a DOM. Removed again at the end of the test.
+ */
+export function setup_fake_window(test, props = {}) {
+  global.window = { ...props };
+
+  test.teardown(function () {
+    delete global.window;
+  });
+
+  return global.window;
+}

--- a/OZprivate/rawJS/OZTreeModule/tests/util_tourwrapper.js
+++ b/OZprivate/rawJS/OZTreeModule/tests/util_tourwrapper.js
@@ -1,6 +1,4 @@
-var jsdom = require('jsdom');
-const { JSDOM } = jsdom;
-
+import { setup_dom } from './util_dom';
 import { UserInterruptError } from '../src/errors';
 import config from '../src/global_config';
 
@@ -25,20 +23,29 @@ export function setup_tour(test, s, interaction = null, verbose_test = false) {
           log.push([n, ...arguments]);
       }
   }
-  let dom = new JSDOM(`
+  // NB: Registered before setup_dom's teardown, since tape runs teardowns in the
+  //     order they were added and this still needs the window to be around
+  test.teardown(function () {
+    // TourStop.exit() doesn't cancel its wait timer, so do it here. Otherwise a
+    // timer outlives the test and explodes once the window has gone away.
+    tour.tourstop_array.forEach((ts) => clearTimeout(ts.goto_next_timer));
+    state_observer.disconnect();
+
+    delete global.alert;
+    delete global.$;
+  });
+
+  let dom = setup_dom(test, `
 <html>
   <body>
     <div id="tour_wrapper">
     </div>
   </body>
 </html>`);
-  test.teardown(function () { dom.window.close() });
 
   verbose_test = verbose_test || process.env.TOUR_DEBUG;
-  global.window = dom.window;
   global.window.is_testing = verbose_test;
   global.window.tour_trace = verbose_test;
-  global.document = dom.window.document;
   global.alert = callback_to_log('alert');
   global.$ = require('../../../../static/js/jquery.js');
   global.window.jQuery = global.$;


### PR DESCRIPTION
A bunch of stuff that came up whilst looking at #1013 

* Tidy up test suite: Fix leaky tests, clear timers that cause tests to hang
* Remove ObjectPools for midnodes: Given our garbage collector was broken, they weren't doing anything, simplify and just create them as we need them.
* Fix the garbage collection for midnodes: It's not been working for a while, so we could just remove it, but seems like a dangerous way to live
* Tidy up the existing spiral_pre_calc, mostly so I can understand what it does