### PR TITLE
Issue 1013 prerequisite fixes (take 2)

### DIFF
--- a/OZprivate/rawJS/OZTreeModule/src/data_store/api.js
+++ b/OZprivate/rawJS/OZTreeModule/src/data_store/api.js
@@ -1,4 +1,5 @@
 import api_manager from '../api/api_manager';
+import { DataStoreNotReadyError } from '../errors';
 
 /**
  * Abstract interface a set of raw array data files
@@ -28,6 +29,7 @@ class DataStoreAPI {
     this._fails = {};
     this._batchSize = 5;  // How many we fetch in one go
     this._maxFails = 5;  // How many times we retry before start unleashing the error upstream
+    this._drainResolves = [];  // resolve() of every promise awaitQueue() is holding open
   }
 
   /**
@@ -67,6 +69,27 @@ class DataStoreAPI {
     this._startTimer(this._notifyTimeoutMs);
   }
 
+
+  /**
+   * Call fn(), if it throws DataStoreNotReadyError (triggered by get_or_fail)
+   * then wait for queues to empty and retry
+   */
+  retryWhenDataStoreReady(fn) {
+    try {
+      fn();
+    } catch (e) {
+      if (!(e instanceof DataStoreNotReadyError)) return Promise.reject(e);
+
+      // Nothing queued and nothing in flight, so nothing to wait for
+      if (!this._timer && Object.keys(this._queue).length === 0) return Promise.resolve();
+
+      return (new Promise((resolve) => this._drainResolves.push(resolve))).then(() => {
+        return this.retryWhenDataStoreReady(fn);
+      });
+    }
+    return Promise.resolve();
+  }
+
   // Start a timer if there isn't already one going
   _startTimer(timeout) {
     // Already waiting, don't bother
@@ -98,7 +121,15 @@ class DataStoreAPI {
         // Now we're done, let another timer start
         this._timer = undefined;
         // If there's more waiting (either added since we started, or over batchSize), go again
-        if (Object.keys(this._queue).length > 0) this._startTimer(this._subsequentTimeoutMs);
+        if (Object.keys(this._queue).length > 0) {
+          this._startTimer(this._subsequentTimeoutMs);
+        } else {
+          // Queue empty, wake anything waiting on it (see awaitQueue). Take the list first:
+          // a resolved promise may well queue up more work, and that has its own wait
+          const drainResolves = this._drainResolves;
+          this._drainResolves = [];
+          drainResolves.forEach((resolve) => resolve());
+        }
       });
     }, timeout);
   }

--- a/OZprivate/rawJS/OZTreeModule/src/data_store/data_store.js
+++ b/OZprivate/rawJS/OZTreeModule/src/data_store/data_store.js
@@ -63,6 +63,8 @@
  *       }
  *     }
  */
+import { DataStoreNotReadyError } from '../errors';
+
 export default class DataStore {
   name = "changeme";  /** The name this DataStore will be added to DataStoreAPI as */
 
@@ -119,6 +121,20 @@ export default class DataStore {
     }
     const out = view[this.nodeToId(node)];
     return out === undefined ? missingValue : out;
+  }
+
+  /**
+   * As get, but throws DataStoreNotReadyError if we need to request a slice
+   *
+   * NB: An undefined from get() can only mean a missing slice: the missingValue/missingSlice
+   * defaults mean there's no way to ask it to return undefined for anything else
+   */
+  get_or_fail(node, missingValue = null, missingSlice = missingValue) {
+    const out = this.get(node, missingValue, missingSlice);
+    if (out === undefined) {
+      throw new DataStoreNotReadyError(`${this.name} not yet available for node ${node.toString()}`);
+    }
+    return out;
   }
 
   /**

--- a/OZprivate/rawJS/OZTreeModule/src/errors.js
+++ b/OZprivate/rawJS/OZTreeModule/src/errors.js
@@ -5,3 +5,10 @@ export class UserInterruptError extends Error {
   }
 }
 
+/** Signals we're still waiting for a data_store to load */
+export class DataStoreNotReadyError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "DataStoreNotReadyError";
+  }
+}

