### PR TITLE
Handle usernames without email addresses

### DIFF
--- a/controllers/manage.py
+++ b/controllers/manage.py
@@ -548,21 +548,18 @@ def SHOW_RENEWAL_INFO():
                     if id_string not in id_map:
                         id_map[id_string] = []
                     id_map[id_string].append(id_string)
-    try:
-        uname_info = {
-            k:r for (k, r) in sponsorship.sponsorship_email_reminders(
-                [uname for info_for_id in id_map.values() for uname in info_for_id])}
+    uname_info = {
+        k:r for (k, r) in sponsorship.sponsorship_email_reminders(
+            [uname for info_for_id in id_map.values() for uname in info_for_id])}
     
-        renew_urls = {
-            k: {uname: uname_info[uname]["renew_url"] for uname in v}
-            for k, v in id_map.items()
-        }
-        if info:
-            response.flash = "Email information:\n" + "\n\n".join(info)
+    renew_urls = {
+        k: {uname: uname_info[uname]["renew_url"] for uname in v if uname in uname_info}
+        for k, v in id_map.items()
+    }
+    if info:
+        response.flash = "Email information:\n" + "\n\n".join(info)
 
-        return dict(urls = renew_urls)
-    except ValueError as e:
-        return dict(error = str(e))
+    return dict(urls = renew_urls)
 
 
 @OZfunc.require_https_if_nonlocal()

--- a/modules/sponsorship.py
+++ b/modules/sponsorship.py
@@ -783,7 +783,7 @@ def sponsorship_email_reminders(for_usernames=None):
     send_to = False
     for r in db(query).select(db.reservations.ALL, orderby=db.reservations.username|db.reservations.sponsorship_ends):
         if r.username != cur_username:
-            if send_to:
+            if send_to and out['email_address']:
                 yield (cur_username, out)
             # Start new user entry
             cur_username = r.username
@@ -847,7 +847,7 @@ def sponsorship_email_reminders(for_usernames=None):
             out['not_yet_due'].append(r.OTT_ID)
 
     # Yield final entry
-    if send_to:
+    if send_to and out['email_address']:
         yield (cur_username, out)
 
 def sponsor_renew_request_logic(user_identifier, mailer=None, reveal_private_data=False, automated=False):
@@ -862,10 +862,7 @@ def sponsor_renew_request_logic(user_identifier, mailer=None, reveal_private_dat
     """
     # Get all reminder blocks for usernames associated to this e-mail address
     unames = usernames.usernames_associated_to_email(user_identifier) if '@' in user_identifier else [user_identifier]
-    try:
-        user_reminders = {k:v for (k, v) in sponsorship_email_reminders(unames)}
-    except ValueError:
-        user_reminders = {}
+    user_reminders = {k:v for (k, v) in sponsorship_email_reminders(unames)}
     info = ''
     if not reveal_private_data:
         info = 'If the user %s exists in our database, we will send them an email' % user_identifier

--- a/modules/usernames.py
+++ b/modules/usernames.py
@@ -130,7 +130,7 @@ def donor_name_for_username(username, include_hidden=False):
     return None, None
 
 def email_for_username(username):
-    """Return the most up to date e-mail address for a given username"""
+    """Return the most up to date e-mail address for a username, or None."""
     db = current.db
     pp_e_mail = None
     for r in db(db.reservations.username == username).iterselect(
@@ -142,9 +142,7 @@ def email_for_username(username):
             return r.e_mail
         if r.PP_e_mail and not pp_e_mail:
             pp_e_mail = r.PP_e_mail
-    if pp_e_mail:
-        return pp_e_mail
-    raise ValueError("No e-mail address found for username %s" % username)
+    return pp_e_mail
 
 
 def usernames_associated_to_email(email):

--- a/tests/unit/test_modules_sponsorship.py
+++ b/tests/unit/test_modules_sponsorship.py
@@ -1084,6 +1084,18 @@ class TestSponsorship(unittest.TestCase):
         self.assertEqual(days_left(user_1, days=0, hours=-1)[r1.OTT_ID], -1, test_msg(r1))
         self.assertEqual(days_left(user_1, days=-1, hours=-1)[r1.OTT_ID], -2, test_msg(r1))
 
+    def test_sponsorship_email_reminders_without_email(self):
+        """Users without an e-mail address cannot receive reminders."""
+        expiry_time = current.request.now + datetime.timedelta(days=10*365)
+        current.request.now = expiry_time - datetime.timedelta(days=sponsorship_config()['duration_days'])
+        reservation = util.purchase_reservation(
+            basket_details=dict(user_sponsor_name='Billy-no-email'),
+            paypal_details=dict(PP_e_mail=None),
+        )[0]
+
+        current.request.now = expiry_time - datetime.timedelta(days=1)
+        self.assertEqual(list(sponsorship_email_reminders([reservation.username])), [])
+
     def test_sponsorship_email_reminders_null_sponsorship_ends(self):
         """NULL sponsorship_ends ==> permanently sponsored"""
         db = current.db

--- a/tests/unit/test_modules_usernames.py
+++ b/tests/unit/test_modules_usernames.py
@@ -258,15 +258,14 @@ class TestUsername(unittest.TestCase):
         """Make sure we can always fish out a username"""
         otts = util.find_unsponsored_otts(4, allow_banned=True)
 
-        # User with no e-mail addresses at all, get ValueError
+        # User with no e-mail addresses at all, get None
         util.time_travel(3)
         r = util.purchase_reservation(
             otts[0:1], basket_details=dict(
             user_donor_name='Billy-no-email',
             user_sponsor_name='Billy-no-email',
         ), paypal_details=dict(PP_e_mail=None))[0]
-        with self.assertRaisesRegex(ValueError, r.username):
-            email_for_username(r.username)
+        self.assertIsNone(email_for_username(r.username))
 
         # Buy one with only a paypal e-mail address, we get that back
         util.time_travel(2)


### PR DESCRIPTION
Closes #1069.

## Summary
- return `None` from `email_for_username()` when no email address exists
  - Note: I think it's better to return `None` instead of raising a dedicated Exception for "no email", since a user not having an assigned email is tolerated by the system. 
- skip renewal reminders for users who cannot receive email
- update renewal consumers for the nullable email contract
- add regression coverage for email-less users

## Testing
- `python3 -m py_compile modules/usernames.py modules/sponsorship.py controllers/manage.py tests/unit/test_modules_usernames.py tests/unit/test_modules_sponsorship.py`
- `git diff --check`

The targeted web2py tests require the project's MySQL-backed test database, which is not available in the local environment.