### PR TITLE
Anchoring problems in long flights 

### DIFF
--- a/OZprivate/rawJS/OZTreeModule/src/position_helper.js
+++ b/OZprivate/rawJS/OZTreeModule/src/position_helper.js
@@ -391,15 +391,23 @@ function reanchor_at_node(node, root_node) {
 }
 
 /**
- * Walk tree, anchoring to the first node on-screen that has 2.2 < node.rvar < 22000
+ * Walk tree, anchoring to the first node that is both on screen and of a reasonable size
  * (i.e. set graphref on this node and it's ancestors)
+ *
+ * Reasonable size here means we should ignore high-up nodes whose bounding boxes encompass half of
+ * insects in a balanced tree (e.g.)
+ *
+ * For debugging, you can draw the current anchor node with:
+ *   onezoom.config.debug_bounding_box = (node => node === onezoom.tree_state.anchor_node ? 0x03 : 0)
+ * ...or add a browser watch condition of:
+ *   onezoom.tree_state.anchor_node + ' ' + onezoom.tree_state.anchor_node.rvar
  */
 function reanchor(node) {
   // If this node (or it's desendents) aren't visible, don't bother
   if (!node.dvar) return;
 
   node.graphref = true;
-  if (node.gvar || !node.has_child || (node.rvar > 2.2 && node.rvar < 22000)) {
+  if (!node.has_child || node.gvar && (node.rvar > 1 && node.rvar < 2200)) {
     // Anchor to this node
     tree_state.xp = node.xvar;
     tree_state.yp = node.yvar;

--- a/OZprivate/rawJS/OZTreeModule/src/position_helper.js
+++ b/OZprivate/rawJS/OZTreeModule/src/position_helper.js
@@ -121,11 +121,17 @@ function get_xyr_target(node, x2,y2,r2,into_node) {
     }
   }
 
-  // If we didn't find a target child, use graphref/gvar to recurse
+  // If we didn't find a target child, walk on down the anchor path to pick somewhere nearer
+  // to fly to first, the way the r_mult cap above does for a flight going the other way.
+  //
+  // NB: How far down we walk is the check at the top's to say, which stops us as soon as the
+  //     node we have reached is a small enough step to take in one go. Don't stop at the first
+  //     child that is drawn on screen: a node high up the tree has a branch long enough to
+  //     cross the screen whatever we are looking at, so that leaves the step uncapped.
   if (r_mult < 0.00000001) more_flying_needed = true;
   for (let i=0; i<node.children.length; i++) {
     let child = node.children[i];
-    if (child.graphref && !child.gvar) {
+    if (child.graphref) {
       get_xyr_target(child, x+r*node.nextx[i],y+r*node.nexty[i],r*node.nextr[i],into_node);
       return;
     }

--- a/OZprivate/rawJS/OZTreeModule/src/position_helper.js
+++ b/OZprivate/rawJS/OZTreeModule/src/position_helper.js
@@ -341,36 +341,26 @@ function perform_fly_b2(controller, into_node, speed, accel_type, finalize_func,
  * @param {float} prop_z Proportion of r_mult to zoom (0 - start, 1 - end)
  */
 function pan_zoom(prop_p, prop_z) {
-  // Copy globals so we can modify
-  let pre_xp2 = pre_xp;
-  let pre_yp2 = pre_yp;
-  let pre_ws2 = pre_ws;
-  let y_add2 = y_add;
-  let x_add2 = x_add;
-  let r_mult2 = r_mult;
-
   const tree_centreX = tree_state.focal_area.xcentre;
   const tree_centreY = tree_state.focal_area.ycentre;
+  const zoom = Math.pow(r_mult, prop_z);
 
-  if (r_mult2 < 1) { // Zooming outwards
-    pre_xp2 = tree_centreX + (pre_xp2-x_add2-tree_centreX)*r_mult2;
-    pre_yp2 = tree_centreY + (pre_yp2-y_add2-tree_centreY)*r_mult2;
-    pre_ws2 = pre_ws2 * r_mult2;
-
-    prop_p = 1-prop_p;
-    prop_z = 1-prop_z;
-
-    y_add2 = (-y_add2)*r_mult2;
-    x_add2 = (-x_add2)*r_mult2;
-    r_mult2 = 1/r_mult2;
-    // todo - getting there, but need to play with the function still - it's not right
-    // also can transform the prop_p and prop_z components of this to make it non linear and more zooming initially
-    // could change to measure x and y add in terms of the zoomed out version
+  tree_state.ws = pre_ws * zoom;
+  if (r_mult < 1) { // Zooming outwards
+    // The flight run backwards: we are at the far end of a zoom in, flying back to where it
+    // started, so the pan is a fixed offset measured at the scale we are flying *to*.
+    //
+    // NB: Worked out here rather than by re-expressing pre_xp/x_add/r_mult at the destination
+    //     and inverting the zoom. (pre_xp - x_add) is swamped by x_add whenever the node we
+    //     are flying to has its centre a long way off screen, so that round trip loses where
+    //     we actually are, and multiplying back up by 1/r_mult turns the rounding error left
+    //     behind into a jump of millions of pixels.
+    tree_state.xp = tree_centreX + (pre_xp - tree_centreX) * zoom - x_add * r_mult * prop_p;
+    tree_state.yp = tree_centreY + (pre_yp - tree_centreY) * zoom - y_add * r_mult * prop_p;
+  } else {
+    tree_state.xp = tree_centreX + x_add * (1 - prop_p) + (pre_xp - x_add - tree_centreX) * zoom;
+    tree_state.yp = tree_centreY + y_add * (1 - prop_p) + (pre_yp - y_add - tree_centreY) * zoom;
   }
-
-  tree_state.ws = pre_ws2 * Math.pow(r_mult2,prop_z);
-  tree_state.xp = tree_centreX + x_add2*(1-prop_p) + (pre_xp2-x_add2-tree_centreX) * Math.pow(r_mult2,prop_z);
-  tree_state.yp = tree_centreY + y_add2*(1-prop_p) + (pre_yp2-y_add2-tree_centreY) * Math.pow(r_mult2,prop_z);
 }
 
 /**

--- a/OZprivate/rawJS/OZTreeModule/tests/test_position_helper.js
+++ b/OZprivate/rawJS/OZTreeModule/tests/test_position_helper.js
@@ -80,10 +80,11 @@ function move_to(controller, node, opts) {
     controller.tree_state.flying = false;
   })
 }
+function round(x) {
+  return Math.round(x * 10000) / 10000;
+}
+
 function test_cur_location(test, controller, node_latin_name, exp_xp, exp_yp, exp_ws, message) {
-  function round(x) {
-    return Math.round(x * 10000) / 10000;
-  }
   const target = controller.get_graphref_node();
 
   test.deepEqual({
@@ -97,7 +98,27 @@ function test_cur_location(test, controller, node_latin_name, exp_xp, exp_yp, ex
     yp: round(exp_yp),
     ws: round(exp_ws),
   }, "At " + node_latin_name + " - " + message);
-  exp_xp = round(exp_xp);
+}
+
+/**
+ * Where (node) ended up on screen, which is what the viewer actually sees.
+ *
+ * xp/yp/ws above are only meaningful next to the node they are anchored on, so a change to
+ * which node that is rewrites all of them without the view having moved at all. Check both,
+ * and the pair tells you which of the two you have changed.
+ */
+function test_node_on_screen(test, controller, node, exp_x, exp_y, exp_r, message) {
+  controller.re_calc();
+
+  test.deepEqual({
+    x: round(node.xvar),
+    y: round(node.yvar),
+    r: round(node.rvar),
+  }, {
+    x: round(exp_x),
+    y: round(exp_y),
+    r: round(exp_r),
+  }, "On screen: " + (node.latin_name || node.ozid) + " - " + message);
 }
 
 test('perform_actual_fly', function (test) {
@@ -127,22 +148,27 @@ test('perform_actual_fly', function (test) {
     return Promise.resolve().then(() => {
       return move_to(controller, nodes['Dobsonia'], {speed: Infinity}).then(() => {
         test_cur_location(test, controller, "Laurasiatheria", 28826.0739, -18858.2284, 48.0688, "Retargeted, jumped");
+        test_node_on_screen(test, controller, nodes['Dobsonia'], 1069.8041, 978.1592, 256.0792, "Retargeted, jumped");
       });
     }).then(() => {
       return move_to(controller, nodes['biota'], {speed: Infinity}).then(() => {
         test_cur_location(test, controller, "biota", 801.3117, 1170.5032, 1.5371, "Retargeted, jumped");
+        test_node_on_screen(test, controller, nodes['biota'], 801.3117, 1170.5032, 338.1551, "Retargeted, jumped");
       });
     }).then(() => {
       return move_to(controller, nodes['Dobsonia'], {speed: Infinity}).then(() => {
         test_cur_location(test, controller, "Laurasiatheria", 28826.0739, -18858.2284, 48.0688, "Went back again, Dobsonia in same place");
+        test_node_on_screen(test, controller, nodes['Dobsonia'], 1069.8041, 978.1592, 256.0792, "Went back again, Dobsonia in same place");
       });
     }).then(() => {
       return move_to(controller, nodes['Acerodon'], {speed: 1}).then(() => {
         test_cur_location(test, controller, "Laurasiatheria", 42907.5839, -32331.2601, 79.3102, "Flights to nearby location");
+        test_node_on_screen(test, controller, nodes['Acerodon'], 594.6564, 625.457, 250.0075, "Flights to nearby location");
       });
     }).then(() => {
       return move_to(controller, nodes['Dobsonia'], {speed: 1}).then(() => {
         test_cur_location(test, controller, "Laurasiatheria", 28826.0739, -18858.2284, 48.0688, "Flight back");
+        test_node_on_screen(test, controller, nodes['Dobsonia'], 1069.8041, 978.1592, 256.0792, "Flight back");
       });
     });
 
@@ -155,9 +181,8 @@ test('perform_actual_fly', function (test) {
   })
 });
 
-
 test.onFinish(function() {
-  
+
   global.requestAnimationFrame = undefined;
   global.cancelAnimationFrame = undefined;
 });

--- a/OZprivate/rawJS/OZTreeModule/tests/test_position_helper.js
+++ b/OZprivate/rawJS/OZTreeModule/tests/test_position_helper.js
@@ -98,6 +98,13 @@ function test_cur_location(test, controller, node_latin_name, exp_xp, exp_yp, ex
     yp: round(exp_yp),
     ws: round(exp_ws),
   }, "At " + node_latin_name + " - " + message);
+
+  // Anchoring on a node far bigger than the screen leaves every position we work out from
+  // it a small difference between large numbers, so reanchor() should have come down to
+  // something of a workable size before settling on it
+  const anchor_size = 220 * controller.tree_state.ws;
+  test.ok(!target.has_child || (anchor_size > 1 && anchor_size < 2200),
+    "Anchored on a node of a workable size (" + round(anchor_size) + "px) - " + message);
 }
 
 /**
@@ -147,7 +154,7 @@ test('perform_actual_fly', function (test) {
     var controller = fake_controller(factory, 2000, 1000);
     return Promise.resolve().then(() => {
       return move_to(controller, nodes['Dobsonia'], {speed: Infinity}).then(() => {
-        test_cur_location(test, controller, "Laurasiatheria", 28826.0739, -18858.2284, 48.0688, "Retargeted, jumped");
+        test_cur_location(test, controller, 836249, 1464.4098, 1157.1168, 1.5132, "Retargeted, jumped");
         test_node_on_screen(test, controller, nodes['Dobsonia'], 1069.8041, 978.1592, 256.0792, "Retargeted, jumped");
       });
     }).then(() => {
@@ -157,17 +164,17 @@ test('perform_actual_fly', function (test) {
       });
     }).then(() => {
       return move_to(controller, nodes['Dobsonia'], {speed: Infinity}).then(() => {
-        test_cur_location(test, controller, "Laurasiatheria", 28826.0739, -18858.2284, 48.0688, "Went back again, Dobsonia in same place");
+        test_cur_location(test, controller, 836249, 1464.4098, 1157.1168, 1.5132, "Went back again, Dobsonia in same place");
         test_node_on_screen(test, controller, nodes['Dobsonia'], 1069.8041, 978.1592, 256.0792, "Went back again, Dobsonia in same place");
       });
     }).then(() => {
       return move_to(controller, nodes['Acerodon'], {speed: 1}).then(() => {
-        test_cur_location(test, controller, "Laurasiatheria", 42907.5839, -32331.2601, 79.3102, "Flights to nearby location");
+        test_cur_location(test, controller, 836249, -2237.239, 692.653, 2.4967, "Flights to nearby location");
         test_node_on_screen(test, controller, nodes['Acerodon'], 594.6564, 625.457, 250.0075, "Flights to nearby location");
       });
     }).then(() => {
       return move_to(controller, nodes['Dobsonia'], {speed: 1}).then(() => {
-        test_cur_location(test, controller, "Laurasiatheria", 28826.0739, -18858.2284, 48.0688, "Flight back");
+        test_cur_location(test, controller, 836249, 1464.4098, 1157.1168, 1.5132, "Flight back");
         test_node_on_screen(test, controller, nodes['Dobsonia'], 1069.8041, 978.1592, 256.0792, "Flight back");
       });
     });

--- a/OZprivate/rawJS/OZTreeModule/tests/test_position_helper.js
+++ b/OZprivate/rawJS/OZTreeModule/tests/test_position_helper.js
@@ -188,6 +188,105 @@ test('perform_actual_fly', function (test) {
   })
 });
 
+/**
+ * A flight outwards from deep in the tree has to hold onto where it is whilst it works in
+ * numbers the size of the node it is flying to, which is enormous next to the screen when
+ * we are a long way inside it. Get that wrong and the view lurches about instead of
+ * drawing back smoothly.
+ */
+test('perform_actual_fly: flying out from a deep zoom keeps hold of the view', function (test) {
+  setup_dom(test);
+
+  // Drive the flight off a clock of our own, one frame's worth at a time, so that the
+  // flight is the same length however fast the machine running the tests happens to be
+  const real_performance = global.performance;
+  let fake_now = 0;
+  global.performance = { now: () => fake_now };
+  global.requestAnimationFrame = (callback) => setTimeout(() => {
+    fake_now += 1000 / 60;
+    callback();
+  }, 0);
+  global.cancelAnimationFrame = clearTimeout;
+  var nodes = {}, frames = [], watch = null;
+
+  /**
+   * Screen size/position of (watch), worked down from whatever we are anchored on.
+   *
+   * The anchor is always one of its ancestors here, so this is a plain walk down the tree,
+   * and unlike xp/yp/ws it means the same thing either side of a re-anchor.
+   */
+  function watch_on_screen(controller) {
+    const path = [];
+    for (let n = watch; n; n = n.upnode) path.push(n);
+
+    let x = tree_state.xp, y = tree_state.yp, r = 220 * tree_state.ws;
+    for (let i = path.indexOf(controller.get_graphref_node()) - 1; i >= 0; i--) {
+      const parent = path[i + 1], ci = parent.children.indexOf(path[i]);
+      x = x + r * parent.nextx[ci];
+      y = y + r * parent.nexty[ci];
+      r = r * parent.nextr[ci];
+    }
+    return { x: x, y: y, r: r };
+  }
+
+  return populate_factory().then((factory) => {
+    return resolve_pinpoints([
+      '@biota=93302',
+      '@Pteralopex_atrata=164526', // Monkey-faced bat
+    ]).then((pps) => pps.forEach((pp) => {
+      nodes[pp.sciname] = factory.dynamic_loading_by_metacode(pp.ozid)
+    })).then(() => factory);
+
+  }).then(function (factory) {
+    var controller = fake_controller(factory, 2000, 1000);
+    controller.trigger_refresh_loop = function () {
+      frames.push(watch_on_screen(controller));
+    };
+
+    return move_to(controller, nodes['Pteralopex atrata'], {speed: Infinity}).then(() => {
+      // Park on the leaf, zoomed as far in as we would be inside the real tree. The test
+      // tree is too shallow to get here by flying, but the arithmetic doesn't care how we
+      // arrived, only how big the node we then fly to is next to the screen
+      watch = nodes['Pteralopex atrata'];
+      position_helper.reanchor_at_node(watch, controller.root);
+      tree_state.xp = tree_state.focal_area.xcentre;
+      tree_state.yp = tree_state.focal_area.ycentre;
+      tree_state.ws = 1e15;
+      controller.re_calc();
+
+      frames = [watch_on_screen(controller)];
+      return move_to(controller, nodes['biota'], {speed: 1});
+    }).then(() => {
+      // The leaf we set off from should draw back steadily. Any frame that moves it a long
+      // way is the view jumping, however smooth the zoom either side of it looks
+      let worst = 0, worst_at = -1;
+      frames.forEach((f, i) => {
+        if (i === 0) return;
+        const moved = Math.hypot(f.x - frames[i - 1].x, f.y - frames[i - 1].y);
+        if (moved > worst) { worst = moved; worst_at = i; }
+      });
+
+      test.ok(frames.length > 100, "Flew out over " + frames.length + " frames");
+      test.ok(worst < 25, "Leaf never jumps: worst frame moves it " +
+        worst.toFixed(1) + "px, at frame " + worst_at + " of " + frames.length);
+      // ...and it did actually draw back, rather than staying put
+      test.ok(frames[frames.length - 1].r < frames[0].r * 1e-6,
+        "Leaf shrank from " + frames[0].r.toExponential(2) + " to " +
+        frames[frames.length - 1].r.toExponential(2) + "px");
+    });
+
+  }).finally(function () {
+    global.performance = real_performance;
+  }).then(function () {
+    test.end();
+  }).catch(function (err) {
+    console.log(err.stack);
+    test.fail(err);
+    test.end();
+  })
+});
+
+
 test.onFinish(function() {
 
   global.requestAnimationFrame = undefined;

--- a/OZprivate/rawJS/OZTreeModule/tests/test_position_helper.js
+++ b/OZprivate/rawJS/OZTreeModule/tests/test_position_helper.js
@@ -9,6 +9,7 @@ import test from 'tape';
 
 import tree_state from '../src/tree_state.js'
 import get_projection from '../src/projection/projection.js';
+import re_calc from '../src/projection/re_calc.js';
 import { set_pre_calculator } from '../src/projection/pre_calc/pre_calc';
 import { set_horizon_calculator } from '../src/projection/horizon_calc/horizon_calc';
 
@@ -277,6 +278,144 @@ test('perform_actual_fly: flying out from a deep zoom keeps hold of the view', f
 
   }).finally(function () {
     global.performance = real_performance;
+  }).then(function () {
+    test.end();
+  }).catch(function (err) {
+    console.log(err.stack);
+    test.fail(err);
+    test.end();
+  })
+});
+
+
+/**
+ * A chain of (depth) nodes, each drawn (ratio) of the size of its parent and sharing its
+ * origin. Every node also gets a second child to hang off it, so that the layout is the
+ * pair of children the rest of the code expects.
+ *
+ * The point of it is the scale range: the tracked test tree spans a few million between
+ * root and leaf, which is not enough for a flight across it to need breaking up. A real
+ * tree is far deeper than that, and this is the cheapest way to get somewhere that has to
+ * be flown in stages.
+ */
+function chain_tree(depth, ratio) {
+  function blank(metacode, is_leaf) {
+    return {
+      metacode: metacode, is_leaf: is_leaf, is_interior_node: !is_leaf,
+      has_child: false, children: [], upnode: null,
+      nextr: [], nextx: [], nexty: [],
+      // Bounding box of the node and its descendants, and of the node on its own
+      hxmin: -1, hxmax: 1, hymin: -1, hymax: 1,
+      gxmin: -1, gxmax: 1, gymin: -1, gymax: 1,
+      arcx: 0, arcy: 0, arcr: 1,
+      graphref: false, gvar: false, dvar: false, targeted: false,
+      rvar: 0, xvar: 0, yvar: 0,
+    };
+  }
+
+  const nodes = [];
+  let node = blank(1, false);
+  nodes.push(node);
+  for (let i = 1; i < depth; i++) {
+    const next = blank(i + 1, i === depth - 1);
+    const spare = blank(1000 + i, true);
+
+    node.has_child = true;
+    node.children = [next, spare];
+    node.nextr = [ratio, ratio];
+    node.nextx = [0, 0];
+    node.nexty = [0, 0];
+    next.upnode = node;
+    spare.upnode = node;
+
+    nodes.push(next);
+    node = next;
+  }
+  return { root: nodes[0], leaf: node };
+}
+
+/**
+ * get_xyr_target() only goes so far at a time, breaking a flight that spans more than that
+ * into steps it can take one at a time. That cap is meant to apply to a flight going
+ * outwards as much as to one going in.
+ */
+test('perform_actual_fly: a flight outwards is broken into capped steps', function (test) {
+  setup_dom(test);
+
+  global.requestAnimationFrame = (callback) => setTimeout(callback, 0);
+  global.cancelAnimationFrame = clearTimeout;
+  tree_state.setup_canvas({ width: 2000, height: 1000 }, 2000, 1000);
+
+  const tree = chain_tree(12, 1e-3);
+  const steps = [];
+
+  function anchor_node() {
+    let node = tree.root;
+    for (;;) {
+      let next = null;
+      for (let i = 0; i < node.children.length; i++) {
+        if (node.children[i].graphref) next = node.children[i];
+      }
+      if (!next) return node;
+      node = next;
+    }
+  }
+
+  /** Screen size of the leaf, worked down from the anchor so a re-anchor doesn't show */
+  function leaf_r() {
+    const path = [];
+    for (let n = tree.leaf; n; n = n.upnode) path.push(n);
+
+    let r = 220 * tree_state.ws;
+    for (let i = path.indexOf(anchor_node()) - 1; i >= 0; i--) {
+      const parent = path[i + 1];
+      r = r * parent.nextr[parent.children.indexOf(path[i])];
+    }
+    return r;
+  }
+
+  const controller = {
+    root: tree.root,
+    re_calc: () => re_calc(tree.root, tree_state.xp, tree_state.yp, tree_state.ws),
+    // A leap lands on one step's destination at a time, re-anchoring between each, so
+    // this catches the intermediate places a flight out of here would have aimed for
+    reanchor: () => {
+      position_helper.reanchor(tree.root);
+      steps.push(leaf_r());
+    },
+    trigger_refresh_loop: () => {},
+  };
+
+  // Park on the leaf, then head all the way out to the root
+  position_helper.reanchor_at_node(tree.leaf, tree.root);
+  tree_state.xp = tree_state.focal_area.xcentre;
+  tree_state.yp = tree_state.focal_area.ycentre;
+  tree_state.ws = 1;
+  controller.re_calc();
+
+  const started_at = leaf_r();
+  tree_state.flying = true;
+  position_helper.clear_target(tree.root);
+  position_helper.target_by_code(tree.root, tree.root.metacode);
+
+  return position_helper.perform_actual_fly(controller, false, Infinity, 'linear').then(() => {
+    let worst = 0;
+    steps.forEach((r, i) => {
+      const zoomed_out_by = (i === 0 ? started_at : steps[i - 1]) / r;
+      if (zoomed_out_by > worst) worst = zoomed_out_by;
+    });
+
+    test.ok(steps.length > 1, "Took " + steps.length + " steps to get out, not one leap");
+    test.ok(worst <= 1e8, "No step goes further than the cap: worst zooms out by " +
+      worst.toExponential(2) + " over " + steps.length + " steps");
+    // ...and it did get there: the root's children, which are what a flight to it aims to
+    // fit on screen, end up filling the focal area
+    const box_height = 2 * tree.root.rvar * tree.root.nextr[0];
+    test.ok(Math.abs(box_height - tree_state.focal_area.height) < 1,
+      "Root fills the screen at the end (" + box_height.toFixed(2) +
+      "px against a focal area of " + tree_state.focal_area.height + "px)");
+  }).finally(() => {
+    tree_state.flying = false;
   }).then(function () {
     test.end();
   }).catch(function (err) {


### PR DESCRIPTION
#981 identified that re-anchoring would only work for particular views. The fix was fine, but the now-working reanchoring resulted in jumping on zooming out, thanks to numerical inaccuracy. This should fix both, for "balanced" as in the original issue and the new view in #1013

Supersedes #981
Fixes #972 