--- a/OZprivate/rawJS/OZTreeModule/src/factory/garbage_collection.js
+++ b/OZprivate/rawJS/OZTreeModule/src/factory/garbage_collection.js
@@ -8,6 +8,8 @@ import {add_hook} from '../util/index';
 function init() {
   //Each time after canvas refresh, call reset_timer_after_draw_gc.
   add_hook("after_draw", clear_garbage);
+  // ...and once a flight has landed, since we skip collecting during one (see below)
+  add_hook("flying_finish", clear_garbage);
 }
 
 
@@ -15,8 +17,19 @@ function init() {
  * Execute garbage collection. Restart next garbage collection at the end of the function.
  */
 function clear_garbage() {
+  // Don't collect mid-flight. A flight develops every branch it will need up-front, in
+  // develop_branch_to_and_target(), but only targets one leg of the flight at a time---so
+  // whatever the later legs need looks like garbage while an earlier leg is in the air, and
+  // gets destroyed. The next leg then has nothing to target, and position_helper's
+  // get_xyr_target() flies to wherever the previous leg was aiming instead.
+  // Nothing is developed during a flight either (see renderer:reanchor_and_dynamic_load_tree),
+  // so there is nothing here for us to keep pace with until it lands.
+  if (tree_state.flying) return;
+
   let factory = get_factory();
-  find_unused_node_and_clear(factory.root, 0, 0);  
+  // flying_finish can fire before there is a tree to collect, e.g. cancel_flight() on resize
+  if (!factory.root) return;
+  find_unused_node_and_clear(factory.root, 0, 0);
 }
 
 

--- a/OZprivate/rawJS/OZTreeModule/src/tree_settings.js
+++ b/OZprivate/rawJS/OZTreeModule/src/tree_settings.js
@@ -38,6 +38,8 @@ import Polytomy2BranchLayout from './projection/layout/polytomy2/branch_layout';
 
 import * as themes from './themes'
 import config from './global_config';
+import data_store_api from './data_store/api';
+import { DataStoreNotReadyError } from './errors';
 
 export let pic_src_order;
 
@@ -274,15 +276,24 @@ class TreeSettings {
       }
 
       let next_tree = is_binary_viewtype(curr) ? controller.binary_tree : controller.polytomy_tree;
+      controller.stop_refresh_loop();
+      controller.draw_loading();
       if (next_tree) {
+        // The tree is re-usable, but the layout hung off it isn't: the new view places
+        // branches its own way, and any data it does that from may have been dropped along
+        // with the old view's (see controller_navigation:change_view_type). So lay the whole
+        // thing out again before handing it back, rather than leaving the first thing to ask
+        // for a position to trip over a half-calculated tree
         controller.factory.root = next_tree;
-        resolve();
+        resolve(data_store_api.retryWhenDataStoreReady(function () {
+          controller.dynamic_load_and_calc(controller.root.ozid);
+          controller.re_calc();
+        }));
       } else {
-        controller.stop_refresh_loop();
-        controller.draw_loading();
         setTimeout(function () {
-          controller.rebuild_tree();
-          resolve();
+          resolve(data_store_api.retryWhenDataStoreReady(function () {
+            controller.rebuild_tree();
+          }));
         }, 10);
       }
     }.bind(this));

--- a/OZprivate/rawJS/OZTreeModule/tests/test_data_store.js
+++ b/OZprivate/rawJS/OZTreeModule/tests/test_data_store.js
@@ -4,6 +4,7 @@
 import test from 'tape';
 var jsdom = require('jsdom');
 import DataStore from '../src/data_store/data_store';
