### PR TITLE
Cloudflare pages

### DIFF
--- a/OZprivate/rawJS/OZTreeModule/src/global_config.js
+++ b/OZprivate/rawJS/OZTreeModule/src/global_config.js
@@ -61,6 +61,8 @@ config.api = {
   abort_request_threshold: 30000, //timeout for ajax call
   max_concurrent_request: 3,
 
+  user_login: null,
+
   image_details_api: null,
 
   tourstop_page: null,

--- a/OZprivate/rawJS/OZTreeModule/src/tour/Tour.js
+++ b/OZprivate/rawJS/OZTreeModule/src/tour/Tour.js
@@ -65,6 +65,7 @@ import TourStopClass from './TourStop'
 import tree_state from '../tree_state';
 import { add_hook, remove_hook } from '../util';
 import { resolve_pinpoints } from '../navigation/pinpoint';
+import config from '../global_config';
 
 const Interaction_Action_Arr = ['mouse_down', 'mouse_wheel', 'touch_start', 'touch_move', 'touch_end']
 
@@ -74,6 +75,51 @@ const tstate = {
   PLAYING: 'tstate-playing',
   PAUSED: 'tstate-paused',
 };
+
+/** Login page, returning to the current tree URL afterwards. */
+function tour_login_url(tour_setting) {
+  const base = (config.api && config.api.user_login) || '/default/user/login';
+  const loc = new URL(window.location.href);
+  // The address bar drops ?tour= while the tour is still loading / inactive.
+  if (tour_setting) loc.searchParams.set('tour', tour_setting);
+  const next = loc.pathname + loc.search + loc.hash;
+  const sep = base.indexOf('?') >= 0 ? '&' : '?';
+  return base + sep + '_next=' + encodeURIComponent(next);
+}
+
+/**
+ * User-facing copy for a failed tour HTML fetch, as a DOM node.
+ * A 403 is treated as "not logged in" (see ``controllers/tour.py`` ``remote``).
+ */
+function tour_fetch_error_el(jqXHR, tour_setting) {
+  const el = document.createElement('div');
+  if (jqXHR && jqXHR.status === 403) {
+    const href = tour_login_url(tour_setting);
+    const a = document.createElement('a');
+    a.href = href;
+    a.textContent = 'Log in';
+    el.appendChild(a);
+    el.appendChild(document.createTextNode(' to play this tour'));
+    return el;
+  }
+  const text = ((jqXHR && jqXHR.responseText) || '').trim();
+  el.textContent = text && !text.startsWith('<')
+    ? text
+    : (jqXHR && jqXHR.status
+      ? 'The server could not load this tour (error ' + jqXHR.status + ').'
+      : 'The server could not load this tour.');
+  return el;
+}
+
+export function report_tour_fetch_error(jqXHR, tour_setting) {
+  console.error('Failed to fetch tour:', jqXHR);
+  const el = tour_fetch_error_el(jqXHR, tour_setting);
+  if (window.UIkit && window.UIkit.modal) {
+    window.UIkit.modal.alert(el.innerHTML);
+  } else {
+    alert(el.textContent);
+  }
+}
 
 class Tour {
   constructor(onezoom) {
@@ -194,8 +240,11 @@ class Tour {
     this.ready_callback = ready_callback || (() => {});
     this.interaction_hooks = {} // when we add interaction hooks, we store the ids here so we can remove them later
 
-    var resolve_tour_loaded;
-    this.tour_loaded = new Promise((resolve) => resolve_tour_loaded = resolve).then(() => {
+    var resolve_tour_loaded, reject_tour_loaded;
+    this.tour_loaded = new Promise((resolve, reject) => {
+      resolve_tour_loaded = resolve;
+      reject_tour_loaded = reject;
+    }).then(() => {
       if (window.tour_trace) console.log("Loaded tour")
       return this.ready_callback();
     });
@@ -211,9 +260,13 @@ class Tour {
         this.tour_setting = tour_setting = m[1]
         tour_start_step = parseInt(m[2])
       }
-      return $.ajax({ url: tour_setting, dataType: "html", success: (s) => {
-        return this.load_tour_from_string(s, tour_start_step).then(resolve_tour_loaded);
-      }});
+      return $.ajax({ url: tour_setting, dataType: "html" }).then(
+        (s) => this.load_tour_from_string(s, tour_start_step).then(resolve_tour_loaded),
+        (jqXHR) => {
+          report_tour_fetch_error(jqXHR, this.tour_setting);
+          reject_tour_loaded(jqXHR);
+        },
+      );
     }
   }
 

--- a/OZprivate/rawJS/OZTreeModule/tests/test_tour_Tour.js
+++ b/OZprivate/rawJS/OZTreeModule/tests/test_tour_Tour.js
@@ -5,6 +5,85 @@ import test from 'tape';
 import { call_hook } from '../src/util';
 import { setup_tour } from './util_tourwrapper';
 import { getTimeoutValue, triggerTimeout } from './util_timeout';
+import Tour, { report_tour_fetch_error } from '../src/tour/Tour';
+import config from '../src/global_config';
+
+test('tour.fetch_error:403 has login link', function (test) {
+  var t = setup_tour(test, `<div class="tour"></div>`);
+  config.api.user_login = 'https://oz.example.com/default/user/login';
+  const origError = console.error;
+  const errors = [];
+  console.error = function () { errors.push(Array.from(arguments)); };
+  const htmls = [];
+  t.window.UIkit = { modal: { alert: function (html) { htmls.push(html); } } };
+  test.teardown(function () {
+    console.error = origError;
+    config.api.user_login = null;
+  });
+
+  return t.tour.tour_loaded.then(function () {
+    report_tour_fetch_error({ status: 403 }, '/tour/remote.html/tours/lava_lamps');
+    test.equal(errors[0][0], 'Failed to fetch tour:');
+    test.match(htmls[0], /<a href="https:\/\/oz.example.com\/default\/user\/login\?_next=/);
+    test.match(htmls[0], />Log in<\/a> to play this tour/);
+    test.match(htmls[0], /tour%3D/);
+    test.match(htmls[0], /lava_lamps/);
+    test.end();
+  });
+});
+
+test('tour.fetch_error:shows server message', function (test) {
+  var t = setup_tour(test, `<div class="tour"></div>`);
+
+  return t.tour.tour_loaded.then(function () {
+    report_tour_fetch_error({
+      status: 502,
+      responseText: 'Could not fetch tour JSON (403)',
+    });
+    report_tour_fetch_error({
+      status: 422,
+      responseText: 'filename must be a .json file <really>',
+    });
+    report_tour_fetch_error({
+      status: 500,
+      responseText: '<html>oops</html>',
+    });
+    const alerts = t.log.filter((x) => x[0] === 'alert').map((x) => x[1]);
+    test.equal(alerts[0], 'Could not fetch tour JSON (403)');
+    test.equal(alerts[1], 'filename must be a .json file <really>');
+    test.match(alerts[2], /error 500/);
+    test.end();
+  });
+});
+
+test('tour.setup_setting:fetch 403', function (test) {
+  var t = setup_tour(test, `<div class="tour"></div>`);
+  const origAjax = global.$.ajax;
+  const origError = console.error;
+  console.error = function () {};
+  global.$.ajax = function () {
+    return Promise.reject({ status: 403, responseText: 'Login required to preview a remote tour' });
+  };
+  if (t.window) t.window.$ = global.$;
+  test.teardown(function () {
+    if (global.$) global.$.ajax = origAjax;
+    console.error = origError;
+  });
+
+  return t.tour.tour_loaded.then(function () {
+    const tour = new Tour(t.oz);
+    tour.setup_setting('/tour/remote.html');
+    return tour.start().then(function () {
+      test.fail('Expected tour.start() to reject');
+      test.end();
+    }, function (err) {
+      test.equal(err.status, 403);
+      const alerts = t.log.filter((x) => x[0] === 'alert');
+      test.match(alerts[alerts.length - 1][1], /^Log in to play this tour$/);
+      test.end();
+    });
+  });
+});
 
 test('tour.start:notourstops', function (test) {
   var t = setup_tour(test, `<div class="tour">

--- a/OZprivate/rawJS/TourEditor/src/media.ts
+++ b/OZprivate/rawJS/TourEditor/src/media.ts
@@ -9,7 +9,7 @@ import type {
     EditorYoutubeMedia,
 } from './types';
 
-export const TOURS_URL_BASE = 'https://onezoom.github.io/tours/';
+export const TOURS_URL_BASE = 'https://tours.onezoom.workers.dev/';
 export const WIKIMEDIA_FILE_BASE = 'https://commons.wikimedia.org/wiki/File:';
 
 export const MEDIA_KIND_OPTIONS: { value: EditorMediaKind; label: string }[] = [
@@ -332,7 +332,10 @@ function uploadCommonsFileName(url: string): string | null {
 
 function parseTours(url: string): MediaSource<'tours'> | null {
     const absolute = url.match(
-        new RegExp(`^https://onezoom\\.github\\.io/tours/(.+\\.(?:${MEDIA_EXT}))$`, 'i'),
+        new RegExp(
+            `^https://(?:tours\\.onezoom\\.workers\\.dev|onezoom\\.github\\.io/tours)/(.+\\.(?:${MEDIA_EXT}))$`,
+            'i',
+        ),
     );
     if (absolute) return { kind: 'tours', path: absolute[1] };
     if (/^https?:\/\//i.test(url)) return null;

--- a/OZprivate/rawJS/TourEditor/src/types.ts
+++ b/OZprivate/rawJS/TourEditor/src/types.ts
@@ -105,7 +105,7 @@ export interface EditorWikimediaMedia extends EditorMediaBlockBase {
 }
 
 /**
- * Asset on ``https://onezoom.github.io/tours/{path}``.
+ * Asset on ``https://tours.onezoom.workers.dev/{path}``.
  * Extension determines if image, audio, or video, same as Wikimedia.
  */
 export interface EditorToursMedia extends EditorMediaBlockBase {

--- a/OZprivate/rawJS/TourEditor/tests/test_media.js
+++ b/OZprivate/rawJS/TourEditor/tests/test_media.js
@@ -73,6 +73,10 @@ test('parseMediaUrl: Wikimedia, tours, image, audio', (t) => {
         { kind: 'wikimedia', filename: 'Sommieria_leucophylla.jpg' },
     );
     t.deepEqual(
+        parseMediaUrl('https://tours.onezoom.workers.dev/frogs/Various_frogs_and_toads.jpeg'),
+        { kind: 'tours', path: 'frogs/Various_frogs_and_toads.jpeg' },
+    );
+    t.deepEqual(
         parseMediaUrl('https://onezoom.github.io/tours/frogs/Various_frogs_and_toads.jpeg'),
         { kind: 'tours', path: 'frogs/Various_frogs_and_toads.jpeg' },
     );

--- a/controllers/tour.py
+++ b/controllers/tour.py
@@ -70,7 +70,7 @@ media
             "frogs/Various_frogs_and_toads.jpeg"
         ],
 
-    In the final case, the URL will be expanded to "https://onezoom.github.io/tours/frogs/Various_frogs_and_toads.jpeg".
+    In the final case, the URL will be expanded to "https://tours.onezoom.workers.dev/frogs/Various_frogs_and_toads.jpeg".
 
     By default media will autoplay when arriving at the tourstop, and stop when leaving. You can override with:
 

--- a/controllers/tour.py
+++ b/controllers/tour.py
@@ -11,6 +11,9 @@ OneZoom JSON tour definition
 
 A OneZoom tour can be defined as JSON, to then be inserted / fetched into the database via. ``/tour/data.html``.
 A document can also be rendered without saving it by POSTing it to ``/tour/preview.html``.
+A JSON file hosted on ``*.onezoom.workers.dev`` can be rendered the same way via
+``/tour/remote.html/<worker>/<file>`` (login required), e.g.
+``/tour/remote.html/test-tour-preview-tours/lava_lamps``.
 
 A library of tour documents is available at https://github.com/OneZoom/tours.
 
@@ -81,6 +84,11 @@ media
     When a media item is visible can be altered by setting ``"visible-transition_in": true``, the rules working the same as "window_text".
 
 """
+import json
+import posixpath
+import urllib.error
+import urllib.request
+
 from pymysql.err import IntegrityError
 
 from OZfunc import (
@@ -88,6 +96,7 @@ from OZfunc import (
     get_common_name, get_common_names,
     nice_name,
 )
+import embed
 import tour
 
 
@@ -122,7 +131,7 @@ def _with_table_defaults(table, doc):
 def _merged_tourstop(ts, ts_shared, **extra):
     """One tourstop document, with ``tourstop_shared`` and the DB defaults merged in.
 
-    Shared by ``data`` (before writing) and ``preview`` (before rendering), so that a
+    Shared by ``data`` (before writing) and ``preview`` / ``remote`` (before rendering), so that a
     tourstop resolves to the same values whether or not it was saved first.
     """
     return _with_table_defaults(db.tourstop, {
@@ -168,6 +177,72 @@ def _parse_tourstop_ott(ott, label):
         return int(ott_str), None
     except (TypeError, ValueError):
         raise HTTP(422, err)
+
+
+def _tour_from_document(doc):
+    """Build the tour dict ``views/tour/data.html`` expects, without touching the DB."""
+    tourstops = doc.get('tourstops') or []
+    if len(tourstops) == 0:
+        raise HTTP(422, "Must have at least one tourstop")
+    ts_shared = doc.get('tourstop_shared', {})
+
+    tour = _with_table_defaults(db.tour, doc)
+    tour['lang'] = doc.get('lang') or 'en'
+    tour['tourstops'] = []
+    for i, ts in enumerate(tourstops):
+        label = _tourstop_label(ts, i + 1)
+        try:
+            if 'symlink_tourstop' in ts:
+                raise ValueError("symlinks can only be resolved for a saved tour")
+            ts = _merged_tourstop(ts, ts_shared)
+            _parse_tourstop_ott(ts.get('ott'), label)
+            tour['tourstops'].append(ts)
+        except (AttributeError, TypeError, ValueError, KeyError) as e:
+            raise HTTP(422, "Tourstop %s: %s" % (label, e))
+    return tour
+
+
+def _tours_url_base_from_slug(slug):
+    """``https://{slug}.onezoom.workers.dev/`` from a single DNS label, or HTTP(422)."""
+    if not slug or not isinstance(slug, str):
+        raise HTTP(422, "Missing tours worker name")
+    slug = slug.strip()
+    if not slug.replace('-', '').isalnum():
+        raise HTTP(422, "tours worker name must contain only letters, digits, and hyphens")
+    return 'https://%s.onezoom.workers.dev/' % slug
+
+
+def _tours_json_url(tours_url_base, filename):
+    """Join a relative JSON path onto an already-validated tours base URL."""
+    if not filename or not isinstance(filename, str):
+        raise HTTP(422, "Missing filename")
+    rel = posixpath.normpath(filename.strip())
+    if posixpath.isabs(rel) or rel == '.' or rel == '..' or rel.startswith('../'):
+        raise HTTP(422, "filename must be relative to the tours worker")
+    return tours_url_base + rel + '.json'
+
+
+def _fetch_tour_json(url):
+    """GET (url) and parse it as a tour document object."""
+    # User agent required to pass Cloudflare Browser Integrity Check.
+    req = urllib.request.Request(url, headers={
+        'User-Agent': 'OneZoom/1.0 (+https://www.onezoom.org/)',
+    })
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            raw = resp.read()
+    except urllib.error.HTTPError as e:
+        raise HTTP(502, "Could not fetch tour JSON (%s): %s" % (e.code, url))
+    except urllib.error.URLError:
+        raise HTTP(502, "Could not fetch tour JSON: %s" % url)
+
+    try:
+        doc = json.loads(raw.decode('utf-8'))
+    except (ValueError, UnicodeDecodeError):
+        raise HTTP(422, "Tour document is not valid JSON: %s" % url)
+    if not isinstance(doc, dict):
+        raise HTTP(422, "Tour document must be a JSON object: %s" % url)
+    return doc
 
 
 def homepage_animation():
@@ -371,6 +446,7 @@ def data():
     return dict(
         tour_identifier=tour_identifier,
         tour=tour,
+        tours_url_base=embed.TOURS_URL_BASE,
     )
 
 
@@ -394,29 +470,41 @@ def preview():
         raise HTTP(415, "Tour document must be sent as application/json")
     session.forget(response)
 
-    tourstops = request.vars.get('tourstops') or []
-    if len(tourstops) == 0:
-        raise HTTP(422, "Must have at least one tourstop")
-    ts_shared = request.vars.get('tourstop_shared', {})
-
-    tour = _with_table_defaults(db.tour, request.vars)
-    tour['lang'] = request.vars.get('lang') or 'en'
-    tour['tourstops'] = []
-    for i, ts in enumerate(tourstops):
-        label = _tourstop_label(ts, i + 1)
-        try:
-            if 'symlink_tourstop' in ts:
-                raise ValueError("symlinks can only be resolved for a saved tour")
-            ts = _merged_tourstop(ts, ts_shared)
-            _parse_tourstop_ott(ts.get('ott'), label)
-            tour['tourstops'].append(ts)
-        except (AttributeError, TypeError, ValueError, KeyError) as e:
-            raise HTTP(422, "Tourstop %s: %s" % (label, e))
-
+    tour = _tour_from_document(request.vars)
     response.view = 'tour/data.html'
     return dict(
         tour_identifier=request.vars.get('identifier') or 'preview',
         tour=tour,
+        tours_url_base=embed.TOURS_URL_BASE,
+    )
+
+
+def remote():
+    """Render a tour JSON file hosted on ``*.onezoom.workers.dev``, without saving it
+
+    GET ``/tour/remote.html/<worker>/<file>``, the same URL shape as
+    ``/tour/data.html/<identifier>``. The JSON is fetched from
+    ``https://<worker>.onezoom.workers.dev/<file>.json`` and rendered with
+    ``views/tour/data.html``. Relative media paths are resolved against that worker.
+
+    Nested paths work as extra args, e.g. ``/tour/remote.html/tours/frogs/great_apes``.
+    Requires a logged-in user. Nothing is read from or written to the database.
+    """
+    auth.basic()
+    if not auth.user:
+        raise HTTP(403, "Login required to preview a remote tour")
+    if len(request.args) < 2:
+        raise HTTP(422, "Expect /tour/remote.html/<worker>/<file>")
+
+    tours_url_base = _tours_url_base_from_slug(request.args[0])
+    doc_url = _tours_json_url(tours_url_base, '/'.join(request.args[1:]))
+    tour = _tour_from_document(_fetch_tour_json(doc_url))
+
+    response.view = 'tour/data.html'
+    return dict(
+        tour_identifier=tour.get('identifier') or 'preview',
+        tour=tour,
+        tours_url_base=tours_url_base,
     )
 
 

--- a/modules/embed.py
+++ b/modules/embed.py
@@ -10,6 +10,9 @@ from gluon.utils import web2py_uuid
 
 import img
 
+# Canonical host for tour-bundled images/audio. Relative media paths are resolved against this.
+TOURS_URL_BASE = 'https://tours.onezoom.workers.dev/'
+
 def embedize_url(url, email):
     request = current.request
     db = current.db
@@ -130,28 +133,32 @@ def media_embed(url, defaults=dict()):
               {element_data}
               ></video><a class="copyright" href="{url}">©</a></div>""".format(**opts)
 
-    ############### Custom tours assets at https://onezoom.github.io/tours/
-    # Replace the media extension with .html to get a link to the copyright page
-    m = re.fullmatch(r'https://onezoom.github.io/tours/(.+)\.(gif|jpg|jpeg|png|svg|ogg|mp3|ogv|webm|mpg|mpeg)', opts['url'])
+    ############### Custom tours assets at https://tours.onezoom.workers.dev/
+    # Also recognise the former GitHub Pages host. Replace the media extension with
+    # .html to get a link to the copyright page on the same host.
+    m = re.fullmatch(
+        r'(https://(?:tours\.onezoom\.workers\.dev|onezoom\.github\.io/tours))/(.+)\.(gif|jpg|jpeg|png|svg|ogg|mp3|ogv|webm|mpg|mpeg)',
+        opts['url'],
+    )
     if m:
         if not opts.get('alt'):
-            opts['alt'] = humanise_url(m.group(1))
+            opts['alt'] = humanise_url(m.group(2))
         if not opts.get('title'):
-            opts['title'] = "%s.%s" % (m.group(1), m.group(2))
+            opts['title'] = "%s.%s" % (m.group(2), m.group(3))
         opts['src_url'] = opts['url']
-        opts['url'] = 'https://onezoom.github.io/tours/%s.html' % m.group(1)
+        opts['url'] = '%s/%s.html' % (m.group(1), m.group(2))
 
-        if m.group(2) in ('gif', 'jpg', 'jpeg', 'png', 'svg'):
+        if m.group(3) in ('gif', 'jpg', 'jpeg', 'png', 'svg'):
             return """<a class="embed-image{klass}" title="{title}" href="{url}" {element_data}><img
               src="{src_url}"
               alt="{alt}"
             /><span class="copyright">©</span></a>""".format(**opts)
-        if m.group(2) in ('ogg', 'mp3'):
+        if m.group(3) in ('ogg', 'mp3'):
             return """<div class="embed-audio{klass}"><audio controls
               src="{src_url}"
               {element_data}
               ></audio><a class="copyright" href="{url}">©</a></div>""".format(**opts)
-        if m.group(2) in ('ogv', 'webm', 'mpg', 'mpeg'):
+        if m.group(3) in ('ogv', 'webm', 'mpg', 'mpeg'):
             return """<div class="embed-video{klass}"><video controls
               src="{src_url}"
               {element_data}

--- a/modules/embed.py
+++ b/modules/embed.py
@@ -133,11 +133,11 @@ def media_embed(url, defaults=dict()):
               {element_data}
               ></video><a class="copyright" href="{url}">©</a></div>""".format(**opts)
 
-    ############### Custom tours assets at https://tours.onezoom.workers.dev/
+    ############### Custom tours assets at https://*.onezoom.workers.dev/
     # Also recognise the former GitHub Pages host. Replace the media extension with
     # .html to get a link to the copyright page on the same host.
     m = re.fullmatch(
-        r'(https://(?:tours\.onezoom\.workers\.dev|onezoom\.github\.io/tours))/(.+)\.(gif|jpg|jpeg|png|svg|ogg|mp3|ogv|webm|mpg|mpeg)',
+        r'(https://(?:(?:[a-z0-9-]+\.)*onezoom\.workers\.dev|onezoom\.github\.io/tours))/(.+)\.(gif|jpg|jpeg|png|svg|ogg|mp3|ogv|webm|mpg|mpeg)',
         opts['url'],
     )
     if m:

--- a/tests/unit/test_controllers_tour.py
+++ b/tests/unit/test_controllers_tour.py
@@ -3,10 +3,13 @@ Run with::
 
     grunt exec:test_server:test_controllers_tour.py
 """
+import json
 import unittest
+from unittest.mock import patch
 
 import applications.OZtree.controllers.tour as tour
 from applications.OZtree.tests.unit import util
+import embed
 
 from gluon import current
 from gluon.globals import Request, Session
@@ -185,6 +188,126 @@ class TestControllersTour(unittest.TestCase):
             'tourstops': [{'identifier': "felids", 'ott': 67819}],
         })
         self.assertEqual(out['tour_identifier'], 'ut_cats')
+
+    def test_preview_tours_url_base(self):
+        """Preview resolves relative media against the default tours CDN"""
+        out = self.tour_preview({
+            'tourstops': [{'identifier': "felids", 'ott': 67819}],
+        })
+        self.assertEqual(out['tours_url_base'], embed.TOURS_URL_BASE)
+
+    def _fake_urlopen(self, payload):
+        class _Resp:
+            def __init__(self, body):
+                self._body = body if isinstance(body, bytes) else body.encode('utf-8')
+            def read(self):
+                return self._body
+            def __enter__(self):
+                return self
+            def __exit__(self, *args):
+                return False
+
+        def urlopen(req, timeout=None):
+            url = req.full_url if hasattr(req, 'full_url') else req
+            urlopen.urls.append((url, timeout))
+            urlopen.reqs.append(req)
+            return _Resp(payload)
+        urlopen.urls = []
+        urlopen.reqs = []
+        return urlopen
+
+    def tour_remote(self, args, payload, username='admin'):
+        urlopen = self._fake_urlopen(
+            payload if isinstance(payload, (bytes, str)) else json.dumps(payload))
+        with patch.object(tour.urllib.request, 'urlopen', urlopen):
+            out = util.call_controller(
+                tour,
+                'remote',
+                method='GET',
+                args=args,
+                username=username,
+            )
+        self._last_remote_reqs = urlopen.reqs
+        return out, urlopen.urls
+
+    def test_remote_requires_login(self):
+        """Remote preview is only for logged-in users"""
+        with self.assertRaisesRegex(HTTP, r'403') as cm:
+            util.call_controller(
+                tour, 'remote', method='GET', args=['tours', 'cats'])
+        self.assertRegex(str(cm.exception.body), r'Login required')
+
+    def test_remote_rejects_untrusted_slug(self):
+        """Worker name must be letters, digits, and hyphens"""
+        one_stop = {'tourstops': [{'identifier': "felids", 'ott': 67819}]}
+
+        def reject(slug, filename='cats'):
+            with self.assertRaisesRegex(HTTP, r'422') as cm:
+                self.tour_remote([slug, filename], one_stop)
+            self.assertRegex(str(cm.exception.body), r'letters, digits, and hyphens')
+
+        reject('evil.com')
+        reject('onezoom.workers.dev.evil')
+        reject('has_underscore')
+
+    def test_remote_rejects_bad_path(self):
+        """File path must stay under the tours worker"""
+        one_stop = {'tourstops': [{'identifier': "felids", 'ott': 67819}]}
+
+        def reject(args):
+            with self.assertRaisesRegex(HTTP, r'422'):
+                self.tour_remote(args, one_stop)
+
+        reject(['tours'])
+        reject(['tours', '..', 'cats'])
+        reject(['tours', 'dir', '..', '..', 'cats'])
+        reject(['tours', ''])
+
+    def test_remote_fetches_and_renders(self):
+        """Fetched JSON renders like preview, with the given media base URL"""
+        tour_count = db(db.tour.identifier).count()
+        doc = {
+            'identifier': "ut_remote_cats",
+            'title': "A unit test tour",
+            'tourstops': [{
+                'identifier': "felids",
+                'ott': 67819,
+                'template_data': {'title': "Cats"},
+            }],
+        }
+        out, urls = self.tour_remote(['my-lovely-tour-tours', 'cats'], doc)
+
+        self.assertEqual(urls, [(
+            'https://my-lovely-tour-tours.onezoom.workers.dev/cats.json',
+            10,
+        )])
+        self.assertIn('OneZoom', self._last_remote_reqs[0].get_header('User-agent'))
+        self.assertEqual(out['tour_identifier'], 'ut_remote_cats')
+        self.assertEqual(
+            out['tours_url_base'],
+            'https://my-lovely-tour-tours.onezoom.workers.dev/',
+        )
+        self.assertEqual(out['tour']['title'], "A unit test tour")
+        self.assertEqual(out['tour']['tourstops'][0]['ott'], 67819)
+        self.assertEqual(out['tour']['tourstops'][0]['transition_in'], 'fly')
+        self.assertEqual(current.response.view, 'tour/data.html')
+        self.assertEqual(db(db.tour.identifier).count(), tour_count)
+
+        previewed = self.tour_preview(dict(doc))['tour']
+        self.assertEqual(out['tour']['tourstops'][0]['template_data'],
+                         previewed['tourstops'][0]['template_data'])
+
+    def test_remote_nested_filename(self):
+        """A filename can include a subdirectory under the tours worker"""
+        doc = {'tourstops': [{'identifier': "felids", 'ott': 67819}]}
+        out, urls = self.tour_remote(
+            ['tours', 'frogs', 'great_apes'],
+            doc,
+        )
+        self.assertEqual(urls[0][0],
+                         'https://tours.onezoom.workers.dev/frogs/great_apes.json')
+        self.assertEqual(out['tours_url_base'],
+                         'https://tours.onezoom.workers.dev/')
 
     def test_data_errors(self):
         """Error conditions handled appropriately?"""

--- a/tests/unit/test_modules_embed.py
+++ b/tests/unit/test_modules_embed.py
@@ -206,6 +206,26 @@ class TestEmbed(unittest.TestCase):
             'href="https://commons.wikimedia.org/wiki/File:Intense_bone_fluorescence_reveals_hidden_patterns_in_pumpkin_toadlets_-_video_1_-_41598_2019_41959_MOESM2_ESM.webm">©</a></div>',
         ])
 
+        self.assertEqual(media_embed('https://tours.onezoom.workers.dev/frogs/Various_frogs_and_toads.jpeg'), [
+            '<a',
+            'class="embed-image"',
+            'title="frogs/Various_frogs_and_toads.jpeg"',
+            'href="https://tours.onezoom.workers.dev/frogs/Various_frogs_and_toads.html"',
+            '><img',
+            'src="https://tours.onezoom.workers.dev/frogs/Various_frogs_and_toads.jpeg"',
+            'alt="Various',
+            'frogs',
+            'and',
+            'toads"',
+            '/><span',
+            'class="copyright">©</span></a>',
+        ])
+        # Can use a URL base
+        self.assertEqual(
+            media_embed('https://tours.onezoom.workers.dev/frogs/Various_frogs_and_toads.jpeg'),
+            media_embed('frogs/Various_frogs_and_toads.jpeg', defaults=dict(url_base=embed.TOURS_URL_BASE)),
+        )
+        # Former GitHub Pages host still embeds with a copyright page on that host
         self.assertEqual(media_embed('https://onezoom.github.io/tours/frogs/Various_frogs_and_toads.jpeg'), [
             '<a',
             'class="embed-image"',
@@ -220,11 +240,6 @@ class TestEmbed(unittest.TestCase):
             '/><span',
             'class="copyright">©</span></a>',
         ])
-        # Can use a URL base
-        self.assertEqual(
-            media_embed('https://onezoom.github.io/tours/frogs/Various_frogs_and_toads.jpeg'),
-            media_embed('frogs/Various_frogs_and_toads.jpeg', defaults=dict(url_base='https://onezoom.github.io/tours/')),
-        )
 
 if __name__ == '__main__':
     import sys

--- a/tests/unit/test_modules_embed.py
+++ b/tests/unit/test_modules_embed.py
@@ -225,6 +225,26 @@ class TestEmbed(unittest.TestCase):
             media_embed('https://tours.onezoom.workers.dev/frogs/Various_frogs_and_toads.jpeg'),
             media_embed('frogs/Various_frogs_and_toads.jpeg', defaults=dict(url_base=embed.TOURS_URL_BASE)),
         )
+        # Per-tour worker hosts get a copyright page on the same host
+        self.assertEqual(media_embed('https://my-lovely-tour-tours.onezoom.workers.dev/frogs/Various_frogs_and_toads.jpeg'), [
+            '<a',
+            'class="embed-image"',
+            'title="frogs/Various_frogs_and_toads.jpeg"',
+            'href="https://my-lovely-tour-tours.onezoom.workers.dev/frogs/Various_frogs_and_toads.html"',
+            '><img',
+            'src="https://my-lovely-tour-tours.onezoom.workers.dev/frogs/Various_frogs_and_toads.jpeg"',
+            'alt="Various',
+            'frogs',
+            'and',
+            'toads"',
+            '/><span',
+            'class="copyright">©</span></a>',
+        ])
+        self.assertEqual(
+            media_embed('https://my-lovely-tour-tours.onezoom.workers.dev/frogs/Various_frogs_and_toads.jpeg'),
+            media_embed('frogs/Various_frogs_and_toads.jpeg', defaults=dict(
+                url_base='https://my-lovely-tour-tours.onezoom.workers.dev/')),
+        )
         # Former GitHub Pages host still embeds with a copyright page on that host
         self.assertEqual(media_embed('https://onezoom.github.io/tours/frogs/Various_frogs_and_toads.jpeg'), [
             '<a',
@@ -240,6 +260,7 @@ class TestEmbed(unittest.TestCase):
             '/><span',
             'class="copyright">©</span></a>',
         ])
+
 
 if __name__ == '__main__':
     import sys

--- a/views/tour/data.html
+++ b/views/tour/data.html
@@ -1,5 +1,5 @@
 {{
-from applications.OZtree.modules.embed import media_embed
+from applications.OZtree.modules.embed import media_embed, TOURS_URL_BASE
 from applications.OZtree.modules.markdown import markdown
 ts_classes = (  # CSS classes that can be added to template_data as boolean properties
     'visible-transition_in',
@@ -58,7 +58,7 @@ ts_fields = (  # HTML fields that can be added to container
     <{{=tag}} class="{{=k}} {{=' '.join(key for key, value in content_dict.items() if value is True)}}"
         >{{=XML(markdown(content_dict['text']))}}</{{=tag}}>{{pass}}{{pass}}{{pass}}
     {{if len(tdata.get('media', [])) > 0:}}{{for url in tdata['media']:}}
-      {{=XML(media_embed(url, defaults=dict(ts_autoplay='tsstate-active_wait', url_base='https://onezoom.github.io/tours/')))}}
+      {{=XML(media_embed(url, defaults=dict(ts_autoplay='tsstate-active_wait', url_base=TOURS_URL_BASE)))}}
     {{pass}}{{pass}}
 
     <div class="actions"><a href="#share-modal" class="tour_pause oz-pill pill-share" style="float: right" uk-toggle>{{=T('Share')}}</a></div>

--- a/views/tour/data.html
+++ b/views/tour/data.html
@@ -1,5 +1,5 @@
 {{
-from applications.OZtree.modules.embed import media_embed, TOURS_URL_BASE
+from applications.OZtree.modules.embed import media_embed
 from applications.OZtree.modules.markdown import markdown
 ts_classes = (  # CSS classes that can be added to template_data as boolean properties
     'visible-transition_in',
@@ -58,7 +58,7 @@ ts_fields = (  # HTML fields that can be added to container
     <{{=tag}} class="{{=k}} {{=' '.join(key for key, value in content_dict.items() if value is True)}}"
         >{{=XML(markdown(content_dict['text']))}}</{{=tag}}>{{pass}}{{pass}}{{pass}}
     {{if len(tdata.get('media', [])) > 0:}}{{for url in tdata['media']:}}
-      {{=XML(media_embed(url, defaults=dict(ts_autoplay='tsstate-active_wait', url_base=TOURS_URL_BASE)))}}
+      {{=XML(media_embed(url, defaults=dict(ts_autoplay='tsstate-active_wait', url_base=tours_url_base)))}}
     {{pass}}{{pass}}
 
     <div class="actions"><a href="#share-modal" class="tour_pause oz-pill pill-share" style="float: right" uk-toggle>{{=T('Share')}}</a></div>

--- a/views/treeviewer/server_urls.html
+++ b/views/treeviewer/server_urls.html
@@ -16,6 +16,7 @@ var server_urls = {
   tour_list_api: "{{=URL('tour', 'list.json', scheme=True, host=True)}}",
   tour_preview_api: "{{=URL('tour', 'preview.html', scheme=True, host=True)}}",
   tour_search_api: "{{=URL('tour','search.json', scheme=True, host=True)}}",
+  user_login: "{{=URL('default', 'user', args=['login'], scheme=True, host=True)}}",
 
   static_data_url_func: function (data_name) {
       const buf_tmpl = '{{=URL("static", "FinalOutputs/data/BASEBASE_{}.EXTEXT".format(tree_version), scheme=True, host=True)}}';


### PR DESCRIPTION
This now uses the cloudflare pages version of the tours repo deployment.
It also adds a remote preview URL for tours e.g. 
http://127.0.0.1:8000/life?tour=/tour/remote.html/test-tour-preview-tours/lava_lamps
Which gets the preview deployment content. It requires auth.