### PR TITLE
Tour editor round trip

### DIFF
--- a/OZprivate/rawJS/TourEditor/src/TourForm.tsx
+++ b/OZprivate/rawJS/TourEditor/src/TourForm.tsx
@@ -28,6 +28,8 @@ export default function TourForm({
     onOpenFile,
     onDownloadFile,
 }: TourFormProps) {
+    const selectedLicense = LICENSE_OPTIONS.find((option) => option.value === tour.license);
+
     return (
         <div className="uk-form-stacked">
             <div className="uk-margin">
@@ -94,12 +96,26 @@ export default function TourForm({
                     id="tour-license"
                     className="uk-select"
                     value={tour.license}
+                    aria-describedby="tour-license-description"
                     onChange={(e) => onChange({ license: e.target.value as TourLicense })}
                 >
                     {LICENSE_OPTIONS.map((option) => (
                         <option key={option.value} value={option.value}>{option.label}</option>
                     ))}
                 </select>
+                {selectedLicense && (
+                    <p className="uk-text-small uk-text-muted uk-margin-small-top" id="tour-license-description">
+                        {selectedLicense.description}
+                        {selectedLicense.infoUrl && (
+                            <>
+                                {' '}
+                                <a href={selectedLicense.infoUrl} target="_blank" rel="noopener noreferrer">
+                                    More info
+                                </a>
+                            </>
+                        )}
+                    </p>
+                )}
             </div>
 
             <div className="tour-editor-section">

--- a/OZprivate/rawJS/TourEditor/src/compile.ts
+++ b/OZprivate/rawJS/TourEditor/src/compile.ts
@@ -113,6 +113,9 @@ function stopQsOpts(stop: EditorTourStop): string | undefined {
         if (highlight.pinpoints.length === 0) continue;
         parts.push(`highlight=${toHighlightStr(highlight)}`);
     }
+    for (const { key, value } of stop.extraQueryStrings ?? []) {
+        parts.push(`${encodeURIComponent(key)}=${encodeURIComponent(value)}`);
+    }
     return parts.length > 0 ? `?${parts.join('&')}` : undefined;
 }
 

--- a/OZprivate/rawJS/TourEditor/src/compile.ts
+++ b/OZprivate/rawJS/TourEditor/src/compile.ts
@@ -42,10 +42,12 @@ export interface ProductionTourStopJson {
     transition_in?: 'fly' | 'leap' | 'fly_straight';
     fly_in_speed?: number;
     stop_wait?: number;
+    comment?: string;
     template_data: {
         title?: string;
         window_text?: ProductionWindowText | ProductionWindowText[];
         media?: ProductionMedia[];
+        comment?: string;
         'visible-transition_in'?: boolean;
         'visible-transition_out'?: boolean;
         'hidden-active_wait'?: boolean;
@@ -90,6 +92,7 @@ function editorStopToJson(stop: EditorTourStop): ProductionTourStopJson {
             ...stopVisibilityFlags(stopVisibility),
             ...(window_text.length > 0 ? { window_text } : {}),
             ...(media.length > 0 ? { media } : {}),
+            ...(stop.templateComment ? { comment: stop.templateComment } : {}),
         },
     };
 
@@ -98,6 +101,7 @@ function editorStopToJson(stop: EditorTourStop): ProductionTourStopJson {
     if (stop.transitionIn !== 'fly') out.transition_in = stop.transitionIn;
     if (stop.flyInSpeed !== 1) out.fly_in_speed = stop.flyInSpeed;
     if (stop.autoAdvance) out.stop_wait = Math.round(stop.stopWaitSeconds * 1000);
+    if (stop.comment) out.comment = stop.comment;
 
     return out;
 }

--- a/OZprivate/rawJS/TourEditor/src/compile.ts
+++ b/OZprivate/rawJS/TourEditor/src/compile.ts
@@ -135,8 +135,17 @@ function mediaValue(block: EditorMediaBlock, stopVisibility: PhaseSelection): Pr
         block.visibility ?? defaultContentVisibility,
         stopVisibility,
     );
-    if (Object.keys(flags).length === 0) return url;
-    return { url, ...flags };
+    const extras = mediaEmbedExtras(block);
+    if (Object.keys(flags).length === 0 && Object.keys(extras).length === 0) return url;
+    return { url, ...flags, ...extras };
+}
+
+function mediaEmbedExtras(block: EditorMediaBlock): Record<string, string | null> {
+    const extras: Record<string, string | null> = {};
+    if (block.ts_autoplay !== undefined) extras.ts_autoplay = block.ts_autoplay;
+    if (block.alt) extras.alt = block.alt;
+    if (block.title) extras.title = block.title;
+    return extras;
 }
 
 /**

--- a/OZprivate/rawJS/TourEditor/src/media.ts
+++ b/OZprivate/rawJS/TourEditor/src/media.ts
@@ -1,6 +1,7 @@
 import { newEditorId } from './tour';
 import type {
     EditorMediaBlock,
+    EditorMediaNonSourceKey,
     EditorMediaSource,
     EditorMediaKind,
     EditorThumbnailKind,
@@ -154,12 +155,21 @@ export function parseMediaUrlAsKind(url: string, kind: EditorMediaKind): EditorM
     }
 }
 
+type MediaOwnerFields = Pick<EditorMediaBlock, EditorMediaNonSourceKey>;
+
 /** Reattach editor-owned fields. Object-spread of the fields union would keep only ``kind``. */
 export function mediaBlockFromFields<T extends EditorMediaSource>(
     fields: T,
-    previous: { id: string; visibility?: EditorMediaBlock['visibility'] },
-): T & { id: string; visibility?: EditorMediaBlock['visibility'] } {
-    return { ...fields, id: previous.id, visibility: previous.visibility };
+    previous: MediaOwnerFields,
+): T & MediaOwnerFields {
+    return {
+        ...fields,
+        id: previous.id,
+        visibility: previous.visibility,
+        ...(previous.ts_autoplay !== undefined ? { ts_autoplay: previous.ts_autoplay } : {}),
+        ...(previous.alt ? { alt: previous.alt } : {}),
+        ...(previous.title ? { title: previous.title } : {}),
+    };
 }
 
 export function mediaBlockWithKind(block: EditorMediaBlock, kind: EditorMediaKind): EditorMediaBlock {

--- a/OZprivate/rawJS/TourEditor/src/parse.ts
+++ b/OZprivate/rawJS/TourEditor/src/parse.ts
@@ -110,6 +110,8 @@ function parseStop(value: unknown, index: number): EditorTourStop {
     const tdata = isRecord(value.template_data) ? value.template_data : {};
     const { fillScreen, highlights } = parseQsOpts(value.qs_opts);
     const stopWaitMs = optionalFiniteNumber(value.stop_wait);
+    const comment = asString(value.comment);
+    const templateComment = asString(tdata.comment);
 
     return {
         id: newEditorId(),
@@ -125,6 +127,8 @@ function parseStop(value: unknown, index: number): EditorTourStop {
         flyInSpeed: asFiniteNumber(value.fly_in_speed, 1),
         autoAdvance: stopWaitMs !== undefined,
         stopWaitSeconds: stopWaitMs !== undefined ? stopWaitMs / 1000 : 5,
+        ...(comment ? { comment } : {}),
+        ...(templateComment ? { templateComment } : {}),
     };
 }
 

--- a/OZprivate/rawJS/TourEditor/src/parse.ts
+++ b/OZprivate/rawJS/TourEditor/src/parse.ts
@@ -201,17 +201,39 @@ function parseMediaList(value: unknown, stopIdentifier: string): EditorMediaBloc
 function parseProductionMedia(value: unknown, label: string): EditorMediaBlock | null {
     let url = '';
     let visibility: PhaseSelection | undefined;
+    let ts_autoplay: string | null | undefined;
+    let alt: string | undefined;
+    let title: string | undefined;
     if (typeof value === 'string') {
         url = value;
     } else if (isRecord(value)) {
         url = asString(value.url);
         visibility = parseContentVisibility(value);
+        ts_autoplay = parseTsAutoplay(value.ts_autoplay);
+        alt = optionalNonEmptyString(value.alt);
+        title = optionalNonEmptyString(value.title);
     } else {
         throw new TourParseError(`${label} is not valid.`);
     }
     if (!url) return null;
     const parsed = parseMediaUrl(url);
-    return mediaBlockFromFields(parsed || { kind: 'link', url }, { id: newEditorId(), visibility });
+    return mediaBlockFromFields(parsed || { kind: 'link', url }, {
+        id: newEditorId(),
+        visibility,
+        ts_autoplay,
+        alt,
+        title,
+    });
+}
+
+function parseTsAutoplay(value: unknown): string | null | undefined {
+    if (value === null) return null;
+    if (typeof value === 'string') return value;
+    return undefined;
+}
+
+function optionalNonEmptyString(value: unknown): string | undefined {
+    return typeof value === 'string' && value.length > 0 ? value : undefined;
 }
 
 function parseThumbnail(value: unknown): EditorThumbnailMedia {

--- a/OZprivate/rawJS/TourEditor/src/parse.ts
+++ b/OZprivate/rawJS/TourEditor/src/parse.ts
@@ -51,7 +51,8 @@ export function parseEditorTour(json: unknown, filename?: string): EditorTour {
         throw new TourParseError('Tour file is missing stops.');
     }
 
-    const stops = json.tourstops.map((stop, index) => parseStop(stop, index));
+    const stops = flattenSharedTourstops(json.tourstops, json.tourstop_shared)
+        .map((stop, index) => parseStop(stop, index));
     const identifiers = new Set<string>();
     for (const stop of stops) {
         if (identifiers.has(stop.identifier)) {
@@ -69,6 +70,32 @@ export function parseEditorTour(json: unknown, filename?: string): EditorTour {
         thumbnail: parseThumbnail(json.image_url),
         stops,
     };
+}
+
+/**
+ * Merge ``tourstop_shared`` into each stop, matching ``controllers/tour.py``:
+ * shared fields first, then the stop, with ``template_data`` merged the same way.
+ */
+function flattenSharedTourstops(tourstops: unknown[], shared: unknown): unknown[] {
+    if (shared === undefined) return tourstops;
+    if (!isRecord(shared)) {
+        throw new TourParseError('Tour file has invalid shared stop data.');
+    }
+    if (shared.template_data !== undefined && !isRecord(shared.template_data)) {
+        throw new TourParseError('Tour file has invalid shared stop data.');
+    }
+    const sharedTemplate = isRecord(shared.template_data) ? shared.template_data : {};
+    return tourstops.map((stop) => {
+        if (!isRecord(stop)) return stop;
+        const stopTemplate = stop.template_data;
+        return {
+            ...shared,
+            ...stop,
+            template_data: isRecord(stopTemplate)
+                ? { ...sharedTemplate, ...stopTemplate }
+                : (stopTemplate !== undefined ? stopTemplate : { ...sharedTemplate }),
+        };
+    });
 }
 
 function parseStop(value: unknown, index: number): EditorTourStop {

--- a/OZprivate/rawJS/TourEditor/src/parse.ts
+++ b/OZprivate/rawJS/TourEditor/src/parse.ts
@@ -17,6 +17,7 @@ import {
     type EditorTour,
     type EditorTourStop,
     type Pinpoint,
+    type QueryStringPair,
     type TourLicense,
     type TransitionIn,
 } from './types';
@@ -108,7 +109,7 @@ function parseStop(value: unknown, index: number): EditorTourStop {
         throw new TourParseError(`Stop ${identifier} is not valid.`);
     }
     const tdata = isRecord(value.template_data) ? value.template_data : {};
-    const { fillScreen, highlights } = parseQsOpts(value.qs_opts);
+    const { fillScreen, highlights, extraQueryStrings } = parseQsOpts(value.qs_opts);
     const stopWaitMs = optionalFiniteNumber(value.stop_wait);
     const comment = asString(value.comment);
     const templateComment = asString(tdata.comment);
@@ -120,6 +121,7 @@ function parseStop(value: unknown, index: number): EditorTourStop {
         location: parseOtt(value.ott),
         fillScreen,
         highlights,
+        extraQueryStrings,
         textBlocks: parseWindowText(tdata.window_text, identifier),
         mediaBlocks: parseMediaList(tdata.media, identifier),
         visibility: parseStopVisibility(tdata),
@@ -132,29 +134,44 @@ function parseStop(value: unknown, index: number): EditorTourStop {
     };
 }
 
-function parseQsOpts(value: unknown): { fillScreen: boolean; highlights: EditorHighlight[] } {
+function parseQsOpts(value: unknown): {
+    fillScreen: boolean;
+    highlights: EditorHighlight[];
+    extraQueryStrings: QueryStringPair[];
+} {
     if (typeof value !== 'string' || !value) {
-        return { fillScreen: false, highlights: [] };
+        return { fillScreen: false, highlights: [], extraQueryStrings: [] };
     }
     const highlights: EditorHighlight[] = [];
+    const extraQueryStrings: QueryStringPair[] = [];
+    let fillScreen = false;
     for (const part of value.replace(/^\?/, '').split('&')) {
-        if (!part.startsWith('highlight=')) continue;
-        let highlightStr = part.slice('highlight='.length);
-        try {
-            highlightStr = decodeURIComponent(highlightStr);
-        } catch {
-            // Keep the raw value if it is not valid URI encoding.
+        if (!part) continue;
+        const eq = part.indexOf('=');
+        const key = decodeQueryPart(eq === -1 ? part : part.slice(0, eq));
+        const raw = decodeQueryPart(eq === -1 ? '' : part.slice(eq + 1));
+        if (key === 'into_node' && raw === 'max') {
+            fillScreen = true;
+            continue;
         }
-        if (!highlightStr) continue;
-        const highlight = fromHighlightStr(highlightStr);
-        if (highlight && highlight.pinpoints.length > 0) {
-            highlights.push(highlight);
+        if (key === 'highlight') {
+            const highlight = fromHighlightStr(raw);
+            if (highlight && highlight.pinpoints.length > 0) {
+                highlights.push(highlight);
+                continue;
+            }
         }
+        extraQueryStrings.push({ key, value: raw });
     }
-    return {
-        fillScreen: value.includes('into_node=max'),
-        highlights,
-    };
+    return { fillScreen, highlights, extraQueryStrings };
+}
+
+function decodeQueryPart(value: string): string {
+    try {
+        return decodeURIComponent(value);
+    } catch {
+        return value;
+    }
 }
 
 function parseWindowText(value: unknown, stopIdentifier: string): EditorTextBlock[] {

--- a/OZprivate/rawJS/TourEditor/src/tour.ts
+++ b/OZprivate/rawJS/TourEditor/src/tour.ts
@@ -72,6 +72,7 @@ export function createEmptyStop(existingStops: EditorTourStop[] = []): EditorTou
         location: null,
         fillScreen: false,
         highlights: [],
+        extraQueryStrings: [],
         textBlocks: [],
         mediaBlocks: [],
         visibility: defaultStopVisibility,

--- a/OZprivate/rawJS/TourEditor/src/tour.ts
+++ b/OZprivate/rawJS/TourEditor/src/tour.ts
@@ -6,10 +6,31 @@ import type {
 } from './types';
 import { defaultStopVisibility } from './stopVisibility';
 
-export const LICENSE_OPTIONS: { value: TourLicense; label: string }[] = [
-    { value: 'all-rights-reserved', label: 'All rights reserved' },
-    { value: 'cc-by-4.0', label: 'CC BY 4.0' },
-    { value: 'cc0-1.0', label: 'CC0 1.0' },
+export interface LicenseOption {
+    value: TourLicense;
+    label: string;
+    description: string;
+    infoUrl?: string;
+}
+
+export const LICENSE_OPTIONS: LicenseOption[] = [
+    {
+        value: 'all-rights-reserved',
+        label: 'All rights reserved',
+        description: 'You retain full copyright. Others may not copy, distribute, or reuse this tour without your permission.',
+    },
+    {
+        value: 'cc-by-4.0',
+        label: 'CC BY 4.0',
+        description: 'Others may share and adapt this tour for any purpose, including commercially, as long as they give you appropriate credit.',
+        infoUrl: 'https://creativecommons.org/licenses/by/4.0/',
+    },
+    {
+        value: 'cc0-1.0',
+        label: 'CC0 1.0',
+        description: 'You waive copyright and related rights. This tour is dedicated to the public domain and may be used freely without permission or attribution.',
+        infoUrl: 'https://creativecommons.org/publicdomain/zero/1.0/',
+    },
 ];
 
 export const DEFAULT_LICENSE: TourLicense = 'all-rights-reserved';

--- a/OZprivate/rawJS/TourEditor/src/types.ts
+++ b/OZprivate/rawJS/TourEditor/src/types.ts
@@ -66,6 +66,10 @@ export interface EditorTextBlock {
 interface EditorMediaBlockBase {
     id: string;
     visibility?: PhaseSelection;
+    // Some fields just need to survive the round-trip, no UI:
+    ts_autoplay?: string | null;
+    alt?: string;
+    title?: string;
 }
 
 /** OneZoom image: ``imgsrc:{src}:{srcId}``. ``src`` is a ``src_flags`` value, e.g. 99 for ``eol_old``. */
@@ -141,7 +145,8 @@ export type EditorThumbnailKind = 'onezoom' | 'image';
 export type EditorThumbnailMedia = Extract<EditorMediaBlock, { kind: EditorThumbnailKind }>;
 
 type DistributiveOmit<T, K extends PropertyKey> = T extends unknown ? Omit<T, K> : never;
-export type EditorMediaSource = DistributiveOmit<EditorMediaBlock, 'id' | 'visibility'>;
+export type EditorMediaNonSourceKey = 'id' | 'visibility' | 'ts_autoplay' | 'alt' | 'title';
+export type EditorMediaSource = DistributiveOmit<EditorMediaBlock, EditorMediaNonSourceKey>;
 
 export interface EditorTour {
     identifier: string;

--- a/OZprivate/rawJS/TourEditor/src/types.ts
+++ b/OZprivate/rawJS/TourEditor/src/types.ts
@@ -167,6 +167,9 @@ export interface EditorTourStop {
     flyInSpeed: number;
     autoAdvance: boolean;
     stopWaitSeconds: number;
+    // Some fields just need to survive the round-trip, no UI:
+    comment?: string;
+    templateComment?: string;
 }
 
 export const DEFAULT_HIGHLIGHT_COLOR = '#ff6b6b';

--- a/OZprivate/rawJS/TourEditor/src/types.ts
+++ b/OZprivate/rawJS/TourEditor/src/types.ts
@@ -153,6 +153,12 @@ export interface EditorTour {
     stops: EditorTourStop[];
 }
 
+/** A ``qs_opts`` key/value the editor does not model, kept for round-trip. */
+export interface QueryStringPair {
+    key: string;
+    value: string;
+}
+
 export interface EditorTourStop {
     id: string;
     identifier: string;
@@ -170,6 +176,7 @@ export interface EditorTourStop {
     // Some fields just need to survive the round-trip, no UI:
     comment?: string;
     templateComment?: string;
+    extraQueryStrings: QueryStringPair[];
 }
 
 export const DEFAULT_HIGHLIGHT_COLOR = '#ff6b6b';

--- a/OZprivate/rawJS/TourEditor/tests/test_compile.js
+++ b/OZprivate/rawJS/TourEditor/tests/test_compile.js
@@ -134,6 +134,21 @@ test('editorTourToJson: writes a direct image thumbnail', (t) => {
     t.end();
 });
 
+test('editorTourToJson: writes extraQueryStrings into qs_opts', (t) => {
+    const json = editorTourToJson(tour({
+        stops: [stop({
+            identifier: 'cats',
+            fillScreen: true,
+            extraQueryStrings: [
+                { key: 'cols', value: 'popularity' },
+                { key: 'pop', value: 'ol_329457' },
+            ],
+        })],
+    }));
+    t.equal(json.tourstops[0].qs_opts, '?into_node=max&cols=popularity&pop=ol_329457');
+    t.end();
+});
+
 test('editorTourToJson: omits defaults and empty location', (t) => {
     const json = editorTourToJson(tour({
         stops: [stop({ identifier: 'empty' })],

--- a/OZprivate/rawJS/TourEditor/tests/test_compile.js
+++ b/OZprivate/rawJS/TourEditor/tests/test_compile.js
@@ -134,6 +134,29 @@ test('editorTourToJson: writes a direct image thumbnail', (t) => {
     t.end();
 });
 
+test('editorTourToJson: writes media embed extras', (t) => {
+    const json = editorTourToJson(tour({
+        stops: [stop({
+            identifier: 'cats',
+            mediaBlocks: [{
+                id: 'm1',
+                kind: 'image',
+                url: 'https://example.com/cat.jpg',
+                ts_autoplay: 'tsstate-transition_in tsstate-active_wait',
+                alt: 'A cat',
+                title: 'Cat photo',
+            }],
+        })],
+    }));
+    t.deepEqual(json.tourstops[0].template_data.media, [{
+        url: 'https://example.com/cat.jpg',
+        ts_autoplay: 'tsstate-transition_in tsstate-active_wait',
+        alt: 'A cat',
+        title: 'Cat photo',
+    }]);
+    t.end();
+});
+
 test('editorTourToJson: writes extraQueryStrings into qs_opts', (t) => {
     const json = editorTourToJson(tour({
         stops: [stop({
@@ -374,6 +397,29 @@ test('tourJsonToHtml: window_text visibility classes', (t) => {
     t.match(html, /<div class="window_text">Always<\/div>/);
     t.match(html, /<div class="window_text visible-transition_in">Fly in<\/div>/);
     t.match(html, /<div class="window_text visible-active_wait">Wait<\/div>/);
+    t.end();
+});
+
+test('tourJsonToHtml: media ts_autoplay, alt, and title', (t) => {
+    const html = tourJsonToHtml({
+        title: '',
+        description: '',
+        author: '',
+        tourstops: [{
+            identifier: 's',
+            template_data: {
+                media: [{
+                    url: 'https://commons.wikimedia.org/wiki/File:Rose_of_Jericho.gif',
+                    ts_autoplay: 'tsstate-transition_in tsstate-active_wait',
+                    alt: 'A resurrection plant',
+                    title: 'Rose of Jericho',
+                }],
+            },
+        }],
+    });
+    t.match(html, /data-ts_autoplay="tsstate-transition_in tsstate-active_wait"/);
+    t.match(html, /alt="A resurrection plant"/);
+    t.match(html, /title="Rose of Jericho"/);
     t.end();
 });
 

--- a/OZprivate/rawJS/TourEditor/tests/test_compile.js
+++ b/OZprivate/rawJS/TourEditor/tests/test_compile.js
@@ -79,6 +79,8 @@ test('editorTourToJson: maps stop fields to production JSON', (t) => {
                 flyInSpeed: 2,
                 autoAdvance: true,
                 stopWaitSeconds: 5,
+                comment: 'needs a nicer photo',
+                templateComment: 'this sound should autoplay',
             }),
             stop({
                 identifier: 'dogs',
@@ -94,8 +96,10 @@ test('editorTourToJson: maps stop fields to production JSON', (t) => {
         transition_in: 'leap',
         fly_in_speed: 2,
         stop_wait: 5000,
+        comment: 'needs a nicer photo',
         template_data: {
             title: 'Cats',
+            comment: 'this sound should autoplay',
             window_text: ['Look at cats', 'And more cats'],
             media: [
                 'https://www.youtube.com/embed/W86cTIoMv2U',

--- a/OZprivate/rawJS/TourEditor/tests/test_parse.js
+++ b/OZprivate/rawJS/TourEditor/tests/test_parse.js
@@ -348,6 +348,70 @@ test('parseEditorTour: round-trips extraQueryStrings', (t) => {
     t.end();
 });
 
+test('parseEditorTour: reads ts_autoplay, alt, and title', (t) => {
+    const loaded = parseEditorTour({
+        identifier: 'demo',
+        tourstops: [{
+            identifier: 'cats',
+            template_data: {
+                media: [{
+                    url: 'https://commons.wikimedia.org/wiki/File:Turdus_philomelos.ogg',
+                    ts_autoplay: 'tsstate-transition_in tsstate-active_wait',
+                    alt: 'Song thrush',
+                    title: 'Turdus philomelos.ogg',
+                }],
+            },
+        }],
+    });
+    t.equal(loaded.stops[0].mediaBlocks[0].ts_autoplay, 'tsstate-transition_in tsstate-active_wait');
+    t.equal(loaded.stops[0].mediaBlocks[0].alt, 'Song thrush');
+    t.equal(loaded.stops[0].mediaBlocks[0].title, 'Turdus philomelos.ogg');
+    t.end();
+});
+
+test('parseEditorTour: round-trips ts_autoplay, alt, and title', (t) => {
+    const original = tour({
+        identifier: 'demo',
+        stops: [stop({
+            identifier: 'cats',
+            mediaBlocks: [{
+                id: 'm1',
+                kind: 'wikimedia',
+                filename: 'Turdus_philomelos.ogg',
+                ts_autoplay: 'tsstate-transition_in tsstate-active_wait',
+                alt: 'Song thrush',
+                title: 'Turdus philomelos.ogg',
+            }, {
+                id: 'm2',
+                kind: 'image',
+                url: 'https://example.com/quiet.jpg',
+                ts_autoplay: null,
+            }],
+        })],
+    });
+    const json = editorTourToJson(original);
+    t.deepEqual(json.tourstops[0].template_data.media, [
+        {
+            url: 'https://commons.wikimedia.org/wiki/File:Turdus_philomelos.ogg',
+            ts_autoplay: 'tsstate-transition_in tsstate-active_wait',
+            alt: 'Song thrush',
+            title: 'Turdus philomelos.ogg',
+        },
+        {
+            url: 'https://example.com/quiet.jpg',
+            ts_autoplay: null,
+        },
+    ]);
+
+    const loaded = parseEditorTour(json);
+    t.equal(loaded.stops[0].mediaBlocks[0].ts_autoplay, 'tsstate-transition_in tsstate-active_wait');
+    t.equal(loaded.stops[0].mediaBlocks[0].alt, 'Song thrush');
+    t.equal(loaded.stops[0].mediaBlocks[0].title, 'Turdus philomelos.ogg');
+    t.equal(loaded.stops[0].mediaBlocks[1].ts_autoplay, null);
+    t.deepEqual(editorTourToJson(loaded), json);
+    t.end();
+});
+
 test('parseEditorTour: retains both stop and template_data comments', (t) => {
     const original = tour({
         identifier: 'demo',

--- a/OZprivate/rawJS/TourEditor/tests/test_parse.js
+++ b/OZprivate/rawJS/TourEditor/tests/test_parse.js
@@ -56,6 +56,7 @@ function completeTour() {
                 flyInSpeed: 2,
                 autoAdvance: true,
                 stopWaitSeconds: 5,
+                comment: 'needs a nicer photo',
             }),
         ],
     });
@@ -81,6 +82,7 @@ test('parseEditorTour: round-trips compiled production JSON', (t) => {
     t.equal(loaded.stops[0].flyInSpeed, 2);
     t.equal(loaded.stops[0].autoAdvance, true);
     t.equal(loaded.stops[0].stopWaitSeconds, 5);
+    t.equal(loaded.stops[0].comment, 'needs a nicer photo');
     t.ok(loaded.stops[0].id);
     t.ok(loaded.thumbnail.id);
     t.end();
@@ -296,6 +298,26 @@ test('parseEditorTour: flattens tourstop_shared into every stop', (t) => {
     t.deepEqual(loaded.stops[1].visibility, {
         transitionIn: true, active: true, transitionOut: false,
     });
+    t.end();
+});
+
+test('parseEditorTour: retains both stop and template_data comments', (t) => {
+    const original = tour({
+        identifier: 'demo',
+        stops: [stop({
+            identifier: 'cats',
+            comment: 'stop comment',
+            templateComment: 'template comment',
+        })],
+    });
+    const json = editorTourToJson(original);
+    t.equal(json.tourstops[0].comment, 'stop comment');
+    t.equal(json.tourstops[0].template_data.comment, 'template comment');
+
+    const loaded = parseEditorTour(json);
+    t.equal(loaded.stops[0].comment, 'stop comment');
+    t.equal(loaded.stops[0].templateComment, 'template comment');
+    t.deepEqual(editorTourToJson(loaded), json);
     t.end();
 });
 

--- a/OZprivate/rawJS/TourEditor/tests/test_parse.js
+++ b/OZprivate/rawJS/TourEditor/tests/test_parse.js
@@ -246,6 +246,67 @@ test('parseEditorTour: round-trips media visibility flags against a visible-in s
     t.end();
 });
 
+test('parseEditorTour: flattens tourstop_shared into every stop', (t) => {
+    const loaded = parseEditorTour({
+        identifier: 'demo',
+        tourstop_shared: {
+            transition_in: 'leap',
+            fly_in_speed: 2,
+            qs_opts: '?into_node=max',
+            template_data: {
+                title: 'Shared title',
+                window_text: ['Shared text'],
+                media: ['https://www.youtube.com/embed/W86cTIoMv2U'],
+                'visible-transition_in': true,
+            },
+        },
+        tourstops: [
+            { identifier: 'cats', ott: '@Felidae' },
+            {
+                identifier: 'dogs',
+                ott: '@Canidae',
+                transition_in: 'fly_straight',
+                qs_opts: '?highlight=fan:#00aa00@Canidae',
+                template_data: {
+                    title: 'Dogs',
+                    window_text: ['Dogs text'],
+                },
+            },
+        ],
+    });
+    t.equal(loaded.stops[0].title, 'Shared title');
+    t.equal(loaded.stops[0].location, '@Felidae');
+    t.equal(loaded.stops[0].fillScreen, true);
+    t.equal(loaded.stops[0].transitionIn, 'leap');
+    t.equal(loaded.stops[0].flyInSpeed, 2);
+    t.equal(loaded.stops[0].textBlocks[0].text, 'Shared text');
+    t.equal(loaded.stops[0].mediaBlocks[0].kind, 'youtube');
+    t.deepEqual(loaded.stops[0].visibility, {
+        transitionIn: true, active: true, transitionOut: false,
+    });
+    t.equal(loaded.stops[1].title, 'Dogs');
+    t.equal(loaded.stops[1].location, '@Canidae');
+    t.equal(loaded.stops[1].fillScreen, false);
+    t.equal(loaded.stops[1].transitionIn, 'fly_straight');
+    t.equal(loaded.stops[1].flyInSpeed, 2);
+    t.equal(loaded.stops[1].textBlocks[0].text, 'Dogs text');
+    t.equal(loaded.stops[1].mediaBlocks[0].kind, 'youtube');
+    t.equal(loaded.stops[1].highlights[0].type, 'fan');
+    t.deepEqual(loaded.stops[1].highlights[0].pinpoints, ['@Canidae']);
+    t.deepEqual(loaded.stops[1].visibility, {
+        transitionIn: true, active: true, transitionOut: false,
+    });
+    t.end();
+});
+
+test('parseEditorTour: rejects invalid tourstop_shared', (t) => {
+    t.throws(
+        () => parseEditorTour({ tourstop_shared: [], tourstops: [] }),
+        /invalid shared stop data/,
+    );
+    t.end();
+});
+
 test('parseEditorTour: rejects a tour without stops', (t) => {
     t.throws(() => parseEditorTour({ title: 'Nope' }), /missing stops/);
     t.end();

--- a/OZprivate/rawJS/TourEditor/tests/test_parse.js
+++ b/OZprivate/rawJS/TourEditor/tests/test_parse.js
@@ -168,6 +168,7 @@ test('parseEditorTour: reads window_text, media objects, and qs_opts', (t) => {
     t.equal(loaded.thumbnail.src, 99);
     t.equal(loaded.thumbnail.srcId, 27732437);
     t.equal(loaded.stops[0].fillScreen, true);
+    t.deepEqual(loaded.stops[0].extraQueryStrings, []);
     t.equal(loaded.stops[0].autoAdvance, true);
     t.equal(loaded.stops[0].stopWaitSeconds, 2.5);
     t.deepEqual(loaded.stops[0].highlights[0].pinpoints, ['@Felidae', '@Canidae']);
@@ -298,6 +299,52 @@ test('parseEditorTour: flattens tourstop_shared into every stop', (t) => {
     t.deepEqual(loaded.stops[1].visibility, {
         transitionIn: true, active: true, transitionOut: false,
     });
+    t.end();
+});
+
+test('parseEditorTour: keeps unparsed qs_opts as extraQueryStrings', (t) => {
+    const loaded = parseEditorTour({
+        identifier: 'demo',
+        tourstops: [{
+            identifier: 'cats',
+            qs_opts: '?cols=popularity&highlight=&into_node=max&highlight=fan:#00aa00@Felidae&pop=ol_329457',
+            template_data: {},
+        }],
+    });
+    t.equal(loaded.stops[0].fillScreen, true);
+    t.equal(loaded.stops[0].highlights.length, 1);
+    t.deepEqual(loaded.stops[0].highlights[0].pinpoints, ['@Felidae']);
+    t.deepEqual(loaded.stops[0].extraQueryStrings, [
+        { key: 'cols', value: 'popularity' },
+        { key: 'highlight', value: '' },
+        { key: 'pop', value: 'ol_329457' },
+    ]);
+
+    const json = editorTourToJson(loaded);
+    t.equal(
+        json.tourstops[0].qs_opts,
+        '?into_node=max&highlight=fan:#00aa00@Felidae&cols=popularity&highlight=&pop=ol_329457',
+    );
+    t.end();
+});
+
+test('parseEditorTour: round-trips extraQueryStrings', (t) => {
+    const original = tour({
+        identifier: 'demo',
+        stops: [stop({
+            identifier: 'cats',
+            extraQueryStrings: [
+                { key: 'cols', value: 'popularity' },
+                { key: 'highlight', value: '' },
+            ],
+        })],
+    });
+    const json = editorTourToJson(original);
+    t.equal(json.tourstops[0].qs_opts, '?cols=popularity&highlight=');
+
+    const loaded = parseEditorTour(json);
+    t.deepEqual(loaded.stops[0].extraQueryStrings, original.stops[0].extraQueryStrings);
+    t.deepEqual(editorTourToJson(loaded), json);
     t.end();
 });
 

--- a/views/tour/list.html
+++ b/views/tour/list.html
@@ -21,6 +21,7 @@
               width="150" height="150"
               alt="" style="position: absolute; left: 0; border: 1px solid #242A22; border-radius: 10px" />
           <h3 style="margin: 0">{{=tour.title}}</h3>
+          {{if tour.author:}}<p class="uk-text-meta" style="margin: 0">{{=tour.author}}</p>{{pass}}
           <p class="uk-flex-auto">{{=tour.description}}</p>
           <progress value="10" max="100">10 %</progress>
       </a>


### PR DESCRIPTION
Closes #1062, #1064, #1061 

We're now respecting tourstop_shared from the imported JSON (though flattening it, not retaining it)
We're now retaining comments, autoplay settings, and additional query string options. These are things that aren't in the editor UI, they're just being kept if they're already in the JSON you import.