+import { DataStoreNotReadyError } from '../src/errors';
 import { getDataStoreAPI } from './util_data_store';
 
 test('data_store:null', function (test) {
@@ -87,6 +88,127 @@ test('data_store:json', function (test) {
       window.fetch.resolve_json(reqIds[1], {"v": "victoria sponge", "c": "chocolate"});
       return new Promise((resolve) => setTimeout(resolve, 10));  // NB: Let fetch promises settle
     });
+  });
+});
+
+test('data_store:get_or_fail', function (test) {
+  class DataStoreUt extends DataStore {
+    name = "ut_gof";
+
+    nodeToId(node) { return node.id; }
+    sliceNameFor(node) { return node.slice ? `gof_${node.slice}.json` : null; }
+    dataView(response) { return response.json(); }
+  };
+  const ds = getDataStoreAPI(test, [DataStoreUt]).ut_gof;
+  // NB: A toString() so we can check what the error message says about the node
+  const node = (slice, id) => ({ slice: slice, id: id, toString: () => `${slice}:${id}` });
+
+  return Promise.resolve().then(() => {
+    // No slice for the node at all: nothing to wait for, so no point failing
+    test.deepEqual(ds.get_or_fail(node(null, 0)), null, "No slice for node --> missingSlice (null by default)");
+    test.deepEqual(ds.get_or_fail(node(null, 0), 88, 99), 99, "No slice for node --> missingSlice");
+    test.deepEqual(ds.get_or_fail(node(null, 0), 44), 44, "No slice for node --> missingSlice falls back to missingValue");
+
+    // Slice not fetched yet: fail, regardless of what the missing* values say
+    test.throws(
+      () => ds.get_or_fail(node('apple_pie', 0)),
+      DataStoreNotReadyError,
+      "Slice not available --> throws DataStoreNotReadyError");
+    test.throws(
+      () => ds.get_or_fail(node('apple_pie', 0), 88, 99),
+      DataStoreNotReadyError,
+      "Slice not available --> throws, missingValue/missingSlice don't apply");
+    try {
+      ds.get_or_fail(node('apple_pie', 4));
+      test.fail("Should have thrown");
+    } catch (e) {
+      test.deepEqual(e instanceof DataStoreNotReadyError, true, "Threw a DataStoreNotReadyError");
+      test.deepEqual(e instanceof Error, true, "...which is also an Error");
+      test.deepEqual(e.name, "DataStoreNotReadyError", "...named after its class");
+      test.deepEqual(e.message, "ut_gof not yet available for node apple_pie:4", "...naming the data store & node");
+    }
+
+    // ...but, as with get(), the missing slice got queued up for fetching
+    return global.window.fetch.waitFor("/static/gof_apple_pie_12345.json").then((reqId) => {
+      window.fetch.resolve_json(reqId, ["a", "b", "c"]);
+      return new Promise((resolve) => setTimeout(resolve, 10));  // NB: Let fetch promises settle
+    });
+  }).then(() => {
+    test.deepEqual(ds.get_or_fail(node('apple_pie', 0)), "a", "Slice now available (0)");
+    test.deepEqual(ds.get_or_fail(node('apple_pie', 1)), "b", "Slice now available (1)");
+
+    // Slice is here, a node with no value in it isn't something waiting will fix
+    test.deepEqual(ds.get_or_fail(node('apple_pie', 5)), null, "Slice available, no value for node --> missingValue (null by default)");
+    test.deepEqual(ds.get_or_fail(node('apple_pie', 5), 88), 88, "Slice available, no value for node --> missingValue");
+    test.deepEqual(ds.get_or_fail(node('apple_pie', 5), 88, 99), 88, "Slice available, no value for node --> missingValue, not missingSlice");
+
+    // A different slice is still missing though
+    test.throws(
+      () => ds.get_or_fail(node('pizza', 0)),
+      DataStoreNotReadyError,
+      "Other slice not available --> throws");
+
+    return global.window.fetch.waitFor("/static/gof_pizza_12345.json").then((reqId) => {
+      window.fetch.resolve_json(reqId, ["pepperoni"]);
+      return new Promise((resolve) => setTimeout(resolve, 10));  // NB: Let fetch promises settle
+    });
+  }).then(() => {
+    test.deepEqual(ds.get_or_fail(node('pizza', 0)), "pepperoni", "Pizza now available");
+
+    ds.clear();
+    test.throws(
+      () => ds.get_or_fail(node('apple_pie', 0)),
+      DataStoreNotReadyError,
+      "Throwing again after clear()");
+
+    return global.window.fetch.waitFor("/static/gof_apple_pie_12345.json").then((reqId) => {
+      window.fetch.resolve_json(reqId, ["a", "b", "c"]);
+      return new Promise((resolve) => setTimeout(resolve, 10));  // NB: Let fetch promises settle
+    });
+  }).then(() => {
+    test.deepEqual(ds.get_or_fail(node('apple_pie', 0)), "a", "Apple pie available once more");
+
+    return global.window.fetch.waitingWithTimeout().then((w) => test.deepEqual(w, {}, "No requests left in queue"));
+  });
+});
+
+test('data_store:get_or_fail_subclass', function (test) {
+  class DataStoreUt extends DataStore {
+    name = "ut_gof_sub";
+
+    nodeToId(node) { return node.id; }
+    sliceNameFor(node) { return `gofsub_${node.slice}.json`; }
+    dataView(response) { return response.json(); }
+
+    // A get() wrapper picking its own missing values, as ds_weighted_mean does
+    get(node) {
+      this.get_calls = (this.get_calls || 0) + 1;
+      return super.get(node, 'no-value', 'no-slice');
+    }
+  };
+  const ds = getDataStoreAPI(test, [DataStoreUt]).ut_gof_sub;
+
+  return Promise.resolve().then(() => {
+    test.throws(
+      () => ds.get_or_fail({ slice: 'apple_pie', id: 0 }),
+      DataStoreNotReadyError,
+      "Slice not available --> still throws through the get() wrapper");
+
+    return global.window.fetch.waitFor("/static/gofsub_apple_pie_12345.json").then((reqId) => {
+      window.fetch.resolve_json(reqId, ["a", "b", "c"]);
+      return new Promise((resolve) => setTimeout(resolve, 10));  // NB: Let fetch promises settle
+    });
+  }).then(() => {
+    ds.get_calls = 0;
+
+    // NB: get_or_fail() goes via get(), so a subclass wrapping get() gets the same treatment
+    // for free --- which is what ds_weighted_mean relies on
+    test.deepEqual(ds.get_or_fail({ slice: 'apple_pie', id: 0 }), "a", "get_or_fail() returns values as normal");
+    test.deepEqual(ds.get_or_fail({ slice: 'apple_pie', id: 5 }), 'no-value', "get_or_fail() picks up the get() wrapper's missingValue");
+    test.deepEqual(ds.get_or_fail({ slice: 'apple_pie', id: 5 }, 88), 'no-value', "...even when the caller asks for something else, since the wrapper drops it");
+    test.deepEqual(ds.get_calls, 3, "All of the above went via get()");
+
+    return global.window.fetch.waitingWithTimeout().then((w) => test.deepEqual(w, {}, "No requests left in queue"));
   });
 });
 

