### PR TITLE
Stuck in tour fix

### DIFF
--- a/OZprivate/rawJS/OZTreeModule/src/tour/Tour.js
+++ b/OZprivate/rawJS/OZTreeModule/src/tour/Tour.js
@@ -37,6 +37,7 @@
  *   * ``visible-transition_in``: Visible whilst transitioning to the tourstop node
  *   * ``visible-transition_out``: Visible whilst transitioning to the next tourstop node
  *   * ``hidden-active_wait``: Hidden whilst at the tourstop (NB: The default is ``visible-active_wait``)
+ *   When the tour is paused, the current stop is always visible.
  * * ``data-ott``: Specifies the OTT / Pinpoint that the tourstop will view, or ``0`` for point on the tree the tour started at
  * * ``data-transition_in``: The type of transition to use, one of ``leap``, ``fly_straight``. Defaults to ``flight``
  * * ``data-transition_in_wait``: Delay start of flight, in milliseconds. Defaults to 0

--- a/OZprivate/rawJS/OZTreeModule/src/tour/Tour.js
+++ b/OZprivate/rawJS/OZTreeModule/src/tour/Tour.js
@@ -47,7 +47,7 @@
  * Other modules provide extra functionality useful when writing tours, in particular:
  * * {@link tour/handler/HtmlAV} Autoplays/stops HTML ``<audio>`` / ``<video>`` in a tourstop based on ``data-ts_autoplay``.
  * * {@link tour/handler/QsOpts} Applies/reverts tree state based on ``data-qs_opts``, e.g. highlights, colour schemes, language.
- * * {@link tour/handler/UiEvents} Behavioural CSS classes to add to tour forward/backward/etc buttons.
+ * * {@link tour/handler/UiEvents} Behavioural CSS classes to add to tour forward/backward/etc buttons, plus Escape / arrow-key shortcuts.
  * * {@link tour/handler/TsProgress} Individual links to tourstops, showing currently visited stops.
  * * {@link tour/handler/Vimeo} Autoplays/stops embedded Vimeo in a tourstop based on ``data-ts_autoplay``.
  * * {@link tour/handler/Youtube} Autoplays/stops embedded Youtube in a tourstop based on ``data-ts_autoplay``.

--- a/OZprivate/rawJS/OZTreeModule/src/tour/handler/UIEvents.js
+++ b/OZprivate/rawJS/OZTreeModule/src/tour/handler/UIEvents.js
@@ -21,6 +21,9 @@
  * On clicking ``tour_backward`` / ``tour_forward``, the tour will go backwards/forwards.
  * On clicking ``tour_exit`` / ``tour_final``, the tour will close.
  *
+ * While the tour is playing or paused, keyboard shortcuts are also bound:
+ * Escape exits, ArrowLeft goes to the previous stop, ArrowRight goes to the next stop.
+ *
  * When the tour is paused (e.g. as a result of user interaction) the ``tour_resume`` button will be visible,
  * clicking it will resume the tour.
  *
@@ -165,6 +168,43 @@ function handler(tour) {
   };
   document.removeEventListener('visibilitychange', onVisibilityChange);
   document.addEventListener('visibilitychange', onVisibilityChange);
+
+  const onKeyDown = (event) => {
+    if (!tour.container || !tour.container[0].isConnected) {
+      document.removeEventListener('keydown', onKeyDown);
+      return;
+    }
+    if (tour.state === 'tstate-inactive') return;
+    if (event.repeat || event.altKey || event.ctrlKey || event.metaKey) return;
+
+    const target = event.target;
+    const tag = (target && target.tagName) || '';
+    if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT' || (target && target.isContentEditable)) {
+      return;
+    }
+
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      tour.user_exit();
+    } else if (event.key === 'ArrowLeft') {
+      event.preventDefault();
+      tour.user_backward();
+    } else if (event.key === 'ArrowRight') {
+      event.preventDefault();
+      tour.user_forward();
+    }
+  };
+  document.addEventListener('keydown', onKeyDown);
+
+  // Tours are often started from the tours iframe modal.
+  // Blur it so we can recieve key events.
+  (new document.defaultView.MutationObserver(() => {
+    if (tour.container[0].getAttribute('data-state') !== 'tstate-playing') return;
+    const active = document.activeElement;
+    if (active && active.tagName === 'IFRAME' && !tour.container[0].contains(active)) {
+      active.blur();
+    }
+  })).observe(tour.container[0], { attributes: true, attributeFilter: ['data-state'] });
 }
 
 export default handler;

--- a/OZprivate/rawJS/OZTreeModule/tests/test_tour_Tour.js
+++ b/OZprivate/rawJS/OZTreeModule/tests/test_tour_Tour.js
@@ -313,7 +313,6 @@ test('tour:block-tourpaused', function (test) {
         }
       }, 10);
     });