--- a/OZprivate/rawJS/OZTreeModule/tests/test_data_store_api.js
+++ b/OZprivate/rawJS/OZTreeModule/tests/test_data_store_api.js
@@ -1,0 +1,169 @@
+/**
+  * Usage: npx babel-tape-runner OZprivate/rawJS/OZTreeModule/tests/test_data_store_api.js
+  */
+import test from 'tape';
+var jsdom = require('jsdom');
+import DataStore from '../src/data_store/data_store';
+import { DataStoreNotReadyError } from '../src/errors';
+import { getDataStoreAPI } from './util_data_store';
+
+/** A DataStore with a slice per (node.slice), for the tests below to starve of data */
+class DataStoreUt extends DataStore {
+  name = "ut_retry";
+
+  nodeToId(node) { return node.id; }
+  sliceNameFor(node) { return `retry_${node.slice}.json`; }
+  dataView(response) { return response.json(); }
+};
+
+/** NB: Let fetch promises settle, so a resolved request is out of the fake fetch's list */
+function settle() {
+  return new Promise((resolve) => setTimeout(resolve, 10));
+}
+
+test('data_store_api:retryWhenDataStoreReady:no_fail', function (test) {
+  const dsApi = getDataStoreAPI(test);
+  let fnCalls = 0;
+
+  return dsApi.retryWhenDataStoreReady(() => { fnCalls++; }).then((out) => {
+    test.deepEqual(fnCalls, 1, "Called fn once");
+    test.deepEqual(out, undefined, "Resolved with nothing (fn's return value is ignored)");
+  }).then(() => {
+    return global.window.fetch.waitingWithTimeout().then((w) => test.deepEqual(w, {}, "Nothing fetched"));
+  });
+});
+
+test('data_store_api:retryWhenDataStoreReady:other_error', function (test) {
+  const dsApi = getDataStoreAPI(test);
+  let fnCalls = 0;
+
+  // Anything that isn't a DataStoreNotReadyError isn't ours to swallow
+  return dsApi.retryWhenDataStoreReady(() => {
+    fnCalls++;
+    throw new Error("Grunty pig");
+  }).then(() => {
+    test.fail("Should have rejected");
+  }, (e) => {
+    test.deepEqual(e.message, "Grunty pig", "Rejected with fn's error");
+    test.deepEqual(fnCalls, 1, "Didn't retry fn");
+  }).then(() => {
+    return global.window.fetch.waitingWithTimeout().then((w) => test.deepEqual(w, {}, "Nothing fetched"));
+  });
+});
+
+test('data_store_api:retryWhenDataStoreReady:nothing_queued', function (test) {
+  const dsApi = getDataStoreAPI(test);
+  let fnCalls = 0;
+
+  test.deepEqual(Object.keys(dsApi._queue), [], "Precondition: nothing queued");
+
+  // fn is unhappy, but nothing is queued or in-flight so waiting won't fix it. Give up
+  // rather than spin forever
+  return dsApi.retryWhenDataStoreReady(() => {
+    fnCalls++;
+    throw new DataStoreNotReadyError("I want data that nobody is fetching");
+  }).then(() => {
+    test.deepEqual(fnCalls, 1, "Gave up rather than retrying fn");
+  }, (e) => {
+    test.fail("Should have resolved, got " + e);
+  }).then(() => {
+    return global.window.fetch.waitingWithTimeout().then((w) => test.deepEqual(w, {}, "Nothing fetched"));
+  });
+});
+
+test('data_store_api:retryWhenDataStoreReady:waits_for_slices', function (test) {
+  const dsApi = getDataStoreAPI(test, [DataStoreUt]);
+  const ds = dsApi.ut_retry;
+  let fnCalls = 0, out = null;
+
+  // Needs 2 slices, and only asks for the second once it has the first, so 3 goes in total
+  const fn = () => {
+    fnCalls++;
+    out = [
+      ds.get_or_fail({ slice: 'apple_pie', id: 0 }),
+      ds.get_or_fail({ slice: 'pizza', id: 0 }),
+    ];
+  };
+
+  const p = dsApi.retryWhenDataStoreReady(fn);
+  test.deepEqual(fnCalls, 1, "fn called synchronously, before we start waiting");
+
+  return global.window.fetch.waitFor("/static/retry_apple_pie_12345.json").then((reqId) => {
+    test.deepEqual(fnCalls, 1, "Still waiting on apple_pie, not spinning on fn");
+    window.fetch.resolve_json(reqId, ["a", "b"]);
+
+    // NB: Only requested once the apple_pie retry got far enough to ask for it
+    return global.window.fetch.waitFor("/static/retry_pizza_12345.json");
+  }).then((reqId) => {
+    test.deepEqual(fnCalls, 2, "Queue drained --> retried fn, which got as far as pizza");
+    window.fetch.resolve_json(reqId, ["pepperoni"]);
+    return p;
+  }).then(() => {
+    test.deepEqual(fnCalls, 3, "Retried fn once more, which made it to the end");
+    test.deepEqual(out, ["a", "pepperoni"], "Final call to fn saw both slices");
+  }).then(() => {
+    return global.window.fetch.waitingWithTimeout().then((w) => test.deepEqual(w, {}, "No requests left in queue"));
+  });
+});
+
+test('data_store_api:retryWhenDataStoreReady:concurrent', function (test) {
+  const dsApi = getDataStoreAPI(test, [DataStoreUt]);
+  const ds = dsApi.ut_retry;
+  const fnCalls = { cake: 0, trifle: 0 };
+
+  const fn = (sliceName) => () => {
+    fnCalls[sliceName]++;
+    ds.get_or_fail({ slice: sliceName, id: 0 });
+  };
+
+  // 2 separate callers, both left waiting on the same drain
+  const ps = Promise.all([
+    dsApi.retryWhenDataStoreReady(fn('cake')),
+    dsApi.retryWhenDataStoreReady(fn('trifle')),
+  ]);
+  test.deepEqual(fnCalls, { cake: 1, trifle: 1 }, "Both fns called, both waiting");
+
+  return Promise.all([
+    global.window.fetch.waitFor("/static/retry_cake_12345.json"),
+    global.window.fetch.waitFor("/static/retry_trifle_12345.json"),
+  ]).then((reqIds) => {
+    // NB: Both slices batched into the same round of fetching
+    window.fetch.resolve_json(reqIds[0], ["victoria sponge"]);
+    window.fetch.resolve_json(reqIds[1], ["sherry"]);
+    return ps;
+  }).then(() => {
+    test.deepEqual(fnCalls, { cake: 2, trifle: 2 }, "Both waiters woken up & retried once");
+  }).then(() => {
+    return global.window.fetch.waitingWithTimeout().then((w) => test.deepEqual(w, {}, "No requests left in queue"));
+  });
+});
+
+test('data_store_api:retryWhenDataStoreReady:fetch_failure', function (test) {
+  const dsApi = getDataStoreAPI(test, [DataStoreUt]);
+  const ds = dsApi.ut_retry;
+  let fnCalls = 0, out = null;
+
+  const fn = () => {
+    fnCalls++;
+    out = ds.get_or_fail({ slice: 'kedgeree', id: 0 });
+  };
+
+  const p = dsApi.retryWhenDataStoreReady(fn);
+
+  return global.window.fetch.waitFor("/static/retry_kedgeree_12345.json").then((reqId) => {
+    // A failed fetch still empties the queue, so we get woken up rather than hanging forever
+    window.fetch.resolve_servfail(reqId);
+    return settle();
+  }).then(() => {
+    return global.window.fetch.waitFor("/static/retry_kedgeree_12345.json");
+  }).then((reqId) => {
+    test.deepEqual(fnCalls, 2, "Woken up after the failure, retried fn & asked for the slice again");
+    window.fetch.resolve_json(reqId, ["smoked haddock"]);
+    return p;
+  }).then(() => {
+    test.deepEqual(fnCalls, 3, "Retried fn once the slice finally turned up");
+    test.deepEqual(out, "smoked haddock", "Final call to fn got its value");
+  }).then(() => {
+    return global.window.fetch.waitingWithTimeout().then((w) => test.deepEqual(w, {}, "No requests left in queue"));
+  });
+});

--- a/OZprivate/rawJS/OZTreeModule/tests/test_factory_garbage_collection.js
+++ b/OZprivate/rawJS/OZTreeModule/tests/test_factory_garbage_collection.js
@@ -25,6 +25,15 @@ function with_gc_config(test, detach_level, generations) {
 }
 
 /**
+  * Remove every hook init() registers, so a leftover one doesn't collect the
+  * tree out from under a later test file
+  */
+function remove_gc_hooks() {
+  remove_hook('after_draw');
+  remove_hook('flying_finish');
+}
+
+/**
   * Return a fresh tree with (depth) generations of children developed, and
   * nothing else (build_tree() develops no children of its own)
   */
@@ -58,7 +67,7 @@ function max_depth(node) {
 test('init: Adds an after_draw hook that collects garbage', function (test) {
   return populate_factory().then((factory) => {
     with_gc_config(test, 1, 1);
-    test.teardown(() => remove_hook('after_draw'));
+    test.teardown(remove_gc_hooks);
     let root = fresh_tree(factory, 4);
 
     // Before init() the after_draw hook does nothing
@@ -82,7 +91,7 @@ test('init: Adds an after_draw hook that collects garbage', function (test) {
 test('clear_garbage: Collects generations beyond the configured levels', function (test) {
   return populate_factory().then((factory) => {
     with_gc_config(test, 2, 2);
-    test.teardown(() => remove_hook('after_draw'));
+    test.teardown(remove_gc_hooks);
     gc_init();
     let root = fresh_tree(factory, 4);
 
@@ -109,7 +118,7 @@ test('clear_garbage: Collects generations beyond the configured levels', functio
 test('clear_garbage: Keeps the greater of detach_level / generation_on_subbranch_during_fly', function (test) {
   return populate_factory().then((factory) => {
     with_gc_config(test, 1, 3);
-    test.teardown(() => remove_hook('after_draw'));
+    test.teardown(remove_gc_hooks);
     gc_init();
 
     // Both conditions have to be met to collect, so the larger config option wins
@@ -135,7 +144,7 @@ test('clear_garbage: Keeps the greater of detach_level / generation_on_subbranch
 test('clear_garbage: Undevelops the whole node, leaving it for develop_children() to rebuild', function (test) {
   return populate_factory().then((factory) => {
     with_gc_config(test, 1, 1);
-    test.teardown(() => remove_hook('after_draw'));
+    test.teardown(remove_gc_hooks);
     gc_init();
     let root = fresh_tree(factory, 4);
 
@@ -169,7 +178,7 @@ test('clear_garbage: Undevelops the whole node, leaving it for develop_children(
 test('clear_garbage: A dvar or targeted node protects the generation below it', function (test) {
   return populate_factory().then((factory) => {
     with_gc_config(test, 1, 1);
-    test.teardown(() => remove_hook('after_draw'));
+    test.teardown(remove_gc_hooks);
     gc_init();
 
     // Without anything drawn only the 1st generation survives (see above), but being
@@ -214,7 +223,7 @@ test('clear_garbage: A dvar or targeted node protects the generation below it', 
 test('clear_garbage: Collects out-of-reach nodes below a dvar node', function (test) {
   return populate_factory().then((factory) => {
     with_gc_config(test, 2, 2);
-    test.teardown(() => remove_hook('after_draw'));
+    test.teardown(remove_gc_hooks);
     gc_init();
     let root = fresh_tree(factory, 4);
 
@@ -242,7 +251,7 @@ test('clear_garbage: Collects out-of-reach nodes below a dvar node', function (t
 test('clear_garbage: Walks into subtrees collected by a previous pass', function (test) {
   return populate_factory().then((factory) => {
     with_gc_config(test, 3, 3);
-    test.teardown(() => remove_hook('after_draw'));
+    test.teardown(remove_gc_hooks);
     gc_init();
     let root = fresh_tree(factory, 4);
 

--- a/OZprivate/rawJS/OZTreeModule/tests/test_tree_settings.js
+++ b/OZprivate/rawJS/OZTreeModule/tests/test_tree_settings.js
@@ -1,0 +1,138 @@
+/**
+  * Usage: npx babel-tape-runner OZprivate/rawJS/OZTreeModule/tests/test_tree_settings.js
+  */
+import test from 'tape';
+var jsdom = require('jsdom');
+import DataStore from '../src/data_store/data_store';
+import tree_settings from '../src/tree_settings';
+import { getDataStoreAPI } from './util_data_store';
+
+/**
+ * NB: Every viewtype used below is a binary one, so rebuild_tree() never crosses the
+ * polytomy boundary. That's deliberate: crossing it calls set_layout()/set_factory_midnode(),
+ * which reconfigure the layout globally and would leak into every test that runs after us
+ */
+
+class DataStoreUt extends DataStore {
+  name = "ut_treesettings";
+
+  nodeToId(node) { return node.id; }
+  sliceNameFor(node) { return `treesettings_${node.slice}.json`; }
+  dataView(response) { return response.json(); }
+};
+
+/**
+ * A stand-in for the handful of controller methods rebuild_tree() pokes, logging the order
+ * it pokes them in. The 2 that lay out a tree ask (ds) for data first, as the real ones
+ * would via the pre-calculator, and thus throw DataStoreNotReadyError until it turns up
+ */
+function fake_controller(ds, root) {
+  const calls = [];
+
+  return {
+    calls: calls,
+    root: { ozid: 91 },
+    factory: { root: root },
+    binary_tree: null,
+    polytomy_tree: null,
+
+    stop_refresh_loop: () => calls.push('stop_refresh_loop'),
+    draw_loading: () => calls.push('draw_loading'),
+    re_calc: () => calls.push('re_calc'),
+    dynamic_load_and_calc: function (ozid) {
+      calls.push('dynamic_load_and_calc:' + ozid);
+      ds.get_or_fail({ slice: 'layout', id: 0 });
+    },
+    rebuild_tree: function () {
+      calls.push('rebuild_tree');
+      ds.get_or_fail({ slice: 'layout', id: 0 });
+    },
+  };
+}
+
+test('tree_settings:rebuild_tree:existing_tree', function (test) {
+  const ds = getDataStoreAPI(test, [DataStoreUt]).ut_treesettings;
+  const existing_tree = { ozid: 91, iam: "an already-built binary tree" };
+  const controller = fake_controller(ds, existing_tree);
+  let resolved = false;
+
+  const p = tree_settings.rebuild_tree('spiral', 'natural', controller).then(() => { resolved = true });
+
+  test.deepEqual(controller.factory.root, existing_tree, "Existing tree handed back to the factory");
+  test.deepEqual(controller.calls, [
+    'stop_refresh_loop',
+    'draw_loading',
+    'dynamic_load_and_calc:91',
+  ], "Stopped drawing the old tree, then had a first go at laying the tree out");
+
+  return global.window.fetch.waitFor("/static/treesettings_layout_12345.json").then((reqId) => {
+    test.deepEqual(resolved, false, "Not resolved yet: the layout is still missing its data");
+    test.deepEqual(controller.calls.indexOf('re_calc'), -1, "...and didn't get as far as re_calc()");
+
+    window.fetch.resolve_json(reqId, ["a", "b"]);
+    return p;
+  }).then(() => {
+    test.deepEqual(controller.calls, [
+      'stop_refresh_loop',
+      'draw_loading',
+      'dynamic_load_and_calc:91',
+      'dynamic_load_and_calc:91',
+      're_calc',
+    ], "Laid the whole tree out again once the data arrived, and only then resolved");
+  }).then(() => {
+    return global.window.fetch.waitingWithTimeout().then((w) => test.deepEqual(w, {}, "No requests left in queue"));
+  });
+});
+
+test('tree_settings:rebuild_tree:no_existing_tree', function (test) {
+  const ds = getDataStoreAPI(test, [DataStoreUt]).ut_treesettings;
+  const controller = fake_controller(ds, null);
+  let resolved = false;
+
+  const p = tree_settings.rebuild_tree('spiral', 'natural', controller).then(() => { resolved = true });
+
+  test.deepEqual(controller.calls, [
+    'stop_refresh_loop',
+    'draw_loading',
+  ], "Nothing to re-use, so drawing stopped & rebuild deferred to give loading a chance to paint");
+
+  return global.window.fetch.waitFor("/static/treesettings_layout_12345.json").then((reqId) => {
+    test.deepEqual(controller.calls.indexOf('rebuild_tree') > -1, true, "Tree rebuild attempted");
+    test.deepEqual(resolved, false, "Not resolved yet: the rebuild is still missing its data");
+
+    window.fetch.resolve_json(reqId, ["a", "b"]);
+    return p;
+  }).then(() => {
+    test.deepEqual(controller.calls, [
+      'stop_refresh_loop',
+      'draw_loading',
+      'rebuild_tree',
+      'rebuild_tree',
+    ], "Rebuilt again once the data arrived, and only then resolved");
+  }).then(() => {
+    return global.window.fetch.waitingWithTimeout().then((w) => test.deepEqual(w, {}, "No requests left in queue"));
+  });
+});
+
+test('tree_settings:rebuild_tree:data_already_available', function (test) {
+  const ds = getDataStoreAPI(test, [DataStoreUt]).ut_treesettings;
+  const controller = fake_controller(ds, { ozid: 91 });
+
+  // Prime the data store first, so there's nothing to wait for when we get going
+  ds.get({ slice: 'layout', id: 0 });
+  return global.window.fetch.waitFor("/static/treesettings_layout_12345.json").then((reqId) => {
+    window.fetch.resolve_json(reqId, ["a", "b"]);
+    return new Promise((resolve) => setTimeout(resolve, 10));  // NB: Let fetch promises settle
+  }).then(() => {
+    return tree_settings.rebuild_tree('spiral', 'natural', controller);
+  }).then(() => {
+    test.deepEqual(controller.calls, [
+      'stop_refresh_loop',
+      'draw_loading',
+      'dynamic_load_and_calc:91',
+      're_calc',
+    ], "Laid out in one go, no retry needed");
+  }).then(() => {
+    return global.window.fetch.waitingWithTimeout().then((w) => test.deepEqual(w, {}, "No requests left in queue"));
+  });
+});


### PR DESCRIPTION
Enabling Midnode garbage collection had the disastrous effect of garbage collecting a flight's destination mid-flight. The first commit stops that, but I'm not sure we're out of the woods yet, this may bubble up elsewhere.

The other commits add a ``get_or_fail()`` mechanism to DataStore, which ultimately means we refuse to show the tree until the loading has finished and we display with the data ready to go. Like the rest of DataStore, nothing is using this functionality yet.