-    return new Promise(resolve => setTimeout(resolve, 1000));
   }).then(function () {
     test.deepEqual(t.log.slice(-2), [
       [ 'flight-interrupted', 2202 ],
@@ -447,6 +446,122 @@ test('tour:user_forward', function (test) {
       '</div>'
     ], "Resumed, at next tourstop");
 
+  }).then(function () {
+    test.end();
+  }).catch(function (err) {
+    console.log(err.stack);
+    test.fail(err);
+    test.end();
+  })
+});
+
+
+test('tour:keyboard', function (test) {
+  function press(key) {
+    t.window.document.dispatchEvent(new t.window.KeyboardEvent('keydown', {
+      key: key,
+      bubbles: true,
+      cancelable: true,
+    }));
+  }
+
+  var t = setup_tour(test, `<div class="tour">
+    <div class="container" data-ott="91101" data-stop_wait="5000">t1</div>
+    <div class="container" data-ott="92202" data-stop_wait="5000">t2</div>
+  </div>`, null, false);
+
+  const iframe = t.window.document.createElement('iframe');
+  t.window.document.body.appendChild(iframe);
+  iframe.focus();
+
+  return t.tour.start().then(function () {
+    test.notEqual(
+      t.window.document.activeElement,
+      iframe,
+      "Tour start blurs a focused iframe so shortcuts reach this document",
+    );
+    return t.wait_for_tourstop_state(0, 'tsstate-transition_in');
+  }).then(function () {
+    press('ArrowRight');
+    return Promise.all([
+      t.wait_for_tourstop_state(0, 'tsstate-active_wait'),
+    ]);
+  }).then(function () {
+    test.deepEqual(t.tour_states(), [
+      'tstate-playing',
+      'tsstate-active_wait',
+      'tsstate-inactive',
+    ], "Right arrow skipped the first flight");
+
+    press('ArrowRight');
+    return Promise.all([
+      t.wait_for_tourstop_state(0, 'tsstate-transition_out'),
+      t.wait_for_tourstop_state(1, 'tsstate-transition_in'),
+    ]);
+  }).then(function () {
+    t.finish_flight();
+    return t.wait_for_tourstop_state(1, 'tsstate-active_wait');
+  }).then(function () {
+    test.deepEqual(t.tour_states(), [
+      'tstate-playing',
+      'tsstate-inactive',
+      'tsstate-active_wait',
+    ], "Right arrow advanced to the next stop");
+
+    press('ArrowLeft');
+    return t.wait_for_tourstop_state(0, 'tsstate-transition_in');
+  }).then(function () {
+    t.finish_flight();
+    return t.wait_for_tourstop_state(0, 'tsstate-active_wait');
+  }).then(function () {
+    test.deepEqual(t.tour_states(), [
+      'tstate-playing',
+      'tsstate-active_wait',
+      'tsstate-inactive',
+    ], "Left arrow returned to the previous stop");
+
+    press('Escape');
+    return t.wait_for_tour_state('tstate-inactive');
+  }).then(function () {
+    test.deepEqual(t.tour_states(), [
+      'tstate-inactive',
+      'tsstate-inactive',
+      'tsstate-inactive',
+    ], "Escape exited the tour");
+    test.deepEqual(t.log.slice(-1), [
+      ['exit_callback'],
+    ], "Escape triggered the exit callback");
+
+    press('ArrowRight');
+    test.deepEqual(t.tour.state, 'tstate-inactive', "Keys do nothing after the tour has exited");
+
+  }).then(function () {
+    test.end();
+  }).catch(function (err) {
+    console.log(err.stack);
+    test.fail(err);
+    test.end();
+  })
+});
+
+
+test('tour:resume-does-not-blur-tourstop-iframe', function (test) {
+  var t = setup_tour(test, `<div class="tour">
+    <div class="container" data-ott="91101" data-stop_wait="5000">t1<iframe></iframe></div>
+  </div>`, null, false);
+
+  return t.tour.start().then(function () {
+    return t.wait_for_tourstop_state(0, 'tsstate-transition_in');
+  }).then(function () {
+    t.finish_flight();
+    return t.wait_for_tourstop_state(0, 'tsstate-active_wait');
+  }).then(function () {
+    t.tour.user_pause();
+    const media = t.tour.container[0].querySelector('iframe');
+    media.focus();
+    test.equal(t.window.document.activeElement, media, "Media iframe can take focus while paused");
+    t.tour.user_resume();
+    test.equal(t.window.document.activeElement, media, "Resume does not blur a tourstop iframe");
   }).then(function () {
     test.end();
   }).catch(function (err) {

--- a/OZprivate/scss/tour.scss
+++ b/OZprivate/scss/tour.scss
@@ -35,6 +35,12 @@
       visibility: visible;
     }
 
+    /* When paused, always show the current stop so Resume is reachable even if the stop is hidden.  */
+    &[data-state=tstate-paused] > .container[data-state=tsstate-active_wait],
+    &[data-state=tstate-paused] > .container[data-state=tsstate-transition_in] {
+      visibility: visible;
+    }
+
     /* tour_resume buttons only visible the tour is paused */
     .tour_resume { display: none }
     &[data-state=tstate-paused] .tour_resume { display: initial }


### PR DESCRIPTION
Fix #1066 

Provides some escape hatches:

- When paused, always show the tourstop, so even if you end up with a hidden-active_wait tourstop with no auto-progress, you have a way of getting out
- (Unchanged) interacting with the tree pauses the tour. So if you get stuck and then you tap the tree, it'll pause and the tourstop will appear
- Keyboard shortcuts for escape, left and right. Obviously no help on touch screens but felt right that hitting escape should get you out